### PR TITLE
Fix GA codes issue

### DIFF
--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -18,6 +18,7 @@
 
 {% extends "base.html" %}
 
+{% block analytics %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-103065-9"></script>
 <script>
@@ -50,6 +51,7 @@
   })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
 </script>
 <!-- End Google Tag Manager (noscript) -->
+{% endblock %}
 
 
 {% block styles %}


### PR DESCRIPTION
## Purpose
The Google and Hotjar analytics tracking codes were not appearing in the <head> of each page. This PR fixes this issue. 