### PR TITLE
Add md-include and code-tabs extensions

### DIFF
--- a/en/docs/assets/css/code-tabs.css
+++ b/en/docs/assets/css/code-tabs.css
@@ -1,0 +1,52 @@
+.md-fenced-code-tabs * {
+    box-sizing: border-box;
+}
+
+.md-fenced-code-tabs {
+    box-sizing: border-box;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
+    max-width: 100%;
+    border-radius: .2rem;
+}
+
+.md-fenced-code-tabs {
+    display: flex;
+    position: relative;
+    flex-wrap: wrap;
+    width: 100%;
+}
+
+.md-fenced-code-tabs input {
+    position: absolute;
+    opacity: 0;
+}
+
+.md-fenced-code-tabs label {
+    width: auto;
+    cursor: pointer;
+    font-size: 1.28rem;
+    padding: 1.2rem 1.6rem;
+}
+
+.md-fenced-code-tabs input:checked + label {
+    color: #03a9f4;
+    border-bottom: 2px solid #03a9f4;
+}
+
+.md-fenced-code-tabs .code-tabpanel {
+    display: none;
+    width: 100%;
+    order: 99;
+}
+
+.md-fenced-code-tabs input:checked + label + .code-tabpanel {
+    display: block;
+}
+
+.md-fenced-code-tabs pre,
+.md-fenced-code-tabs .codehilite {
+    width: 100%;
+    margin: 0px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}

--- a/en/docs/key-concepts/access-control-and-entitlement-management.md
+++ b/en/docs/key-concepts/access-control-and-entitlement-management.md
@@ -196,7 +196,7 @@ descriptive attributes about the user or any other missing attribute in
 the request. Policy Administration Point (PAP) is used to manage the PDP
 and PIP functionality.
 
-![XACML system architecture](assets/attachments/concepts/xacml-system-architecture.png)
+![XACML system architecture](../../assets/attachments/concepts/xacml-system-architecture.png)
 
 ------------------------------------------------------------------------
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -74,10 +74,13 @@ markdown_extensions:
     - pymdownx.superfences
     - markdown_include.include:
         base_path: docs
+    - markdown_fenced_code_tabs:
+        template: 'default' 
     
 # Customization
 extra_css:
   - 'assets/css/theme.css'
+  - 'assets/css/code-tabs.css'
 extra_javascript:
   - 'assets/js/theme.js'
 extra:

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -72,6 +72,8 @@ markdown_extensions:
     - pymdownx.details
     - pymdownx.inlinehilite
     - pymdownx.superfences
+    - markdown_include.include:
+        base_path: docs
     
 # Customization
 extra_css:


### PR DESCRIPTION
## Purpose
Add extension for including a markdown file within another markdown file in order to reduce duplication of content. 

Add extension and .css for tabbed code blocks. 