### PR TITLE
Bulk fix image paths in admin guide

### DIFF
--- a/en/docs/admin-guide/adding-Datasources.md
+++ b/en/docs/admin-guide/adding-Datasources.md
@@ -8,7 +8,7 @@ Use the following steps to add a datasource:
 
 1.  In the product management console, click **Data Sources** on the
     **Configure** tab.  
-    ![](http://docs.wso2.org/wiki/download/attachments/4885163/1.png?version=2&modificationDate=1327323080000) 
+    ![](http://docs.wso2.org/wiki/download/../../assets/img/4885163/1.png?version=2&modificationDate=1327323080000) 
 2.  Click **Add Data Source**.
 3.  Specify the required options for connecting to the database. The
     available options are based on the type of datasource you are

--- a/en/docs/admin-guide/adding-New-Tenants.md
+++ b/en/docs/admin-guide/adding-New-Tenants.md
@@ -16,7 +16,7 @@ be logged in as a super user.
 1.  Click **Add New Tenant** in the **Configure** tab of your product's
     management console.
 
-    ![](attachments/53125481/53287366.png)
+    ![](../../assets/img/53125481/53287366.png)
 
 2.  Enter the tenant information in **Register A New Organization**
     screen as follows, and click **Save**.
@@ -37,7 +37,7 @@ be logged in as a super user.
     currently exist in the system. If you want to view only tenants of a
     specific domain, enter the domain name in the **Enter the Tenant
     Domain** parameter and click **Find**.  
-    ![](attachments/53125481/87718672.png) 
+    ![](../../assets/img/53125481/87718672.png) 
 
 ### Managing tenants using Admin Services
 
@@ -112,7 +112,7 @@ follows:
     machine as the product instance. Note that there are several
     operations shown in the SOAP UI after importing the wsdl file:
 
-    ![](attachments/53125481/92516206.png) 
+    ![](../../assets/img/53125481/92516206.png) 
 
     !!! warning
     

--- a/en/docs/admin-guide/adding-a-Custom-Proxy-Path.md
+++ b/en/docs/admin-guide/adding-a-Custom-Proxy-Path.md
@@ -15,7 +15,7 @@ configuring your servers with 'custom proxy paths', you can host all
 products under a single domain and assign proxy paths for each product
 separately as shown below:  
 ![Custom Proxy
-Paths](attachments/53125476/53287365.png "Custom Proxy Paths")  
+Paths](../../assets/img/53125476/53287365.png "Custom Proxy Paths")  
 
 **Proxy URLs mapped to Carbon server URLs:**
 

--- a/en/docs/admin-guide/adding-a-Resource.md
+++ b/en/docs/admin-guide/adding-a-Resource.md
@@ -7,7 +7,7 @@ Follow the instructions below to add a new child entry to a collection.
 
 1\. To add a new resource, click on the *Add Resource* link.
 
-![](attachments/53125534/53287664.png)
+![](../../assets/img/53125534/53287664.png)
 
 2\. In the *Add Resource* panel, select *Method* from the drop-down menu.
 
@@ -18,7 +18,7 @@ The following methods are available:
 -   **[Create Text content](#AddingaResource-3)**
 -   **[Create custom content](#AddingaResource-4)**
 
-![](attachments/53125534/53287663.png)
+![](../../assets/img/53125534/53287663.png)
 
 ### Uploading Content from File
 
@@ -34,7 +34,7 @@ The following methods are available:
 2\. Click *Add* once the information is added as shown in the example
 below.
 
-![](attachments/53125534/53287661.png)
+![](../../assets/img/53125534/53287661.png)
 
 ### Importing Content from URL
 
@@ -48,7 +48,7 @@ below.
 
 2\. Click *Add* once the information is added.
 
-![](attachments/53125534/53287659.png)
+![](../../assets/img/53125534/53287659.png)
 
 ### Text Content Creation
 
@@ -63,14 +63,14 @@ below.
 
 2\. Click *Add* once the information is added.
 
-![](attachments/53125534/53287658.png)
+![](../../assets/img/53125534/53287658.png)
 
 ### Custom Content Creation
 
 1\. If this method was selected, choose the *Media Type* from the
 drop-down menu and click *Create Content* .
 
-![](attachments/53125534/53287662.png)
+![](../../assets/img/53125534/53287662.png)
 
 **Media Types**
 

--- a/en/docs/admin-guide/all-Partitions-in-a-Single-Server.md
+++ b/en/docs/admin-guide/all-Partitions-in-a-Single-Server.md
@@ -2,7 +2,7 @@
 
 #### Strategy 1: Local Registry
 
-![](attachments/21037149/21331970.png) 
+![](../../assets/img/21037149/21331970.png) 
 
 Figure 1: All registry partitions in a single server instance.  
 

--- a/en/docs/admin-guide/apply-WUM-Updated-Products-Using-Automation.md
+++ b/en/docs/admin-guide/apply-WUM-Updated-Products-Using-Automation.md
@@ -121,7 +121,7 @@ distribution is deployed. To increase the deployment time interval:
     -   If your configuration management tool (such as Puppet, Chef, or
         Ansible) is managing your customizations, you need to clone the
         deployment directory from the configuration management tool.
-4.  Download the [merge script](attachments/72429776/76750720.sh) (
+4.  Download the [merge script](../../assets/img/72429776/76750720.sh) (
     `           merge_v1.s          ` h) and run it as explained below.
 
     !!! note
@@ -183,7 +183,7 @@ distribution is deployed. To increase the deployment time interval:
     the customizations. Select **Yes** and provide the location of your
     **deployment script**. If you are using SVN-based deployment
     synchronization, you can use the [deployment script for
-    SVN](attachments/72429776/76750721.sh) (
+    SVN](../../assets/img/72429776/76750721.sh) (
     `           deploy_v1.sh          ` ).
 
     -   If any errors are indicated when the merge script is run, you

--- a/en/docs/admin-guide/changing-a-Password.md
+++ b/en/docs/admin-guide/changing-a-Password.md
@@ -8,10 +8,10 @@ To change a user's password:
 
 1.  Log in to the management console of your product.
 2.  On the **Main** tab, click **List** under **Users and Roles**.  
-    ![](attachments/53125500/53287376.png) 
+    ![](../../assets/img/53125500/53287376.png) 
 3.  To change your own password, click **Change My Password**, enter
     your current password and new password, and click **Change**.  
-    ![](attachments/53125500/53287375.png) 
+    ![](../../assets/img/53125500/53287375.png) 
 4.  If you are an admin user and need to  change another user's password
     (such as if they have forgotten their current password and need you
     to reset it), do the following:

--- a/en/docs/admin-guide/changing-to-Embedded-Derby.md
+++ b/en/docs/admin-guide/changing-to-Embedded-Derby.md
@@ -270,7 +270,7 @@ follows:
 1.  Run the `          ij         ` tool located in the
     `          <DERBY_HOME>/bin/         ` directory as illustrated
     below:  
-    ![](attachments/56996013/57739826.png)
+    ![](../../assets/img/56996013/57739826.png)
 2.  Create the database and connect to it using the following command
     inside the `          ij         ` prompt:
 

--- a/en/docs/admin-guide/changing-to-Remote-H2.md
+++ b/en/docs/admin-guide/changing-to-Remote-H2.md
@@ -299,7 +299,7 @@ Follow the steps below to run the script in Web console:
 2.  Copy the script text from the SQL file.
 3.  Paste it into the console.
 4.  Click **Run**.  
-    ![](attachments/53125507/53287421.png) 
+    ![](../../assets/img/53125507/53287421.png) 
 5.  Restart the server.
 
     You can create database tables automatically **when starting the

--- a/en/docs/admin-guide/config-and-Governance-Partitions-in-Separate-Nodes.md
+++ b/en/docs/admin-guide/config-and-Governance-Partitions-in-Separate-Nodes.md
@@ -7,7 +7,7 @@ shares a configuration registry space by the name G-Reg 2 and the
 product Bar cluster shares a configuration registry space by the name
 G-Reg 3.  
 
-![](attachments/53125543/53287693.png)   
+![](../../assets/img/53125543/53287693.png)   
 
 Figure 4: Config and governance partitions in separate registry
 instances .  

--- a/en/docs/admin-guide/config-and-Governance-Partitions-in-a-Remote-Registry.md
+++ b/en/docs/admin-guide/config-and-Governance-Partitions-in-a-Remote-Registry.md
@@ -8,7 +8,7 @@ registry that is shared across each node of the cluster. A separate
 instance of the WSO2 Governance Registry is used to provide the space
 used in common.
 
-![](attachments/21037149/21331972.png) 
+![](../../assets/img/21037149/21331972.png) 
 
 Figure 2: Config and governance partitions in the remote Governance
 Registry instance .  
@@ -293,10 +293,10 @@ instances.
 3\. Start both servers and note the log entries that indicate successful
 mounting to the remote Governance Registry instance. For example,
 
-![](attachments/21037149/21332021.png)   
+![](../../assets/img/21037149/21332021.png)   
 
 4\. Navigate to the registry browser in the Carbon server's management
 console and note the config and governance partitions indicating
 successful mounting to the remote registry instance. For example,
 
-![](attachments/21037149/21332022.png) 
+![](../../assets/img/21037149/21332022.png) 

--- a/en/docs/admin-guide/configuring-Log4j-Properties.md
+++ b/en/docs/admin-guide/configuring-Log4j-Properties.md
@@ -30,7 +30,7 @@ Carbon server at run time:
 1.  Log in to the management console of your product and go to
     **Configure** -\> **Logging** in the navigator. The **Logging
     Configuration** window appears as shown below.  
-    ![](attachments/28705820/28870019.png)
+    ![](../../assets/img/28705820/28870019.png)
 2.  If you select the **Persist All Configuration Changes** check box,
     all the modifications will persist and they will be available even
     after the server restarts.  
@@ -48,7 +48,7 @@ Carbon server at run time:
 
 #### Global Log4J Configuration
 
-![](attachments/28705820/28870018.png)
+![](../../assets/img/28705820/28870018.png)
 
 This section allows you to assign a single log level and log pattern to
 all loggers.
@@ -65,7 +65,7 @@ logging configurations specified in the
 
 #### Configure Log4J Appenders
 
-![](attachments/28705820/28870017.png)
+![](../../assets/img/28705820/28870017.png)
 
 This section allows you to configure appenders individually. Log4j
 allows logging requests to print to multiple destinations. These output
@@ -139,7 +139,7 @@ one logger.
 
 #### Configure Log4J Loggers
 
-![](attachments/28705820/28870022.png)
+![](../../assets/img/28705820/28870022.png)
 
 A Logger is an object used to log messages for a specific system or
 application component. Loggers are normally named using a hierarchical

--- a/en/docs/admin-guide/configuring-Roles.md
+++ b/en/docs/admin-guide/configuring-Roles.md
@@ -42,7 +42,7 @@ Follow the instructions below to add a user role.
     this permission enabled. For more information on permissions, see
     [Role-based Permissions](_Role-based_Permissions_).
 3.  Click **Add New Role**. The following screen appears:  
-    ![](attachments/53125497/53287369.png)
+    ![](../../assets/img/53125497/53287369.png)
 4.  Do the following:  
     1.  In the **Domain** list, specify the user store where you want to
         create this role. This list includes the primary user store and

--- a/en/docs/admin-guide/configuring-SAML2-Single-Sign-On-Across-Different-WSO2-Products.md
+++ b/en/docs/admin-guide/configuring-SAML2-Single-Sign-On-Across-Different-WSO2-Products.md
@@ -140,6 +140,6 @@ configuration for registering a Carbon server as a service provider.
     -   Select **Use user store domain in local subject identifier**
         to append the user store domain that the user resides in the
         local subject identifier.  
-        ![](attachments/53125544/53287694.png) 
+        ![](../../assets/img/53125544/53287694.png) 
 8.  Click the **Update** button to update the details of the service
     provider.

--- a/en/docs/admin-guide/configuring-Secondary-User-Stores.md
+++ b/en/docs/admin-guide/configuring-Secondary-User-Stores.md
@@ -92,7 +92,7 @@ or using the management console:
     defining user stores, see [Properties of User
     Stores](_Working_with_Properties_of_User_Stores_).
 
-    ![](attachments/53125491/72424354.png) 
+    ![](../../assets/img/53125491/72424354.png) 
 
     !!! note
     
@@ -104,7 +104,7 @@ or using the management console:
     name is given and click **Add**.
 
 7.  A message appears saying that the user stores are being added.  
-    ![](attachments/31130739/31359112.png)
+    ![](../../assets/img/31130739/31359112.png)
 
     **Note** : The above message does not imply that the user store is
     added successfully. It simply means that the server is attempting to

--- a/en/docs/admin-guide/configuring-Transport-Level-Security.md
+++ b/en/docs/admin-guide/configuring-Transport-Level-Security.md
@@ -74,7 +74,7 @@ layer.
 4.  Start the server.
 
 5.  To verify that the configurations are all set correctly, download
-    and run the [TestSSLServer.jar](attachments/53125465/53287360.jar).
+    and run the [TestSSLServer.jar](../../assets/img/53125465/53287360.jar).
 
     ``` java
         java -jar TestSSLServer.jar localhost 9443
@@ -197,8 +197,8 @@ running on JDK 1.7. You cannot configure this using the
 setting a system property.
 
 1.  Download the following artifacts:
-    -   [wso2-ssl-socket-factory-provider-1.0.0.jar](attachments/53125465/72434246.jar)
-    -   [wso2-ssl-security](attachments/53125465/72434248)
+    -   [wso2-ssl-socket-factory-provider-1.0.0.jar](../../assets/img/53125465/72434246.jar)
+    -   [wso2-ssl-security](../../assets/img/53125465/72434248)
 2.  Copy the `          wso2-         ` ssl
     `          -socket-factory-provider-1.0.0.jar         ` file to the
     `          <                     PRODUCT_HOME>                    /lib/endorsed         `
@@ -266,7 +266,7 @@ ciphers by JSSE. This will enable the weak ciphers.
 
 4.  Start the server.
 5.  To verify that the configurations are all set correctly, download
-    and run the [TestSSLServer.jar](attachments/53125465/53287360.jar).
+    and run the [TestSSLServer.jar](../../assets/img/53125465/53287360.jar).
 
     ``` java
         $ java -jar TestSSLServer.jar localhost 9443

--- a/en/docs/admin-guide/configuring-Users.md
+++ b/en/docs/admin-guide/configuring-Users.md
@@ -42,7 +42,7 @@ its role.
 2.  Click **Users**. This link is only visible to users with the Admin
     role.  
 3.  Click **Add New User**. The following screen will open:  
-    ![](attachments/53125498/53287370.png)
+    ![](../../assets/img/53125498/53287370.png)
 4.  Do the following:  
     1.  In the **Domain** list, specify the user store where you want to
         create this user account. This list includes the primary user
@@ -148,7 +148,7 @@ user3, password123,http://wso2.org/claims/givenname= myname3,http://wso2.org/cla
     option](https://docs.wso2.com/display/IS530/Creating+Users+Using+the+Ask+Password+Option)
     for the server.
     
-    ![](attachments/53125498/57761882.png) 
+    ![](../../assets/img/53125498/57761882.png) 
     
 
 #### Importing users from the CSV/Excel file
@@ -162,7 +162,7 @@ To import users in bulk:
 4.  The user stores configured for your product will be listed in the
     **Domain** field. Select the user store to which you want to import
     the users from the list, upload the CSV or excel sheet, and click
-    Finish. ![](attachments/53125498/80118426.png){height="250"}
+    Finish. ![](../../assets/img/53125498/80118426.png){height="250"}
 
 The default password of the imported users is valid only for 24 hours.
 As the system administrator, you can resolve issues of expired passwords

--- a/en/docs/admin-guide/configuring-a-Custom-Datasource.md
+++ b/en/docs/admin-guide/configuring-a-Custom-Datasource.md
@@ -3,7 +3,7 @@
 When adding a datasource, if you select the custom datasource type, the
 following screen will appear:
 
-![](attachments/53125523/53287621.png) 
+![](../../assets/img/53125523/53287621.png) 
 
 Following are descriptions of the custom datasource fields:
 
@@ -78,7 +78,7 @@ cluster for data synchronization.
 Shown below is an example configuration of a custom datasource of type
 `         <DS_CUSTOM_TABULAR>        ` :
 
-![](attachments/53125523/53287622.png) 
+![](../../assets/img/53125523/53287622.png) 
 
 After creating datasources, they will appear on the **Data Sources**
 page. You can edit and delete them as needed by clicking **Edit** or

--- a/en/docs/admin-guide/configuring-a-JNDI-Datasource.md
+++ b/en/docs/admin-guide/configuring-a-JNDI-Datasource.md
@@ -11,7 +11,7 @@ When adding a datasource, to expose a RDBMS datasource as a JNDI
 datasource, click **Expose as a JNDI Data Source** to display the JNDI
 fields as follows:
 
-![](attachments/53125520/53287618.png) 
+![](../../assets/img/53125520/53287618.png) 
 
 Following are descriptions of the JNDI fields:
 

--- a/en/docs/admin-guide/configuring-an-RDBMS-Datasource.md
+++ b/en/docs/admin-guide/configuring-an-RDBMS-Datasource.md
@@ -3,7 +3,7 @@
 When adding a datasource, if you select RDBMS as the datasource type,
 the following screen appears:
 
-![](attachments/53125518/53287615.png)
+![](../../assets/img/53125518/53287615.png)
 
 This is the default RDBMS datasource configuration provided by WSO2. You
 can also write your own RDBMS configuration by selecting the custom

--- a/en/docs/admin-guide/configuring-the-Datasource-Connection-Pool-Parameters.md
+++ b/en/docs/admin-guide/configuring-the-Datasource-Connection-Pool-Parameters.md
@@ -19,7 +19,7 @@ configuration parameters section that appears in the product management
 console when creating a datasource. Click and expand the option as shown
 below:
 
-![](attachments/53125522/53287619.png)
+![](../../assets/img/53125522/53287619.png)
 
 Following are descriptions of the parameters you can configure. For more
 details on datasource configuration parameters, see [ApacheTomcat JDBC

--- a/en/docs/admin-guide/configuring-the-Datasource-Provider.md
+++ b/en/docs/admin-guide/configuring-the-Datasource-Provider.md
@@ -11,7 +11,7 @@ To use the default datasource provider, select **default**, and then
 enter the Driver, URL, User Name, and Password connection properties  as
 follows:
 
-![](attachments/53125519/53287617.png) 
+![](../../assets/img/53125519/53287617.png) 
 
 ### External datasource provider
 
@@ -23,4 +23,4 @@ enter the name and value of each connection property you need to
 configure. Following is an example datasource for an external datasource
 provider:
 
-![](attachments/53125519/53287616.png) 
+![](../../assets/img/53125519/53287616.png) 

--- a/en/docs/admin-guide/configuring-the-User-Realm.md
+++ b/en/docs/admin-guide/configuring-the-User-Realm.md
@@ -16,7 +16,7 @@ relevant configuration files.
 
 The following diagram illustrates the required configurations and
 repositories:  
-![](attachments/53125484/53287368.png)
+![](../../assets/img/53125484/53287368.png)
 
 The following sections include instructions on the above required
 configurations and repositories:

--- a/en/docs/admin-guide/customizing-the-Management-Console.md
+++ b/en/docs/admin-guide/customizing-the-Management-Console.md
@@ -91,7 +91,7 @@ Note that the images and instructions given on this page are valid for
 WSO2 products that are based on Carbon 4.4.x.
 
 ![current logo of the Management
-Console](attachments/53125528/53287629.png "current logo of the Management Console")
+Console](../../assets/img/53125528/53287629.png "current logo of the Management Console")
 
 Follow the steps below to customize the above management console by
 changing the logo.
@@ -177,7 +177,7 @@ changing the logo.
     `           org.wso2.carbon.ui_           <version-number>          `
     `           _patch          ` project should now look as shown
     below.  
-    ![](attachments/53125528/80723769.png) 
+    ![](../../assets/img/53125528/80723769.png) 
 
 5.  Create a new CSS file (e.g.
     `           customizations.css          ` ) with the following
@@ -236,7 +236,7 @@ changing the logo.
     `           <org.wso2.carbon.ui_<version-number>_patch>/src/main/resources/          `
     `           web/admin/images/          ` directory.
 
-    ![new logo](attachments/53125528/53287628.png "new logo")
+    ![new logo](../../assets/img/53125528/53287628.png "new logo")
 
 11. Create another Maven project using your IDE. Be sure to include the
     symbolic name of the original bundle that you extracted in step 1
@@ -324,4 +324,4 @@ changing the logo.
     logo, which the patch bundle contains as shown below.
 
     ![Management Console with the new
-    logo](attachments/53125528/80723770.png "Management Console with the new logo") 
+    logo](../../assets/img/53125528/80723770.png "Management Console with the new logo") 

--- a/en/docs/admin-guide/deploying-Composite-Applications-in-the-Server.md
+++ b/en/docs/admin-guide/deploying-Composite-Applications-in-the-Server.md
@@ -31,14 +31,14 @@ right click on it in the **Servers** tab, and c lick **Add and
 Remove...**
 
 ![add and remove to an already-added
-server](attachments/57739657/87693724.png "add and remove to an already-added server")
+server](../../assets/img/57739657/87693724.png "add and remove to an already-added server")
 
 Then, select the Composite Application you want to deploy from the
 **Available** list, click **Add** to move it into the **Configured**
 list, and then click **Finish**.
 
 ![select the composite app you want to
-deploy](attachments/57739657/87693726.png "select the composite app you want to deploy")
+deploy](../../assets/img/57739657/87693726.png "select the composite app you want to deploy")
 
 1.  In the Tooling interface, navigate to **Developer Studio Dashboard**
    , and click **Server** under **Add Server**.
@@ -46,11 +46,11 @@ deploy](attachments/57739657/87693726.png "select the composite app you want to 
 2.  In the **Define a New Server** dialog box, expand the
     WSO2 folder and select the version of your server. In this case, it
     is `          WSO2 ESB Server 5.0.0         ` .  
-    ![](attachments/53121319/53284204.png) 
+    ![](../../assets/img/53121319/53284204.png) 
 3.  Click **Next**. In the CARBON\_HOME field, provide the path to your
     product's home directory and then click **Next** again. For
     example,  
-    ![](attachments/53121319/53284218.png) 
+    ![](../../assets/img/53121319/53284218.png) 
 4.  Review the default port details for your server and click **Next**
     .  
     Typically, you can leave these unchanged but if you are already
@@ -62,7 +62,7 @@ deploy](attachments/57739657/87693726.png "select the composite app you want to 
         Products](_Default_Ports_of_WSO2_Products_) for more information.
     
 
-    ![](attachments/53121319/53284206.png) 
+    ![](../../assets/img/53121319/53284206.png) 
 
 5.  To deploy the C-App project to your server, select
     **SampleServicesCompositeApplication** from the list, click **Add**
@@ -73,13 +73,13 @@ deploy](attachments/57739657/87693726.png "select the composite app you want to 
 
 6.  Note that your server is now added to the Tooling interface.
 
-    ![](attachments/53121319/53285006.png) 
+    ![](../../assets/img/53121319/53285006.png) 
 
 7.  On the **Servers** tab, note that the server is currently stopped.
     Click the "start the server" icon on the **Servers** tab's toolbar.
     If prompted to save changes to any of the artifact files you created
     earlier, click **Yes**.  
-    ![](attachments/53121319/53285075.png) 
+    ![](../../assets/img/53121319/53285075.png) 
 
 8.  As the server starts, the **Console** tab appears. Note messages
     indicating that the Composite app was successfully deployed. The
@@ -94,7 +94,7 @@ deploy](attachments/57739657/87693726.png "select the composite app you want to 
     to remove, and click **Remove** as shown below.
     
     ![remove a deployed Composite
-    Application](attachments/57739657/87693730.png "remove a deployed Composite Application")
+    Application](../../assets/img/57739657/87693730.png "remove a deployed Composite Application")
     
 
 If you do not use the Tooling interface to deploy your artifacts to the
@@ -224,7 +224,7 @@ to keep the configurations on all nodes of the cluster in sync.
         11. Inbound endpoints
         12. Other types
 
-        ![](attachments/57739657/57760645.png){height="250"}
+        ![](../../assets/img/57739657/57760645.png){height="250"}
 
 !!! tip
     

--- a/en/docs/admin-guide/editing-collections-using-the-Entries-panel.md
+++ b/en/docs/admin-guide/editing-collections-using-the-Entries-panel.md
@@ -5,7 +5,7 @@ Entries panel with details of child collections and resources it has. It
 provides a UI to view details, add new resources, collections and links
 as follows:
 
-![](attachments/53125536/53287668.png)
+![](../../assets/img/53125536/53287668.png)
 
 -   Add Resource
 -   Add Collection

--- a/en/docs/admin-guide/entries-and-Content.md
+++ b/en/docs/admin-guide/entries-and-Content.md
@@ -5,7 +5,7 @@ select a collection in the registry, the **Entries** panel opens with
 details of the child collections and resources of the collection. For
 example,
 
-![](attachments/33128918/33325829.png)
+![](../../assets/img/33128918/33325829.png)
 
 The **Info** and **Actions** links in the **Entries** panel provide the
 following information:
@@ -56,7 +56,7 @@ following information:
 <td><strong>Actions</strong></td>
 <td><div class="content-wrapper">
 <p>Allows you to <strong>rename, move, copy or delete</strong> a resource/child collection.<br />
-<img src="attachments/33128918/33325827.png" width="700" /></p>
+<img src="../../assets/img/33128918/33325827.png" width="700" /></p>
 <div>
 <p>You cannot move/copy resources and collections across registry mounts if they have dependencies or associations. You can only move/copy within a mount. For more information on mounts, read WSO2 Governance Registry documentation: <a href="http://docs.wso2.org/display/Governance460/Remote+Instance+and+Mount+Configuration+Details">Remote Instance and Mount Configuration Details</a> .</p>
 </div>
@@ -82,7 +82,7 @@ as shown below:
 
 1.  Select a collection. You can see the Entries panel with details of
     child collections and resources it has.
-2.  Click **Add Collection**. ![](attachments/22185138/22514113.png)
+2.  Click **Add Collection**. ![](../../assets/img/22185138/22514113.png)
 3.  Specify the following options:  
     -   A unique name for the collection and a description
     -   Select a media type from the drop-down menu
@@ -96,7 +96,7 @@ resources as follows:
 1.  Select a collection. In its detailed view, you can see the Entries
     panel with details of child collections and resources it has.
 2.  In the Entries panel, click **Add Resource**.
-    ![](attachments/22185139/22514115.png)
+    ![](../../assets/img/22185139/22514115.png)
 3.  In the Add Resource page that opens, select one of the following
     methods **:**
 
@@ -115,21 +115,21 @@ resources as follows:
     Allows you to create a resource by fetching its content from a
     specified file (e.g., XML, WSDL, JAR). For example,
 
-    ![](attachments/33128918/33325824.png) 
+    ![](../../assets/img/33128918/33325824.png) 
 
     #### Importing content from URL
 
     Allows you to fetch a resource from a specified URL path. For
     example,
 
-    ![](attachments/33128918/33325823.png) 
+    ![](../../assets/img/33128918/33325823.png) 
 
     #### Creating text content
 
     Allows you to write the content in the UI itself, using either the
     Rich Text Editor or Plain Text Editor. For example,
 
-    ![](attachments/22185139/22514118.png) 
+    ![](../../assets/img/22185139/22514118.png) 
 
     You can add external links (hyperlinks) as resources in the
     registry. To add such a link, create a text resource with the media
@@ -144,7 +144,7 @@ resources as follows:
     `           application/vnd.wso2-profiles+xml          ` and provide
     the user name. For example,
 
-    ![](attachments/22185139/22514117.png)
+    ![](../../assets/img/22185139/22514117.png)
 
 ### Editing resources
 
@@ -152,19 +152,19 @@ If you select a resource, in its detailed view, you can see the Content
 panel, which provides a UI to edit, upload, and download the content as
 follows:
 
-![](attachments/22185137/22514094.png)
+![](../../assets/img/22185137/22514094.png)
 
 -   **Display as text** : Allows only to view the configuration of a
     resource. For example, ****  
     ****
 
-    ![](attachments/22185137/22514098.png)
+    ![](../../assets/img/22185137/22514098.png)
 
 -   **Edit as text** : Allows to edit a resource either in plain text
     editor or rich text editor. **  
     **
 
-    ![](attachments/22185137/22514096.png)
+    ![](../../assets/img/22185137/22514096.png)
 
 -   **Upload** : Allows to upload a file to the resource. The existing
     content of the resource will be replaced by the you upload.
@@ -180,7 +180,7 @@ follows:
     If a Security Warning appears when you try to download a resource,
     click **Save** to start downloading.
 
-    ![](attachments/22185137/22514091.png)
+    ![](../../assets/img/22185137/22514091.png)
 
 ### Adding links
 
@@ -207,7 +207,7 @@ in the collection.
 1.  Symbolic links and Remote links can be created in a similar way to
     adding a normal resource. To add a link, click "Create Link" in the
     "Entries" panel.  
-    ![](attachments/22185140/22514132.png)
+    ![](../../assets/img/22185140/22514132.png)
 2.  From the drop-down menu, select a symbolic or a remote link to
     add:  
 
@@ -217,12 +217,12 @@ in the collection.
     of the existing resource or collection being linked. It creates a
     link to the particular resource.
 
-    ![](attachments/22185140/22514127.png)
+    ![](../../assets/img/22185140/22514127.png)
 
     The created Symbolic link is shown by an icon with an arrow in the
     Entries panel.
 
-    ![](attachments/22185140/22514131.png)
+    ![](../../assets/img/22185140/22514131.png)
 
     ##### Remote links
 
@@ -232,7 +232,7 @@ in the collection.
     the remote collection. If no path is given, the root collection will
     be mounted.
 
-    ![](attachments/22185140/22514129.png)
+    ![](../../assets/img/22185140/22514129.png)
 
     After mounting the Remote collection, you can access and work on
     that collection from your local instance.

--- a/en/docs/admin-guide/governance-Partition-in-a-Remote-Registry.md
+++ b/en/docs/admin-guide/governance-Partition-in-a-Remote-Registry.md
@@ -8,7 +8,7 @@ which is shared across each node of the cluster. A separate instance of
 the WSO2 Governance Registry (G-Reg) is used to provide the space used
 in common.
 
-![](attachments/53125542/53287692.png) 
+![](../../assets/img/53125542/53287692.png) 
 
 Figure 3: Governance partition in the remote Governance Registry
 instance .

--- a/en/docs/admin-guide/installing-as-a-Windows-Service.md
+++ b/en/docs/admin-guide/installing-as-a-Windows-Service.md
@@ -274,7 +274,7 @@ windows service.
 
         If the configurations are set properly for YAJSW, you will see
         console output similar to the following:  
-        ![](attachments/45946424/46206534.png)
+        ![](../../assets/img/45946424/46206534.png)
 
     2.  You can now access the management console from your web browser
         via <https://localhost:9443/carbon> .
@@ -292,7 +292,7 @@ windows service.
         The console will display a message confirming that
         the WSO2CARBON service was installed:
 
-        ![](attachments/28717183/29364285.png)
+        ![](../../assets/img/28717183/29364285.png)
 
     2.  Start the service by executing the following command in the same
         console window:
@@ -304,7 +304,7 @@ windows service.
         The console will display a message confirming that
         the WSO2CARBON service was started:
 
-        ![](attachments/28717183/29364288.png)
+        ![](../../assets/img/28717183/29364288.png)
 
 5.  **Stop and uninstall service:** Execute the relevant scripts as
     shown below.
@@ -318,7 +318,7 @@ windows service.
         The console will display a message confirming that
         the WSO2CARBON service has stopped:
 
-        ![](attachments/28717183/29364290.png)
+        ![](../../assets/img/28717183/29364290.png)
 
     2.  To uninstall the service, execute the following command in the
         same console window:
@@ -330,7 +330,7 @@ windows service.
         The console will display a message confirming that
         the WSO2CARBON service was removed:
 
-        ![](attachments/28717183/29364291.png)
+        ![](../../assets/img/28717183/29364291.png)
 
 ### Installing multiple products as Windows services
 
@@ -404,7 +404,7 @@ services and follow the instructions given below.
 12. Right click on **My Computer -\> Manage**. Then click **Services
     and Applications -\> Services**. You can see both ESB and DSS
     services running.  
-    ![](attachments/53125425/53287331.png)
+    ![](../../assets/img/53125425/53287331.png)
 
     You can stop or restart the services from the UI as shown in the
     diagram above.  

--- a/en/docs/admin-guide/introduction-to-Composite-Applications.md
+++ b/en/docs/admin-guide/introduction-to-Composite-Applications.md
@@ -27,11 +27,11 @@ with a file named `         artifacts.xml        `, which contains
 metadata about the artifacts that are inside the C-App. The diagram
 below depicts the structure of a sample C-App:
 
-![](attachments/53125457/53287354.png) 
+![](../../assets/img/53125457/53287354.png) 
 
 Given below is a sample `         artifacts.xml        ` file:
 
-![](attachments/53125457/53287353.png)
+![](../../assets/img/53125457/53287353.png)
 
 The sample file contains the name of the C-App, its version and the
 artifact type according to which the deployer for the artifact is
@@ -92,9 +92,9 @@ server roles.
 2.  Click **Add New Server Role**, e nter the r ole name and click
     **Add**. You can add any textual name as a server role without
     special characters except underscore.  
-    ![](attachments/41255091/41517078.png)
+    ![](../../assets/img/41255091/41517078.png)
 3.  Note that the newly added server role is displayed in the list.  
-    ![](attachments/41255091/41517077.png) You can delete the server
+    ![](../../assets/img/41255091/41517077.png) You can delete the server
     role by clicking **Delete**.
 
     !!! tip

--- a/en/docs/admin-guide/introduction-to-Multitenancy.md
+++ b/en/docs/admin-guide/introduction-to-Multitenancy.md
@@ -69,7 +69,7 @@ and permissions for those users to access resources. Thus, a tenant is
 restricted by the users and permissions of the domain assigned to it.
 The artifact repositories of the tenants are separated from each other.
 
-![](attachments/45960071/46211144.png)
+![](../../assets/img/45960071/46211144.png)
 
 An individual tenant can carry out the following activities within the
 boundaries of its own configuration and context module:

--- a/en/docs/admin-guide/introduction-to-User-Management.md
+++ b/en/docs/admin-guide/introduction-to-User-Management.md
@@ -39,7 +39,7 @@ Any user management system has the following basic components:
 The following diagram illustrates how the user management functionality
 is structured to work in WSO2 products:
 
-![](attachments/53125483/53287367.png){.image-center}
+![](../../assets/img/53125483/53287367.png){.image-center}
 
 -   **User stores:** A **user store** is the database where information
     about the users and user roles is stored, including login name,
@@ -75,7 +75,7 @@ is structured to work in WSO2 products:
     <li><code>                 LDAPUserStoreManager                </code> (read-only)</li>
     <li><code>                 ApacheDSUserStoreManager                </code> (read and write)</li>
     </ul>
-    <p><img src="attachments/33134346/33345382.jpg" width="500" /></p>
+    <p><img src="../../assets/img/33134346/33345382.jpg" width="500" /></p>
     <p>You can write a custom user store manager implementation by implementing <code>                UserStoreManager               </code> or by extending <code>                AbstractUserStoreManager               </code> or one of the default implementations.</p>
     <h5 id="IntroductiontoUserManagement-UsingJDBCUserStoreManager">Using JDBCUserStoreManager</h5>
     <p>The <code>                JDBCUserStoreManager               </code> class uses a schema that is specific to WSO2 Carbon. It contains the following tables:</p>

--- a/en/docs/admin-guide/jMX-Based-Monitoring.md
+++ b/en/docs/admin-guide/jMX-Based-Monitoring.md
@@ -155,7 +155,7 @@ Once the product server is started, you can start the JC
 2.  Execute the j `          console         ` command to open the
     log-in screen of the **Java Monitoring & Management Console** as
     shown below.  
-    ![](attachments/53125400/57746949.png) 
+    ![](../../assets/img/53125400/57746949.png) 
 3.  Enter the connection details in the above screen as follows:
     1.  Enter the **JMX server URL** in the **Remote Process** field.
         This URL is published on the command prompt when you start the
@@ -206,44 +206,44 @@ Once the product server is started, you can start the JC
     JConsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html)
     for more information on these tabs.
 
-    ![](attachments/53125400/57747081.png) 
+    ![](../../assets/img/53125400/57747081.png) 
 
     See the Oracle documentation on [using
     JConsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html)
     for more information on these tabs.
 
-    ![](attachments/53125400/57747082.png) 
+    ![](../../assets/img/53125400/57747082.png) 
 
     See the Oracle documentation on [using
     JConsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html)
     for more information on these tabs.
 
-    ![](attachments/53125400/57747083.png) 
+    ![](../../assets/img/53125400/57747083.png) 
 
     See the Oracle documentation on [using
     JConsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html)
     for more information on these tabs.
 
-    ![](attachments/53125400/57747084.png) 
+    ![](../../assets/img/53125400/57747084.png) 
 
     See the Oracle documentation on [using
     JConsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html)
     for more information on these tabs.
 
-    ![](attachments/53125400/57747085.png) 
+    ![](../../assets/img/53125400/57747085.png) 
 
     See the Oracle documentation on [using
     JConsole](http://docs.oracle.com/javase/7/docs/technotes/guides/management/jconsole.html)
     for more information on these tabs.
 
-    ![](attachments/53125400/57747086.png) 
+    ![](../../assets/img/53125400/57747086.png) 
 
 #### Using the ServerAdmin MBean
 
 When you go to the **MBeans** tab in the JConsole, the **ServerAdmin**
 MBean will be listed under the "org.wso2.carbon" domain as shown
 below.  
-![](attachments/53125400/57746985.png) 
+![](../../assets/img/53125400/57746985.png) 
 
 The **ServerAdmin** MBean is used for administering the product server
 instance. There are several server attributes such as "ServerStatus",
@@ -255,7 +255,7 @@ any of the following values:
 -   RESTARTING
 -   IN\_MAINTENANCE
 
-![](attachments/53125400/57746978.png) 
+![](../../assets/img/53125400/57746978.png) 
 
 The **ServerAdmin** MBean has the following operations:
 
@@ -269,7 +269,7 @@ The **ServerAdmin** MBean has the following operations:
 | **endMaintenance**     | Switch the server to normal mode if it was switched to maintenance mode earlier.                            |
 
   
-![](attachments/53125400/57746982.png) 
+![](../../assets/img/53125400/57746982.png) 
 
 #### Using the ServiceAdmin MBean
 
@@ -282,7 +282,7 @@ Its attributes are as follows:
 | **NumberOfInactiveServices** | The number of services which have been disabled by an administrator. |
 | **NumberOfFaultyServices**   | The number of services which are faulty.                             |
 
-![](attachments/45968791/57747545.png) 
+![](../../assets/img/45968791/57747545.png) 
 
 The operations available in the ServiceAdmin MBean:
 
@@ -291,7 +291,7 @@ The operations available in the ServiceAdmin MBean:
 | **startService** ( [p1:string](http://p1string/) ) | The p1 parameter is the service name. You can activate a service using this operation.           |
 | **stopService** ( [p1:string](http://p1string/) )  | The p1 parameter is the service name. You can deactivate/disable a service using this operation. |
 
-![](attachments/45968791/57747543.png) 
+![](../../assets/img/45968791/57747543.png) 
 
 #### Using the StatisticsAdmin MBean
 
@@ -307,7 +307,7 @@ attributes are as follows:
 | **SystemRequestCount**    | The total number of requests that has been served by the system since the server was started.                                                    |
 | **SystemResponseCount**   | The total number of response that has been sent by the system since the server was started.                                                      |
 
-![](attachments/45968791/57747542.png) 
+![](../../assets/img/45968791/57747542.png) 
 
 Operations available in the **Statistics** MBean:
 
@@ -326,7 +326,7 @@ Operations available in the **Statistics** MBean:
 | **getMinOperationResponseTime** ( [p1:string](http://p1string/), [p2:string](http://p2string/) ) | The p1 parameter is the service name. The p2 parameter is the operation name. You can get the minimum response time of this operation since deployment.                                                             |
 | **getAvgOperationResponseTime** ( [p1:string](http://p1string/), [p2:string](http://p2string/) ) | The p1 parameter is the service name. The p2 parameter is the operation name. You can get the average response time of this operation since deployment.                                                             |
 
-![](attachments/45968791/57747540.png) 
+![](../../assets/img/45968791/57747540.png) 
 
 #### Using the DataSource MBean
 
@@ -334,7 +334,7 @@ If you have [JMX enabled for a datasource connected to the
 product](#JMX-BasedMonitoring-EnablingJMXforadatasource), you can
 monitor the performance of the datasource using this MBean. The
 **DataSource** MBean will be listed as shown below.  
-![](attachments/53125400/57747100.png) 
+![](../../assets/img/53125400/57747100.png) 
 
 **Example:** If you have JMX enabled for the default Carbon datasource
 in the `         master-datasources.xml.        ` file, the [JDBC
@@ -344,7 +344,7 @@ are configured for the Carbon datasource will be listed as attributes as
 shown below. See the [performance tuning guide](_Performance_Tuning_)
 for instructions on how these parameters are configured for a
 datasource.  
-![](attachments/53125400/57747097.png) 
+![](../../assets/img/53125400/57747097.png) 
 
 #### Using product-specific MBeans
 

--- a/en/docs/admin-guide/link-Creation.md
+++ b/en/docs/admin-guide/link-Creation.md
@@ -6,7 +6,7 @@ Follow the instructions below to create a link on a resource/collection.
 adding a normal resource. To add a link, click *Create Link* in the
 *Entries* panel.
 
-![](attachments/53125535/53287666.png)
+![](../../assets/img/53125535/53287666.png)
 
 2\. Select a link to add from the drop-down menu.
 
@@ -16,7 +16,7 @@ When adding a Symbolic link, enter a name for the link and the path of
 an existing resource or collection which is being linked. It creates a
 link to the particular resource.
 
-![](attachments/53125535/53287665.png)
+![](../../assets/img/53125535/53287665.png)
 
 ### A Remote Link
 
@@ -27,4 +27,4 @@ going to mount and give the path of the remote collection which you need
 to mount for the path field, or else the root collection will be
 mounted.
 
-![](attachments/53125535/53287667.png)
+![](../../assets/img/53125535/53287667.png)

--- a/en/docs/admin-guide/managing-Keystores-with-the-UI.md
+++ b/en/docs/admin-guide/managing-Keystores-with-the-UI.md
@@ -62,7 +62,7 @@ uploaded.
     are currently added to the product will be listed here.  
 4.  Click **View** in the list of actions. The **View Key Store** screen
     shows information about the available certificates.  
-    ![](attachments/53125464/53287358.png)  
+    ![](../../assets/img/53125464/53287358.png)  
     It also displays information about private key certificates:  
-    ![](attachments/53125464/53287357.png)
+    ![](../../assets/img/53125464/53287357.png)
 5.  Click **Finish** to go back to the **Key Store Management** screen.

--- a/en/docs/admin-guide/managing-User-Attributes.md
+++ b/en/docs/admin-guide/managing-User-Attributes.md
@@ -39,7 +39,7 @@ attributes of a user in the product.
     4.  From the list of users that appear in the resulting page,
         identify the user whose attributes you want to modify and click
         **User Profile**.  
-        ![](attachments/43997703/44195174.png)
+        ![](../../assets/img/43997703/44195174.png)
     5.  Click **Update** to save changes to the attributes.
 2.  You can use the `           RemoteUserStoreManagerService          `
     API. This is a SOAP-based API and is very easy to use. Supposing you
@@ -99,7 +99,7 @@ this.
 
     See the following screen for how this will look in the user
     interface of the product's Management Console.  
-    ![](attachments/43997703/44195175.png)
+    ![](../../assets/img/43997703/44195175.png)
 
 2.  When using the `           RemoteUserStoreManagerService          `
     API, call it as follows.
@@ -116,7 +116,7 @@ this.
     ```
 
     The following screen shows how this looks in the LDAP.  
-    ![](attachments/43997703/44195177.png) 
+    ![](../../assets/img/43997703/44195177.png) 
 
 ### Writing custom attributes
 

--- a/en/docs/admin-guide/managing-the-Registry.md
+++ b/en/docs/admin-guide/managing-the-Registry.md
@@ -2,12 +2,12 @@
 
 1.  Log in to the product's management console and select Browse from
     the Registry menu that is under the Main menu.  
-    ![](attachments/53125530/53287633.png) 
+    ![](../../assets/img/53125530/53287633.png) 
 2.  The **Browse** page opens. For example,  
-    ![](attachments/53125530/53287630.png)
+    ![](../../assets/img/53125530/53287630.png)
 3.  Click a registry artifact from the tree view and you will be
     navigated to its detail view. For example,  
-    ![](attachments/53125530/53287632.png)   
+    ![](../../assets/img/53125530/53287632.png)   
     It gives the following four main components:
     -   [Metadata](_Metadata_)
     -   [Properties](_Properties_)

--- a/en/docs/admin-guide/message-Monitoring-with-TCPMon.md
+++ b/en/docs/admin-guide/message-Monitoring-with-TCPMon.md
@@ -12,14 +12,14 @@ The following diagram depicts a typical communication between the front
 end client and the back end server. 80 is the listening port of the back
 end server which receives the messages from the client:  
   
-![](attachments/56986697/56986699.png)
+![](../../assets/img/56986697/56986699.png)
 
 The following diagram depicts how TCPMon is placed between the client
 and the server in order to monitor the messages. 8081 is the listening
 port in TCPMon which receives the messages from the client instead of
 the back end server:
 
-![](attachments/56986697/56986698.png)
+![](../../assets/img/56986697/56986698.png)
 
 !!! note
     
@@ -43,17 +43,17 @@ To monitor messages from client to server using TCPMon:
     the hostname.
 4.  Give 80 as the target port, which is the listening port of
     [www.apache.org.](http://www.apache.org.)  
-    ![](attachments/56986697/56986700.png)
+    ![](../../assets/img/56986697/56986700.png)
 5.  Click **Add** to save the setting.
 6.  Now, p oint the browser to 'localhost:8081' instead of
     [www.apache.org](http://www.apache.org).  
-    ![](attachments/56986697/56986701.png)
+    ![](../../assets/img/56986697/56986701.png)
 7.  A new tab in TCPMon will indicate the 8081 port. You can view the
     requests and responses passing through TCPMon as shown below.  
-    ![](attachments/56986697/56986702.png)
+    ![](../../assets/img/56986697/56986702.png)
 8.  The options at the bottom of the screen can be used to have the
     messages in XML format (useful in debugging Web services), to save
     and resend the messages and also to switch the layout of the message
     windows.
 
-    ![](attachments/56986697/56986703.png)
+    ![](../../assets/img/56986697/56986703.png)

--- a/en/docs/admin-guide/metadata.md
+++ b/en/docs/admin-guide/metadata.md
@@ -31,13 +31,13 @@ or the collection:
 
 For example,  
 
-![](attachments/22185146/22514191.png) 
+![](../../assets/img/22185146/22514191.png) 
 
 #### Creating a checkpoint
 
 T o create a checkpoint, click on the **Create Checkpoint** link:
 
-![](attachments/53125531/53287635.png)
+![](../../assets/img/53125531/53287635.png)
 
 **NOTE** : When checkpoints are created, properties, comments, ratings
 and tags will also be taken into consideration. If you do not want them
@@ -51,11 +51,11 @@ the first time.
 
 To view the resource versions, click on the **View versions** link:
 
-![](attachments/53125531/53287640.png)  
+![](../../assets/img/53125531/53287640.png)  
 
 It opens the versions. For example,
 
-![](attachments/22185146/22514195.png) 
+![](../../assets/img/22185146/22514195.png) 
 
 This page gives the following information:  
 

--- a/en/docs/admin-guide/monitoring-Logs-using-Management-Console.md
+++ b/en/docs/admin-guide/monitoring-Logs-using-Management-Console.md
@@ -13,7 +13,7 @@ This feature enables the log viewer on the management console. You can
 click **System Logs** or **Application Logs** on the **Monitor** tab to
 access the log viewer as shown below.
 
-![Log Viewer UI](attachments/53125396/53287283.png "Log Viewer UI")
+![Log Viewer UI](../../assets/img/53125396/53287283.png "Log Viewer UI")
 
 To use this feature in your Carbon server, see the following topics:  
 

--- a/en/docs/admin-guide/monitoring-Message-Flows.md
+++ b/en/docs/admin-guide/monitoring-Message-Flows.md
@@ -29,16 +29,16 @@ Follow the instructions below to access the Message Flows.
     service. These phases vary according to the currently engaged
     modules within the system. The interface displays the current phases
     in each and every flow as shown in the diagram below.  
-    ![](attachments/53125407/53287294.png)
+    ![](../../assets/img/53125407/53287294.png)
 4.  In the graphical view of the message flows, click the links to get a
     view of the engaged handlers in each phase. For example, the figure
     below shows the handlers engaged in the Addressing phase at system
     start up.  
-    ![](attachments/53125407/53287299.png)
+    ![](../../assets/img/53125407/53287299.png)
 5.  You can see the text view of message flows by clicking **Show Text
     View**.  
-    ![](attachments/53125407/53287296.png)
+    ![](../../assets/img/53125407/53287296.png)
 6.  The page with the text view of message flows appears. The textual
     view provides the name and the fully qualified classes of all
     handlers within each and every phase.  
-    ![](attachments/53125407/53287297.png)
+    ![](../../assets/img/53125407/53287297.png)

--- a/en/docs/admin-guide/monitoring-Performance-Statistics.md
+++ b/en/docs/admin-guide/monitoring-Performance-Statistics.md
@@ -16,9 +16,9 @@ Follow the instructions given below to access system-level statistics.
 
 1.  Log in to the management console and click **System Statistics** in
     the **Monitor** tab:  
-    ![](attachments/53125409/53287307.png)
+    ![](../../assets/img/53125409/53287307.png)
 2.  The **System Statistics** page appears as follows:  
-    ![](attachments/53125409/53287311.png)  
+    ![](../../assets/img/53125409/53287311.png)  
     The following information is available:
     -   [Service
         Summary](#MonitoringPerformanceStatistics-ServiceSummary)
@@ -32,7 +32,7 @@ Follow the instructions given below to access system-level statistics.
 
 #### Service Summary
 
-![](attachments/53125409/53287308.png)
+![](../../assets/img/53125409/53287308.png)
 
 This panel provides the following information:
 
@@ -52,7 +52,7 @@ This panel provides the following information:
 
 #### Server Information
 
-![](attachments/53125409/53287310.png)
+![](../../assets/img/53125409/53287310.png)
 
 This panel provides the following information:
 
@@ -65,13 +65,13 @@ This panel provides the following information:
 
 #### Response Time Graph
 
-![](attachments/53125409/53287309.png)
+![](../../assets/img/53125409/53287309.png)
 
 This graph shows the temporal variation of the Average Response time.
 
 #### Memory Graph
 
-![](attachments/53125409/53287315.png)
+![](../../assets/img/53125409/53287315.png)
 
 This graph shows the temporal variation of the server Memory.
 
@@ -81,7 +81,7 @@ The **Statistics Configuration** panel is provided to customize the
 **System Statistics** display by configuring the level information that
 can be viewed on the panel.
 
-![](attachments/53125409/53287313.png)
+![](../../assets/img/53125409/53287313.png)
 
 The following information can be configured:
 

--- a/en/docs/admin-guide/monitoring-SOAP-Messages.md
+++ b/en/docs/admin-guide/monitoring-SOAP-Messages.md
@@ -23,12 +23,12 @@ Follow the instructions below to access the SOAP Tracer.
 
 1.  Log in to the management console and select **Monitor -\> SOAP
     Tracer**.  
-    ![](attachments/53125408/53287302.png)
+    ![](../../assets/img/53125408/53287302.png)
 2.  In the drop-down menu, select **Yes**.  
-    ![](attachments/53125408/53287305.png)
+    ![](../../assets/img/53125408/53287305.png)
 3.  The tracer will show the messages of the operations that were
     invoked. For example,  
-    ![](attachments/53125408/53287301.png)  
+    ![](../../assets/img/53125408/53287301.png)  
     By using the SOAP Tracer, you can see the SOAP messages with their
     time-stamps, service name, operation invoked and the number of
     requests to the server. The most recent SOAP messages are listed at
@@ -42,8 +42,8 @@ Follow the instructions below to access the SOAP Tracer.
 
 4.  If you want to find a message, fill in the Filter field with a word
     (or a part of word) in the message and click **Search**.  
-    ![](attachments/53125408/53287304.png)
+    ![](../../assets/img/53125408/53287304.png)
 5.  You will see the message in the **Messages** list and its full
     description will be shown in the **Request** or **Response** text
     area. For example,  
-    ![](attachments/53125408/53287300.png)
+    ![](../../assets/img/53125408/53287300.png)

--- a/en/docs/admin-guide/monitoring-Server-Health.md
+++ b/en/docs/admin-guide/monitoring-Server-Health.md
@@ -58,7 +58,7 @@ components in a WSO2 Carbon product that does not support this feature
 by default.
 
 1.  Download the
-    [org.wso2.carbon.healthcheck.server.feature-\<version-number\>.zip](attachments/97566182/97566189.zip)
+    [org.wso2.carbon.healthcheck.server.feature-\<version-number\>.zip](../../assets/img/97566182/97566189.zip)
     and extract it. This folder is reffered to as
     `          <API_HOME>         ` in this document.
 2.  Copy the

--- a/en/docs/admin-guide/other-Usages-of-TCPMon.md
+++ b/en/docs/admin-guide/other-Usages-of-TCPMon.md
@@ -17,7 +17,7 @@ TCPMon can also be used as a request sender for Web services. The
 request SOAP message can be pasted on the send screen and sent directly
 to the server.
 
-![](attachments/45946410/46206514.png)
+![](../../assets/img/45946410/46206514.png)
 
 #### As a Proxy
 
@@ -25,7 +25,7 @@ TCPMon can act as a proxy. To start it in proxy mode, select the Proxy
 option. When acting as a proxy, TCPMon only needs the listener port to
 be configured.
 
-![](attachments/45946410/46206513.png)
+![](../../assets/img/45946410/46206513.png)
 
 #### Advanced Settings
 
@@ -33,7 +33,7 @@ TCPMon can simulate a slow connection, in which case the delay and the
 bytes to be dropped can be configured. This is useful when testing Web
 services.
 
-![](attachments/45946410/46206512.png)
+![](../../assets/img/45946410/46206512.png)
 
 Also, if HTTP proxy support is required, that can also be set on the
 admin screen.

--- a/en/docs/admin-guide/packaging-Artifacts-into-Composite-Applications.md
+++ b/en/docs/admin-guide/packaging-Artifacts-into-Composite-Applications.md
@@ -17,22 +17,22 @@ Applications](#PackagingArtifactsintoCompositeApplications-Packagingindividualar
 1.  Open the Tooling interface with all the artifacts/projects that you
     created. For example, shown below is an ESB mediation sequeance
     created with ESB artifacts.  
-    ![](attachments/50521962/119114531.png) 
+    ![](../../assets/img/50521962/119114531.png) 
 2.  Right-click the **Project Explorer** and click **New -\> Project**
     .  
-    ![](attachments/50521962/119114532.png) 
+    ![](../../assets/img/50521962/119114532.png) 
 3.  From the window that opens, click **Composite Application Project**
     .  
-    ![](attachments/50521962/51252779.png) 
+    ![](../../assets/img/50521962/51252779.png) 
 4.  Give a name to the **Composite Application** project and select the
     projects that you need to group into your C-App from the list of
     available projects below. For example,  
-    ![](attachments/50521962/119114537.png) 
+    ![](../../assets/img/50521962/119114537.png) 
 5.  In the **Composite Application Project POM Editor** that opens,
     under **Dependencies**, note the information for each of the
     projects you selected earlier. You can also change the project
     details here.  
-    ![](attachments/50521962/119114534.png) 
+    ![](../../assets/img/50521962/119114534.png) 
 
 #### Creating a Composite Application Archive (CAR) file
 
@@ -102,4 +102,4 @@ artifact type.
 | Registry Resource            | Registry Resource with necessary metadata |
 | Third Party Library Artifact | .jar (OSGI Bundle)                        |
 
-![](attachments/50521962/57744665.png) 
+![](../../assets/img/50521962/57744665.png) 

--- a/en/docs/admin-guide/production-Deployment-Guidelines.md
+++ b/en/docs/admin-guide/production-Deployment-Guidelines.md
@@ -726,7 +726,7 @@ tool, which is a command-line utility that allows you to get the latest
 updates ( bug fixes and security fixes ) of a particular product
 release.
 
-![](attachments/56984556/61672631.png) 
+![](../../assets/img/56984556/61672631.png) 
 
 **Diagram** : managing your artifacts using a configuration management
 system

--- a/en/docs/admin-guide/properties.md
+++ b/en/docs/admin-guide/properties.md
@@ -7,9 +7,9 @@ existing properties can be edited or deleted .
 1.  To add a property, click on th e **Add New Property** link in the
     **Properties** panel .  
       
-    ![](attachments/53125532/53287646.png)  
+    ![](../../assets/img/53125532/53287646.png)  
 2.  E nter a unique name for the property and a value and click **Add
     .  
-    ** ![](attachments/53125532/53287645.png)
+    ** ![](../../assets/img/53125532/53287645.png)
 3.  After adding the property, you can edit or delete it using the
     **Edit** and **Delete** links associated with it.

--- a/en/docs/admin-guide/role-Permissions.md
+++ b/en/docs/admin-guide/role-Permissions.md
@@ -10,7 +10,7 @@ resource or a collection.
 1.  In the **New Role Permissions** section, select a role from the
     drop-down list. This list is populated by all user roles configured
     in the system.  
-    ![](attachments/53125537/53287669.png)
+    ![](../../assets/img/53125537/53287669.png)
 
     The
     `                         wso2.anonymous.role                       `
@@ -40,7 +40,7 @@ resource or a collection.
 
 3.  Select whether to allow the action or deny and click **Add
     Permission**. For example  
-    ![](attachments/53125537/53287670.png)
+    ![](../../assets/img/53125537/53287670.png)
 
     `                         Deny                       ` permissions
     have higher priority over
@@ -59,7 +59,7 @@ resource or a collection.
     role.
 
 4.  The new permission appears in the list.  
-    ![](attachments/53125537/53287671.png) From here, you can edit the
+    ![](../../assets/img/53125537/53287671.png) From here, you can edit the
     permissions by selecting and clearing the check boxes. After editing
     the permissions, click **Apply All Permissions** to save the
     alterations.

--- a/en/docs/admin-guide/role-based-Permissions.md
+++ b/en/docs/admin-guide/role-based-Permissions.md
@@ -18,11 +18,11 @@ is divided into these two categories ( **Super Admin** permissions and
 other categories of permissions enabled for a WSO2 product, depending on
 the type of features that are installed in the product.
 
-![](attachments/44826804/45088792.png)
+![](../../assets/img/44826804/45088792.png)
 
 You can access the permissions navigator for a particular role by
 clicking **Permissions** as shown below.  
-![](attachments/53125499/53287373.png)
+![](../../assets/img/53125499/53287373.png)
 
 By default, every WSO2 product comes with the following User, Role and
 Permissions configured:
@@ -92,21 +92,21 @@ follows:
     <tbody>
     <tr class="odd">
     <td><strong>Configuration</strong> permissions:<br />
-    <img src="attachments/53125499/53287372.png" /></td>
+    <img src="../../assets/img/53125499/53287372.png" /></td>
     <td>The <strong>Super Admin/Configuration</strong> permissions are used to grant permission to the key functions in a product server, which are common to all the tenants. In each WSO2 product, several configuration permissions will be available depending on the type of features that are installed in the product.<br />
     <br />
     <strong>- Feature Management</strong> permission ensures that a user can control the features installed in the product using the management console. That is, the <strong>Features</strong> option will be enabled under the <strong>Configure</strong> menu.<br />
     <strong>- Logging</strong> permission enables the possibility to configure server logging from the management console. That is, the <strong>Logging</strong> option will be enabled under the <strong>Configure</strong> menu.</td>
     </tr>
     <tr class="even">
-    <td><strong>Management</strong> permissions: <img src="attachments/44826804/45088796.png" /></td>
+    <td><strong>Management</strong> permissions: <img src="../../assets/img/44826804/45088796.png" /></td>
     <td><p>The <strong>Super Admin/Manage</strong> permissions are used for adding new tenants and monitoring them.</p>
     <p><strong>- Modify/Tenants</strong> permission enables the <strong>Add New Tenant</strong> option in the <strong>Configure</strong> menu of the management console, which allows users to add new tenants.<br />
     <strong>- Monitor/Tenants</strong> permission enables the <strong>View Tenants</strong> option in the <strong>Configure</strong> menu of the management console.</p></td>
     </tr>
     <tr class="odd">
     <td><strong>Server Admin</strong> permissions:<br />
-    <img src="attachments/44826804/45088797.png" /></td>
+    <img src="../../assets/img/44826804/45088797.png" /></td>
     <td>Selecting the <strong>Server Admin</strong> permission enables the <strong>Shutdown/Restart</strong> option in the <strong>Main</strong> menu of the management console.</td>
     </tr>
     </tbody>

--- a/en/docs/admin-guide/searching-the-Registry.md
+++ b/en/docs/admin-guide/searching-the-Registry.md
@@ -5,9 +5,9 @@ registry.
 
 1.  Log in to the product's management console a nd select **Search -\>
     Metadata** under the **Registry** menu.  
-    ![](attachments/53125538/53287682.png)
+    ![](../../assets/img/53125538/53287682.png)
 2.  The **Search** page opens .  
-    ![](attachments/53125538/53287681.png) You can define a search
+    ![](../../assets/img/53125538/53287681.png) You can define a search
     criteria using the following parameters:
     -   Resource name
     -   **Created/updated date range** - The date when a resource was
@@ -16,7 +16,7 @@ registry.
         Created/updated dates must be in MM/DD/YYYY format.
         Alternatively, you can pick it from the calendar interface
         provided.  
-        ![](attachments/53125538/53287680.png)
+        ![](../../assets/img/53125538/53287680.png)
 
     -   **Created/updated author** - The person who created/updated the
         resource

--- a/en/docs/admin-guide/separating-the-Worker-and-Manager-Nodes.md
+++ b/en/docs/admin-guide/separating-the-Worker-and-Manager-Nodes.md
@@ -60,7 +60,7 @@ application runs continuously.
 This mode is rarely used. The preferred mode is having two management
 nodes in Active/Passive mode as in deployment pattern 2.
 
-![](attachments/56984503/56984506.png) 
+![](../../assets/img/56984503/56984506.png) 
 
 #### Worker/Manager clustering deployment pattern 2
 
@@ -75,7 +75,7 @@ deployment/modification might be frequent and therefore, need a cluster
 of manager nodes. However, if the load is less, you can share a single
 load balancer with the worker cluster.
 
-![](attachments/56984503/56984505.png) 
+![](../../assets/img/56984503/56984505.png) 
 
   
 
@@ -93,4 +93,4 @@ application/modification load (or any other administrative load) might
 be high, so there is a dedicated load balancer for the manager cluster
 to prevent this load from affecting the load of the worker cluster.
 
-![](attachments/56984503/56984504.png) 
+![](../../assets/img/56984503/56984504.png) 

--- a/en/docs/admin-guide/setting-up-IBM-DB2.md
+++ b/en/docs/admin-guide/setting-up-IBM-DB2.md
@@ -43,7 +43,7 @@ center](#SettingupIBMDB2-UsingtheDB2controlcenter) as described below.
 
     For example:
 
-    ![](attachments/53125504/53287380.png) 
+    ![](../../assets/img/53125504/53287380.png) 
 
     For more information on DB2 commands, see the [DB2 Express-C
     Guide](https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/Big%20Data%20University/page/FREE%20eBook%20-%20Getting%20Started%20with%20DB2%20Express-C)
@@ -54,18 +54,18 @@ center](#SettingupIBMDB2-UsingtheDB2controlcenter) as described below.
 1.  Open the DB2 control center using the `          db2cc         `
     command as follows:  
 
-    ![](attachments/53125504/53287383.png)
+    ![](../../assets/img/53125504/53287383.png)
 
 2.  Right-click **All Databases** in the control center tree (inside the
     object browser), click **Create Database**, and then click
     **Standard** and follow the steps in the **Create New Database**
     wizard.  
-    ![](attachments/53125504/53287398.png) 
+    ![](../../assets/img/53125504/53287398.png) 
 3.  Click **User and Group Objects** in the control center tree to
     create users for the newly created database.  
-    ![](attachments/53125504/53287381.png) 
+    ![](../../assets/img/53125504/53287381.png) 
 4.  Give the required permissions to the newly created users.  
-    ![](attachments/53125504/53287382.png) 
+    ![](../../assets/img/53125504/53287382.png) 
 
 ### Setting up DB2 JDBC drivers
 
@@ -74,7 +74,7 @@ Copy the DB2 JDBC drivers ( `         db2jcc.jar        ` and
 `         <DB2_HOME>/SQLLIB/java/        ` directory to the
 `         <PRODUCT_HOME>/repository/components/lib/        ` directory.
 
-![](attachments/53125504/53287393.png)
+![](../../assets/img/53125504/53287393.png)
 
 `          <DB2_HOME>         ` refers to the installation directory of
 DB2 Express-C, and \< `          PRODUCT         `

--- a/en/docs/admin-guide/setting-up-MariaDB.md
+++ b/en/docs/admin-guide/setting-up-MariaDB.md
@@ -17,7 +17,7 @@ information on the MariaDB versions that are tested with WSO2 products.
     <https://downloads.mariadb.org/> .
 
     You can install MariaDB standalone or as a [galera
-    cluster](attachments/53125509/53287445.png) for high availability.
+    cluster](../../assets/img/53125509/53287445.png) for high availability.
     Database clustering is independent of WSO2 product clustering.
 
     For instructions on installing MariaDB on MAC OS, go to

--- a/en/docs/admin-guide/setting-up-Oracle-RAC.md
+++ b/en/docs/admin-guide/setting-up-Oracle-RAC.md
@@ -31,9 +31,9 @@ Follow the steps below to set up an Oracle RAC database.
     `          /oracle/app/oracle/product/11.2.0/dbhome_1         `,
     `          $PATH:<ORACLE_HOME>/bin         `, and
     `          orcl1         ` ) as follows:  
-    ![](attachments/53125514/53287565.png) 
+    ![](../../assets/img/53125514/53287565.png) 
 2.  Connect to Oracle using SQL\*Plus as SYSDBA.  
-    ![](attachments/53125514/53287577.png) 
+    ![](../../assets/img/53125514/53287577.png) 
 3.  Create a database user and grant privileges to the user as shown
     below:
 

--- a/en/docs/admin-guide/setting-up-PostgreSQL.md
+++ b/en/docs/admin-guide/setting-up-PostgreSQL.md
@@ -12,16 +12,16 @@ default H2 database in your WSO2 product:
 Follow the steps below to set up a PostgreSQL database.
 
 1.  Install PostgreSQL on your computer as follows:  
-    ![](attachments/53125515/53287605.png)
+    ![](../../assets/img/53125515/53287605.png)
 2.  Start the PostgreSQL service using the following command:  
-    ![](attachments/53125515/53287604.png)
+    ![](../../assets/img/53125515/53287604.png)
 3.  Create a database and the login role from a GUI using the
     [PGAdminIII tool](http://www.pgadmin.org/download/).
 4.  To connect PGAdminIII to a PostgreSQL database server, locate the
     server from the object browser, right-click the client and click
     **Connect**. This will show you the databases, tablespaces, and
     login roles as follows:  
-    ![](attachments/53125515/53287590.png) 
+    ![](../../assets/img/53125515/53287590.png) 
 5.  To create a database, click **Databases** in the tree (inside the
     object browser), and click **New Database**.
 6.  In the **New Database** dialog box, give a name to the database,

--- a/en/docs/admin-guide/setting-up-Remote-H2.md
+++ b/en/docs/admin-guide/setting-up-Remote-H2.md
@@ -31,13 +31,13 @@ Follow the steps below to set up a Remote H2 database.
     For instructions on installing, see the [H2 installation
     guide](http://www.h2database.com/html/quickstart.html).
 
-    ![](attachments/53125507/53287411.png)
+    ![](../../assets/img/53125507/53287411.png)
 
 2.  Go to the \< `          H2_HOME>/bin         ` directory and run the
     H2 network server starting script as follows, where \<
     `          H2_HOME>         ` is the H2 installation directory:  
 
-    ![](attachments/53125507/53287410.png)
+    ![](../../assets/img/53125507/53287410.png)
 
 3.  Run the H2 database server with the following commands:
     -   For Linux:  

--- a/en/docs/admin-guide/sharing-Databases-in-a-Cluster.md
+++ b/en/docs/admin-guide/sharing-Databases-in-a-Cluster.md
@@ -36,7 +36,7 @@ governance) depending on the amount of data used.
 The following diagram depicts how the databases are configured in a
 typical WSO2 product cluster.
 
-![](attachments/56984483/56984486.png)
+![](../../assets/img/56984483/56984486.png)
 
 In the above diagram, the governance and configuration registry is
 shared for the whole WSO2 product cluster (assuming the cluster is

--- a/en/docs/admin-guide/using-JVM-Metrics.md
+++ b/en/docs/admin-guide/using-JVM-Metrics.md
@@ -14,35 +14,35 @@ Metrics](_Setting_Up_Carbon_Metrics_).
     page.
 2.  Specify the source for the JVM metrics by selecting a value from the
     drop-down list for the **Source** parameter in the top panel.  
-    ![](attachments/53125402/53287291.png)
+    ![](../../assets/img/53125402/53287291.png)
 3.  Specify the time interval for which the statistics should be
     displayed in the dashboard by selecting a value from the following
     drop-down list in the top panel.  
-    ![](attachments/53125402/53287286.png)
+    ![](../../assets/img/53125402/53287286.png)
 4.  Click the required buttons opposite **Views** in the top panel to
     select the types of information you want to view in the dashboard
     and refresh the web page.  
-    ![](attachments/53125402/53287285.png)  
+    ![](../../assets/img/53125402/53287285.png)  
     Statistics corresponding to each button can be viewed as follows:
     -   **CPU  
         ** Click this button to view statistics relating to the CPU as
         shown below.  
-        ![](attachments/53125402/53287284.png)
-        ![](attachments/53125402/53287293.png)
+        ![](../../assets/img/53125402/53287284.png)
+        ![](../../assets/img/53125402/53287293.png)
     -   **Memory**  
         Click **Memory** to view statistics relating to the memory as
         shown below.  
-        ![](attachments/53125402/53287292.png)
-        ![](attachments/53125402/53287290.png)
+        ![](../../assets/img/53125402/53287292.png)
+        ![](../../assets/img/53125402/53287290.png)
     -   **Threading  
         ** Click **Threading** to view statistics relating to threading
         as shown below.  
-        ![](attachments/53125402/53287289.png)
+        ![](../../assets/img/53125402/53287289.png)
     -   **Class Loading  
         ** Click **Class Loading** to view statistics relating to class
         loading as shown below.  
-        ![](attachments/53125402/53287288.png)
+        ![](../../assets/img/53125402/53287288.png)
     -   **File Descriptor  
         ** Click **File Descriptor** to view information relating to the
         file descriptor count as shown below.  
-        ![](attachments/53125402/53287287.png)
+        ![](../../assets/img/53125402/53287287.png)

--- a/en/docs/admin-guide/using-Messaging-Metrics.md
+++ b/en/docs/admin-guide/using-Messaging-Metrics.md
@@ -16,10 +16,10 @@ Metrics** dashboard.
 
 1.  Log in to the management console of the broker and click **Monitor
     -\> Metrics -\> Messaging Metrics**.  
-    ![](attachments/87694058/87694050.png)
+    ![](../../assets/img/87694058/87694050.png)
 2.  The **View Metrics** page will open. At the top of this page, you
     will find the following panel:  
-    ![](attachments/87694058/87694057.png)
+    ![](../../assets/img/87694058/87694057.png)
 3.  First, select the **Source** from the drop-down list. In a clustered
     setup, you must specify the broker node that you want to monitor.
 4.  You can specify the time interval for which the statistics displayed
@@ -30,7 +30,7 @@ Metrics** dashboard.
     relevant button to view the statistics. Given below are the
     statistics corresponding to each button:  
     -   **Disruptor**
-        ![](attachments/87694058/87694056.png)
+        ![](../../assets/img/87694058/87694056.png)
 
         |                                      |                                                                                                                                                                                                                |
         |--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Metrics** dashboard.
           
 
     -   **Publish & Subscribe**
-        ![](attachments/87694058/87694055.png)
+        ![](../../assets/img/87694058/87694055.png)
 
         |                         |                                                                                                                            |
         |-------------------------|----------------------------------------------------------------------------------------------------------------------------|
@@ -69,10 +69,10 @@ Metrics** dashboard.
         **  
         **
     -   **Database**  
-        ![](attachments/87694058/87694051.png)
-        ![](attachments/87694058/87694052.png)
-        ![](attachments/87694058/87694053.png)
-        ![](attachments/87694058/87694054.png)
+        ![](../../assets/img/87694058/87694051.png)
+        ![](../../assets/img/87694058/87694052.png)
+        ![](../../assets/img/87694058/87694053.png)
+        ![](../../assets/img/87694058/87694054.png)
 
         |                         |                                                                 |
         |-------------------------|-----------------------------------------------------------------|

--- a/en/docs/admin-guide/view-and-Download-Logs.md
+++ b/en/docs/admin-guide/view-and-Download-Logs.md
@@ -46,7 +46,7 @@ below to access statistics on system logs:
 2.  To view old archived logs, click **Show archived logs** tab at the
     bottom of the **System Logs** page.
 
-    ![](attachments/32351462/32525350.png)
+    ![](../../assets/img/32351462/32525350.png)
 
     The **Download** link can be used to download the log files. For
     example, if the server is configured to use the [default log
@@ -65,12 +65,12 @@ below to access statistics on system logs:
     -   **ERROR** - Error messages.
     -   **FATAL** - Fatal error messages.
 
-    ![](attachments/32351462/32525349.png)
+    ![](../../assets/img/32351462/32525349.png)
 
 4.  You can also find a specific log using the search function. Enter a
     keyword (or part of a keyword) and click **Search**.
 
-    ![](attachments/32351462/32525348.png)
+    ![](../../assets/img/32351462/32525348.png)
 
 ### View application logs
 
@@ -93,7 +93,7 @@ logs:
 
 3.  You can see a drop-down list from which a deployed web services or a
     web applications can be selected to view its log files.  
-    ![](attachments/12421402/12747658.png)
+    ![](../../assets/img/12421402/12747658.png)
 4.  In the **View** list, select the category of logs you want to view.
     The available categories are:  
 
@@ -107,10 +107,10 @@ logs:
 
     For Example,
 
-    ![](attachments/12421402/12747656.png)
+    ![](../../assets/img/12421402/12747656.png)
 
 5.  You can also find a certain log using the search function. Enter a
     keyword (or part of a keyword) and click **Search**. When a search
     criterion is given, the value in the **View** field is displayed as
     **Custom**. For example,  
-    ![](attachments/12421402/12747655.png) 
+    ![](../../assets/img/12421402/12747655.png) 

--- a/en/docs/admin-guide/working-with-Features.md
+++ b/en/docs/admin-guide/working-with-Features.md
@@ -134,7 +134,7 @@ Follow the instructions below:
     To find a particular feature, you can use the search function. Enter
     the name of a feature (or a part of the name) and press **Enter**
     .  
-    ![](attachments/53125432/85387849.png) This search will return only
+    ![](../../assets/img/53125432/85387849.png) This search will return only
     available features; excluding the ones already installed.
 
 9.  Click **Install**.
@@ -357,7 +357,7 @@ process, some features might get installed and some uninstalled.
 2.  Go to the **Configure** menu, and click **Features**.
 3.  Click on the **Installation History** tab **.** The **Installation
     History** page appears. See the example below.  
-    ![](attachments/53125432/85387850.png) 
+    ![](../../assets/img/53125432/85387850.png) 
 4.  Select the configuration to which you wish to revert.  
 5.  Click **Revert**, to revert the current configuration to a previous
     configuration.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -99,7 +99,6 @@ nav:
         - 'Understanding What Has Changed': setup/understanding-what-has-changed.md
       - 'Upgrading From an Older Version of WSO2 IS': setup/upgrading-from-an-older-version-of-wso2-is.md
   - 'Tutorials':
-    - 'Tutorials': tutorials/tutorials.md
     - 'Authentication':
       - 'Logging in to your application via Identity Server using Facebook Credentials': tutorials/logging-in-to-your-application-via-identity-server-using-facebook-credentials.md
       - 'Configuring Shibboleth IdP as a Trusted Identity Provider': tutorials/configuring-shibboleth-idp-as-a-trusted-identity-provider.md
@@ -233,9 +232,8 @@ nav:
           - 'Writing XACML 3 Policies in WSO2 Identity Server - 7': tutorials/writing-xacml-3-policies-in-wso2-identity-server-7.md
         - 'Sending Notifications to External PEP Endpoints': tutorials/sending-notifications-to-external-pep-endpoints.md
         - 'Writing an XACML 3.0 Policy Using XPath': tutorials/writing-a-xacml-3.0-policy-using-xpath.md
-      - 'Setting Up An LDAP User Store': tutorials/setting-up-an-ldap-user-store.md
+    - 'Setting Up An LDAP User Store': tutorials/setting-up-an-ldap-user-store.md
   - 'Using WSO2 Identity Server': 
-    - 'Using WSO2 Identity Server': using-wso2-identity-server/using-WSO2-Identity-Server.md
     - 'Product Administration': 
       - 'Product Administration': using-wso2-identity-server/product-Administration.md
       - 'Configuring the Identity Server':


### PR DESCRIPTION
## Purpose
- Temp bulk fix for image paths in admin-guide
- Removed tutorials.md and using-wso2-identity-server.md files (redundant landing pages with links to children pages)
- Re-positioned setting-up-an-ldap-user-store.md within the left nav