### PR TITLE
Fix 'key-concepts' path missing in nav config

### DIFF
--- a/en/docs/references/config-catalog.md
+++ b/en/docs/references/config-catalog.md
@@ -167,7 +167,10 @@ pool_options.maxActiv="5"
                             <div class="param-description">
                                 <p>The type of database that is used for the primary database. All the database types that are supported by this product is listed below as possible values.</p>
                                 <p>E.g. "MySql", "Oracle", "Postgre"</p>
-                                <p>"H2" (not recommended for production environments). So please change when going on production.</p>
+                                <details class="warning classes" open="open">
+                                    <summary>Warning</summary>
+                                    <p>"H2" (not recommended for production environments). So please change when going on production.</p>
+                                </details>
                             </div>
                         </div>
                     </div>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -49,10 +49,10 @@ theme:
 # Navigation
 nav:
   - 'Key Concepts':
-    - 'Single Sign-On and Identity Federation': single-sign-on-and-identity-federation.md
-    - 'Identity Provisioning and its Standards': identity-provisioning-and-its-standards.md
-    - 'Access Control and Entitlement Management': access-control-and-entitlement-management.md
-    - 'Identity Anti patterns and the Identity Bus': identity-anti-patterns-and-the-identity-bus.md
+    - 'Single Sign-On and Identity Federation': key-concepts/single-sign-on-and-identity-federation.md
+    - 'Identity Provisioning and its Standards': key-concepts/identity-provisioning-and-its-standards.md
+    - 'Access Control and Entitlement Management': key-concepts/access-control-and-entitlement-management.md
+    - 'Identity Anti patterns and the Identity Bus': key-concepts/identity-anti-patterns-and-the-identity-bus.md
   - 'Basic Tutorials':
     - 'Adaptive Authentication': 
       - 'Adaptive Authentication Overview': tutorials/adaptive-authentication-overview.md


### PR DESCRIPTION
## Purpose
> Fixed 'key-concepts' path missing in nav config: Issue in the PR #24