### PR TITLE
Fix 'Edit on Github' button

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -23,6 +23,7 @@ site_url: 'https://wso2.com/'
 # Repository
 repo_name: wso2/docs-is
 repo_url: https://github.com/wso2/docs-is
+edit_uri: https://github.com/wso2/docs-is/edit/master/en/docs/
 
 # Copyright
 copyright: WSO2 Identity Server - Documentation


### PR DESCRIPTION
## Purpose
The edit on github button was using the repo_url parameter to navigate to the editable .md, which does not work because there is an additional 'en' folder before the 'docs' folder. 
Added the edit_uri to fix the issue. 