### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/en/docs/admin-guide/writing-a-Custom-User-Store-Manager.md
+++ b/en/docs/admin-guide/writing-a-Custom-User-Store-Manager.md
@@ -483,8 +483,15 @@ Do the following steps to write the custom user store manager.
                                isAuthenticated = passwordEncryptor.checkPassword(candidatePassword, storedPassword);
                            }
                        }
+                       dbConnection.commit();
                        log.info(userName + " is authenticated? " + isAuthenticated);
                    } catch (SQLException exp) {
+                       try {
+                           connection.rollback();
+                       } catch (SQLException e1) {
+                           throw new UserStoreException("Transaction rollback connection error occurred while" + 
+                           " retrieving user authentication info. Authentication Failure.", e1);
+                       }                   
                        log.error("Error occurred while retrieving user authentication info.", exp);
                        throw new UserStoreException("Authentication Failure");
                    }

--- a/en/docs/using-wso2-identity-server/writing-a-Custom-User-Store-Manager.md
+++ b/en/docs/using-wso2-identity-server/writing-a-Custom-User-Store-Manager.md
@@ -483,8 +483,15 @@ Do the following steps to write the custom user store manager.
                                isAuthenticated = passwordEncryptor.checkPassword(candidatePassword, storedPassword);
                            }
                        }
+                       dbConnection.commit();
                        log.info(userName + " is authenticated? " + isAuthenticated);
                    } catch (SQLException exp) {
+                       try {
+                           connection.rollback();
+                       } catch (SQLException e1) {
+                           throw new UserStoreException("Transaction rollback connection error occurred while" + 
+                               " retrieving user authentication info. Authentication Failure.", e1);
+                       }
                        log.error("Error occurred while retrieving user authentication info.", exp);
                        throw new UserStoreException("Authentication Failure");
                    }


### PR DESCRIPTION


## Purpose
When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the docs-is repository, there are some places use the JDBC transaction but did not properly commit and rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5480