### PR TITLE
Adding anchor tag for parameters table

### DIFF
--- a/en/docs/learn/openid-connect-logout-url-redirection.md
+++ b/en/docs/learn/openid-connect-logout-url-redirection.md
@@ -81,7 +81,7 @@ Follow the steps below to send an OIDC logout request:
     ```
       
     Following are the parameters you need to specify in the URL:
-
+    <a name="parameters"></a>
     <table>
     <thead>
     <tr class="header">
@@ -157,9 +157,7 @@ when you send an OIDC logout request as a POST request:
 ```
 
 For descriptions of all the parameters that you need to specify in the
-POST request, see the [parameter descriptions given
-above](#OpenIDConnectLogoutURLRedirection-parameters).
-
+POST request, see the <a href="<#parameters>parameter descriptions given above</a>
 Following is the sample HTML form with sample parameter values to render
 the page in a browser:
 


### PR DESCRIPTION
## Purpose
"parameter descriptions given above" should  link to a table in the same page
