### PR TITLE
Add REST API swagger link to the using-the-account-recovery-rest-apis.md

### DIFF
--- a/en/docs/develop/using-the-account-recovery-rest-apis.md
+++ b/en/docs/develop/using-the-account-recovery-rest-apis.md
@@ -2,7 +2,7 @@
 
 !!! tip     
     For information on password and username recovery using REST APIs, see the [REST API swagger docs on account
-    recovery](../../references/account-recovery).
+    recovery](https://docs.wso2.com/display/IS590/apidocs/self-registration/).
     
 !!! info "Related Links" 
     For information on password and username recovery via the UI instead,


### PR DESCRIPTION
Updated the `using-the-account-recovery-rest-apis.md` file by adding the `https://docs.wso2.com/display/IS590/apidocs/account-recovery/`.