### PR TITLE
Adding new link to deploy and configure travelocity

### DIFF
--- a/en/docs/develop/customizing-login-pages-for-service-providers.md
+++ b/en/docs/develop/customizing-login-pages-for-service-providers.md
@@ -22,7 +22,7 @@ parameter.
 The following is a sample of how to customize the login page for SAML2
 SSO.
 
-### Customizing the login page for SAML SSO service providers
+## Customizing the login page for SAML SSO service providers
 
 Usually WSO2 Identity Server displays a default login page for all the
 SAML SSO service providers that send authentication requests to it. The
@@ -30,60 +30,38 @@ following steps indicate how to change the default login page into a
 customized one.
 
 !!! tip "Before you begin"
-    
-    -   To ensure you get the full understanding of customizing the login
-        page with WSO2 IS, the sample travelocity application is used in
-        this use case. Therefore, make sure to [download the
-        samples](../../learn/downloading-a-sample) before you begin.
     -   The samples run on the Apache Tomcat server and are written based on
-        Servlet 3.0. Therefore, download Tomcat 7.x from
+        Servlet 3.0. Therefore, download Tomcat 8.x from
         [here](https://tomcat.apache.org/download-70.cgi).
-    -   Install Apache Maven to build the samples. For more information, see
-        [Installation
-        Prerequisites](../../setup/installation-prerequisites).
+    
     
 
-#### Configuring two service providers
+### Configuring two service providers
 
-1.  Open a terminal window and add the following entry to the
-    `           /etc/hosts          ` file of your machine to configure
-    the hostname.
+1.  [Deploy traveloctity](../../develop/deploying-the-sample-app/) sample application.
 
-    ``` bash
-    127.0.0.1   wso2is.local
-    ```
+    !!! note
+        - Open `           travelocity.properties          ` file and check for following 
+        configurations.
+            ```
+            #The URL of the SAML 2.0 Assertion Consumer
+            SAML2.AssertionConsumerURL=http://wso2is.local:8080/travelocity.com/home.jsp
+        
+        
+            #openid.return_to parameter
+            OpenId.ReturnToURL=http://wso2is.local:8080/travelocity.com/home.jsp
+            ```
 
-2.  Open the `           travelocity.properties          ` file found in
-    the
-    `           <SAMPLE_HOME>/sso/sso-agent-sample/src/main/resources          `
-    directory of the samples folder you just checked out. Configure the
-    following properties with the hostname (
-    `           wso2is.local          ` ) that you configured above.
+        - Open the `avis.properties` file  and check for following configurations.
+            ```
+            #The URL of the SAML 2.0 Assertion Consumer
+            SAML2.AssertionConsumerURL=http://wso2.is:8080/avis.com/home.jsp
+        
+            #openid.return_to parameter
+            OpenId.ReturnToURL=http://wso2.is:8080/avis.com/home.jsp
+            ```
 
-    ```xml
-    #The URL of the SAML 2.0 Assertion Consumer
-    SAML2.AssertionConsumerURL=http://wso2is.local:8080/travelocity.com/home.jsp
-
-
-    #openid.return_to parameter
-    OpenId.ReturnToURL=http://wso2is.local:8080/travelocity.com/home.jsp
-    ```
-
-3.  Open the avis.properties file found in the
-    `           <SAMPLE_HOME>/sso/sso-agent-sample/src/main/resources          `
-    directory of the samples folder you just checked out. Configure the
-    following properties with the hostname (
-    `           wso2is.local          ` ).
-
-    ``` xml
-    #The URL of the SAML 2.0 Assertion Consumer
-    SAML2.AssertionConsumerURL=http://wso2.is:8080/avis.com/home.jsp
-
-    #openid.return_to parameter
-    OpenId.ReturnToURL=http://wso2.is:8080/avis.com/home.jsp
-    ```
-
-4.  Start the application server and access following URLs to make sure
+2.  Start the application server and access following URLs to make sure
     both apps are running.
 
     **travelocity.com**
@@ -100,7 +78,7 @@ customized one.
 
     ![Avis screen](../assets/img/using-wso2-identity-server/avis-screen.png) 
 
-#### Registering the two service providers in WSO2 Identity Server
+### Registering the two service providers in WSO2 Identity Server
 
 1.  Sign in to the WSO2 Identity Server [Management
     Console](../../setup/getting-started-with-the-management-console).
@@ -142,9 +120,9 @@ customized one.
     .  
     ![Identity Server sign in screen](../assets/img/using-wso2-identity-server/identity-server-sign-in-screen.png) 
 
-#### Configuring the login page
+### Configuring the login page
 
-##### Understanding the authenticationendpoint web application
+#### Understanding the authenticationendpoint web application
 
 The login page that is displayed during SAML2 SSO, OAuth, OpenID Connect
 and Passive-STS flows is located inside the webapp named
@@ -213,7 +191,7 @@ Server. Additionally, you must point to the correct location via the
 `         <IS_HOME>/repository/conf/identity/application-authentication.xml        `
 file.
 
-##### Customizing the login page
+#### Customizing the login page
 
 When a request comes to the default login page, you can see several
 parameters being passed in the address bar. For this customization, the
@@ -246,7 +224,7 @@ When customizing the pages, ensure that the following is applied.
     <input type="hidden" name="sessionDataKey" value="<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>"/>
     ```
 
-##### **Using a JSP to redirect to SP relevant pages**
+#### **Using a JSP to redirect to SP relevant pages**
 
 1.  Rename the existing 'login.jsp' to 'default\_login.jsp'
 2.  Create a new file with the name 'login.jsp' including the following

--- a/en/docs/develop/instagram-authenticator.md
+++ b/en/docs/develop/instagram-authenticator.md
@@ -65,13 +65,6 @@ information in the following sections.
 The next step is to [deploy the sample app](../../develop/deploying-the-sample-app)
 in order to use it in this scenario.
 
-Once this is done, the next step is to configure the WSO2 Identity
-Server by adding an [identity
-provider](../../learn/adding-and-configuring-an-identity-provider)
-and [service
-provider](../../learn/adding-and-configuring-a-service-provider)
-.
-
 ### Configuring the identity provider
 
 Now you have to configure WSO2 Identity Server by [adding a new identity

--- a/en/docs/develop/password-policy-authenticator.md
+++ b/en/docs/develop/password-policy-authenticator.md
@@ -11,7 +11,7 @@ prompted to reset the password.
     to view the latest documentation.
 
 
-### Deploying Password Policy artifacts
+## Deploying Password Policy artifacts
 
 1.  Download the [Password Policy Authenticator and
     artifacts](https://store.wso2.com/store/assets/isconnector/details/502efeb1-cc59-4b62-a197-8c612797933c)
@@ -79,7 +79,7 @@ prompted to reset the password.
         If the property is not added to the file, by default, the password
         reset time is 30 days.
 
-### Add claim mapping
+## Add claim mapping
 
 A claim is a piece of information about a particular subject. It can be
 anything that the subject is owned by or associated with, such as name,
@@ -111,17 +111,12 @@ is expired or not for this flow to work.
 
     ![](../assets/img/50511336/97551782.png)   
 
-### Deploying travelocity.com sample
+## Deploying travelocity sample application
 
 The next step is to [deploy the sample app](../../develop/deploying-the-sample-app)
 in order to use it in this scenario.
 
-Once this is done, the next step is to configure the WSO2 Identity
-Server by adding a [service
-provider](../../learn/adding-and-configuring-a-service-provider)
-.
-
-### Configuring the Service Provider
+## Configuring the Service Provider
 
 The next step is to configure the service provider.
 
@@ -181,7 +176,7 @@ The next step is to configure the service provider.
 
 You have now added and configured the service provider.
 
-### Testing the sample
+## Testing the sample
 
 1.  To test the sample, the password needs be expired. So select
     "Supported by Default" checkbox in the

--- a/en/docs/develop/twitter-authenticator.md
+++ b/en/docs/develop/twitter-authenticator.md
@@ -19,7 +19,7 @@ information in the following sections.
     This is tested with the Twitter API version 1.1 which uses OAuth 1.0a.
     Twitter Authenticator is supported by Identity Server 5.1.0 upwards.
 
-### Deploying Twitter artifacts
+## Deploying Twitter artifacts
 
 -   Download the WSO2 Identity Server from
     [here](http://wso2.com/products/identity-server/).
@@ -38,7 +38,7 @@ information in the following sections.
         instructions.](../../develop/upgrading-an-authenticator)
     
 
-### Configuring the Twitter App
+## Configuring the Twitter App
 
 1.  Create an account at <https://twitter.com> and log in.
 2.  Navigate to https://apps.twitter.com/ and click **Create New App**.
@@ -79,15 +79,16 @@ information in the following sections.
     Example:  
     ![](../assets/img/50515587/75109896.png) 
 
-### Deploying travelocity.com sample app
+## Deploying travelocity sample application
 
-The next step is to [deploy the sample app](../../develop/deploying-the-sample-app)
-in order to use it in this scenario.
+The next step is to deploy and configure travelocity application. See 
+[deploy the sample app](../../develop/deploying-the-sample-app) for more information 
+on configuring travelocity application. 
 
 Once this is done, the next step is to configure the WSO2 Identity
 Server by adding an identity provider and service provider as shown below.
 
-### Configuring the identity provider
+## Configuring the identity provider
 
 Now you have to configure WSO2 Identity Server by adding a new identity
 provider. For more information about the Identity Providers, see
@@ -121,7 +122,7 @@ Provider](../../learn/adding-and-configuring-an-identity-provider)
 
 You have now added the identity provider.
 
-### Configuring the service provider
+## Configuring the service provider
 
 The next step is to configure the service provider.
 
@@ -169,7 +170,7 @@ The next step is to configure the service provider.
 
 You have now added and configured the service provider.
 
-### Testing the sample
+## Testing the sample
 
 1.  To test the sample, go to the following URL:
     `           http://<TOMCAT_HOST>:<TOMCAT_PORT>/travelocity.com/index.jsp          `

--- a/en/docs/develop/wordpress-authenticator.md
+++ b/en/docs/develop/wordpress-authenticator.md
@@ -61,13 +61,12 @@ You can find more information in the following sections.
     Now you have finished configuring Wordpress so copy the **Client ID** and **Client Secret** for use in the Identity Server.  
     ![](../assets/img/49092145/49226414.png) 
 
-### Deploying travelocity.com sample app
+### Deploying travelocity sample application
 
 The next step is to deploy the travelocity.com sample app in order to
 use it in this scenario.
 
-To configure this, see [deploying travelocity.com sample
-app](../../develop/deploying-the-sample-app).
+For deployment and configuration, see [Deploying the Sample App](../../develop/deploying-the-sample-app).
 
 ### Configuring the identity provider
 

--- a/en/docs/learn/configuring-a-sp-and-idp-using-service-calls.md
+++ b/en/docs/learn/configuring-a-sp-and-idp-using-service-calls.md
@@ -351,7 +351,7 @@ console](../../setup/getting-started-with-the-management-console) user interface
 
       -   See [Configuring SAML
       SSO](../../learn/configuring-single-sign-on)
-      for information on using the travelocity.com application for single
+      for information on using the pickup-dispatch application for single
       sign-on. This provides insight on some parameters used.
       -   See [Configuring a Service
       Provider](../../learn/adding-and-configuring-a-service-provider)

--- a/en/docs/learn/configuring-access-control-policy-for-a-service-provider.md
+++ b/en/docs/learn/configuring-access-control-policy-for-a-service-provider.md
@@ -81,7 +81,7 @@ the WSO2 IS architecture, see [Architecture](../../get-started/architecture).
 6.  Configure an inbound authentication protocol for the service
     provider (i.e, SAML, OpenID Connect etc).
 
-    !!! info
+    ??? info "Configure travelocity"
 		The responsibility of the inbound authentication protocol is to
 		identify and parse all the incoming authentication requests and then
 		helps in building the correct response. As Inbound Authentication
@@ -89,21 +89,20 @@ the WSO2 IS architecture, see [Architecture](../../get-started/architecture).
 		etc.
 
 		For this tutorial, we will set up the travelocity sample application
-		by following the instructions in [Configuring Single
-		Sign-On](../../learn/configuring-single-sign-on)
-		. Here we use **SAML2** as the inbound authentication protocol.
+		by following the instructions in [Deploying the Sample App](../../develop/deploying-the-sample-app). 
+		Here we use **SAML2** as the inbound authentication protocol. The following screenshot 
+		shows the SAML configuration for the travelocity sample service provider. 
+		
+		![inbound-authentication-protocol](../assets/img/tutorials/inbound-authentication-protocol.png)
+		
+    !!! note
+        If your service provider needs any claims of the authenticated user to
+        provide the service, you can [configure claims of the service
+        provider](../../configuring-single-sign-on/#configuring-claims). Then once the access is
+        provided after evaluating the XACML policy, the Service Provider can
+        get those claim details of the authorized user from the Identity
+        Provider side.
 
-		Since this is the only available configuration that we have for
-		travelocity.com service provider. The screenshot below shows the
-		SAML configuration for the travelocity sample service provider. If
-		your service provider needs any claims of the authenticated user to
-		provide the service, you can [configure claims of the service
-		provider](../../learn/configuring-single-sign-on). Then once the access is
-		provided after evaluating the XACML policy, the Service Provider can
-		get those claim details of the authorized user from the Identity
-		Provider side.
-
-    ![inbound-authentication-protocol](../assets/img/tutorials/inbound-authentication-protocol.png)
 
 7.  Expand the **Local and Outbound Authentication Configuration**
     section and select the authenticator used to authenticate users in

--- a/en/docs/learn/configuring-claims-for-a-service-provider.md
+++ b/en/docs/learn/configuring-claims-for-a-service-provider.md
@@ -112,7 +112,6 @@ To register a service provider, do the following.
                 ![enable-attribute-profile](../assets/img/using-wso2-identity-server/enable-attribute-profile.png)
             
                 !!! info "Why?"
-            
                         This is required since Identity Server include user claims
                         in the SAML2 response only if SAML2 attribute profile is
                         enabled.
@@ -132,31 +131,29 @@ To register a service provider, do the following.
                 to provide them at the time of login as shown in the image
                 below.  
 
-                ??? note "Expand for steps to test out mandatory claims"
-                    !!! tip "Testing mandatory claims"
-                        To test out mandatory claims,
+                ??? tip "Testing mandatory claims"
+                    To test out mandatory claims,
                     
-                        1.  Configure the travelocity sample application by
-                            following the steps in the [Configuring Single
-                            Sign-On](../../learn/single-sign-on) topic.
-            
-                        2.  Configure a few claims and select the checkbox for
-                            mandatory claims.
-            
-                        3.  Ensure that there are one or more claims which are
-                            missing in the user profile of the user you wish to
-                            login with.
-            
-                        4.  Run the travelocity sample and try the SAML login.
-            
-                        5.  Log in with the user credentials of the user who has a
-                            few mandatory claims missing, and click **Submit**.
-                        6.  A claim request will be prompted, Similiar to the image
-                            below. At this point, the mandatory claim rule is
-                            enforced and you cannot proceed without providing the
-                            necessary claim values. Provide the necessary claim
-                            values and click **Submit**.
-                        7.  You will be successfully logged in to the application.
+                    1.  Configure the travelocity sample application by
+                        following the steps in the [Deploying the Sample App](../../develop/deploying-the-sample-app/). 
+                        
+                    2.  Configure a few claims and select the checkbox for
+                        mandatory claims.
+        
+                    3.  Ensure that there are one or more claims which are
+                        missing in the user profile of the user you wish to
+                        login with.
+        
+                    4.  Run the travelocity sample and try the SAML login.
+        
+                    5.  Log in with the user credentials of the user who has a
+                        few mandatory claims missing, and click **Submit**.
+                    6.  A claim request will be prompted, Similiar to the image
+                        below. At this point, the mandatory claim rule is
+                        enforced and you cannot proceed without providing the
+                        necessary claim values. Provide the necessary claim
+                        values and click **Submit**.
+                    7.  You will be successfully logged in to the application.
         
 
                 Marking a mapped claim as a **Requested Claim** would ensure

--- a/en/docs/learn/configuring-email-otp.md
+++ b/en/docs/learn/configuring-email-otp.md
@@ -11,16 +11,9 @@ Email OTP:
 
 !!! tip "Before you begin"
     
-    -   To ensure you get the full understanding of configuring Email OTP
-        with WSO2 IS, the sample travelocity application is used in this use
-        case. Therefore, make sure to [download the
-        samples](../../learn/downloading-a-sample)
-        before you begin.
     -   The samples run on the Apache Tomcat server and are written based on
-        Servlet 3.0. Therefore, download Tomcat 7.x from
+        Servlet 3.0. Therefore, download Tomcat 8.x from
         [here](https://tomcat.apache.org/download-70.cgi) .
-    -   Install Apache Maven to build the samples. For more information, see
-        [Installation Prerequisites](../../setup/installation-prerequisites).
     
 ### Configure the email OTP provider
 
@@ -513,111 +506,10 @@ set up the email OTP provider.
     	
 ------------------------------------------------------------------------
 
-### Deploy the travelocity.com sample
+### Deploying travelocity sample application
 
-!!! abstract ""
-    Now that you have set up WSO2 IS or Gmail as the Email
-    OTP provider, follow the steps below to deploy the travelocity.com
-    sample application, which you can use to try out the Email OTP scenario.
-    
-    To obtain and configure the single sign-on travelocity sample, follow
-    the steps below.
-    
-    1.  Add the following entry to the `            /etc/hosts           `
-        file of your machine to configure the hostname.
-    
-        !!! info "Why is this step needed?"
-    
-            Some browsers do not allow creating cookies for a naked hostname,
-            such as `             localhost            ` . Cookies are required
-            when working with SSO. Therefore, to ensure that the SSO
-            capabilities work as expected in this tutorial, you need to
-            configure the `             etc/host            ` file as explained
-            in this step.
-    
-            The `             etc/host            ` file is a read-only file.
-            Therefore, you won't be able to edit it by opening the file via a
-            text editor. To avoid this, edit the file using the terminal
-            commands.  
-            For example, use the following command if you are working on a
-            Mac/Linux environment.
-    
-            ``` java
-            sudo nano /etc/hosts
-            ```
-    
-        ``` bash
-        127.0.0.1  wso2is.local
-        ```
-    
-    2.  Open the `            travelocity.properties           ` file found
-        in the
-        `            is-samples/modules/samples/sso/sso-agent-sample/src/main/resources           `
-        directory of the samples folder you just checked out. Configure the
-        following property with the hostname (
-        `            wso2is.local           ` ) that you configured above.
-    
-        ``` text
-        #The URL of the SAML 2.0 Assertion Consumer
-        SAML2.AssertionConsumerURL=http://wso2is.local:8080/travelocity.com/home.jsp
-        ```
-    
-    3.  In your terminal, navigate to
-        `            is-samples/modules/samples/sso/sso-agent-sample           `
-        folder and build the sample using the following command. You must
-        have Apache Maven installed to do this
-    
-        ``` java
-        mvn clean install
-        ```
-    
-    4.  After successfully building the sample, a
-        `            .war           ` file named **travelocity.com** can be
-        found inside the
-        `            is-samples/sso/sso-agent-sample/           `
-        `            target           ` directory. Deploy this sample web
-        app on a web container. To do this, use the Apache Tomcat server.
-    
-        !!! note
-        
-            Since this sample is written based on Servlet 3.0 it needs to be
-            deployed on [Tomcat 7.x](https://tomcat.apache.org/download-70.cgi)
-            .
-        
-    
-        Use the following steps to deploy the web app in the web container:
-    
-        1.  Stop the Apache Tomcat server if it is already running.
-        2.  Copy the
-            `                           travelocity.com.war                         `
-            file to the `             <TOMCAT_HOME>/webapps            `
-            directory.
-        3.  Start the Apache Tomcat server.
-    
-    !!! tip
-        
-        If you wish to change properties like the issuer ID, consumer URL, and
-        IdP URL, you can edit the **travelocity.properties** file found in the
-        `          travelocity.com/WEB-INF/classes         ` directory. If the
-        service provider is configured in a tenant you can use the
-        `          QueryParams         ` property to send the tenant domain.
-        For  example, `          QueryParams=tenantDomain=wso2.com         ` .
-        
-        This sample uses the following default values.
-        
-        | Properties                                                                                                  | Description                                                         |
-        |-------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-        | `              SAML2.SPEntityId=travelocity.com             `                                               | A unique identifier for this SAML 2.0 Service Provider application. |
-        | `               SAML2.AssertionConsumerURL=http://wso2is.local:8080/travelocity.com/home.jsp              ` | The URL of the SAML 2.0 Assertion Consumer.                         |
-        | `               SAML2.IdPURL=https://localhost:9443/samlsso              `                                  | The URL of the SAML 2.0 Identity Provider.                          |
-        
-        If you edit the
-        `                     travelocity.properties                   ` file,
-        you must restart the Apache Tomcat server for the changes to take
-        effect.
-        
-    
-    Now the web application is successfully deployed on a web container.
+To deploy the travelocity sample application, see 
+[Deploying the Sample App](../../develop/deploying-the-sample-app/).
 
 ------------------------------------------------------------------------
 

--- a/en/docs/learn/configuring-shibboleth-idp-as-a-trusted-identity-provider.md
+++ b/en/docs/learn/configuring-shibboleth-idp-as-a-trusted-identity-provider.md
@@ -406,7 +406,7 @@ To configure the service provider, do the following.
 ### Testing the scenario
 
 1.  [Set up the travelocity web
-    application](../../learn/configuring-single-sign-on#configuring-the-sso-web-application)
+    application](../../develop/deploying-the-sample-app)
     and access it from
     `                     http://wso2is.local:8080/travelocity.com                   `.
     

--- a/en/docs/learn/consent-management-with-single-sign-on.md
+++ b/en/docs/learn/consent-management-with-single-sign-on.md
@@ -90,8 +90,8 @@ authentication.
 !!! tip "Before you begin"
 
     Configure the Travelocity sample app as a service provider in WSO2
-    Identity Server. For more information on how to do this, see the
-    [Configuring Single Sign-On](../../learn/configuring-single-sign-on) tutorial.
+    Identity Server. For more information, see the
+    [Deploying the Sample App](../../develop/deploying-the-sample-app) tutorial.
     
 
 1.  Configure the following service provider claims.

--- a/en/docs/learn/log-in-to-the-identity-server-using-another-identity-server-saml2.md
+++ b/en/docs/learn/log-in-to-the-identity-server-using-another-identity-server-saml2.md
@@ -112,63 +112,70 @@ in the secondary IS instance.
 ### Setting up an application as the SP in the primary IS
 
 The client application in this scenario is the travelocity sample
-application that can be checked out from the following GitHub repo. See
-[Downloading a
-Sample](../../learn/downloading-a-sample) topic
-for more information.
+application.
 
-``` java
-https://github.com/wso2/product-is/tree/master/modules/samples/sso
-```
-
-1.  The client application must be set up as a service provider in the
-    primary Identity Server instance and this can be done by following
-    the instructions given in the [Configuring Single
-    Sign-On](../../learn/configuring-single-sign-on)
-    topic.
+1.  [Deploy travelocity application](develop/deploying-the-sample-app/) and 
+    [configure as a service provider](develop/deploying-the-sample-app/) in the
+    primary Identity Server instance. 
+ 
 2.  After adding the client application as a service provider in the
     primary Identity Server instance, navigate to the **Main** menu and
     click **List** under **Service Providers**. Click **Edit** next to
     the service provider you created.
+    
 3.  Expand the **Local & Outbound Authentication Configuration**
     section. Here we set the travelocity client to use the primary IS
     instance and the identity provider named 'Secondary' also as its
     identity provider. For this we have to add authentication steps.  
-    ![add-authentication-steps](../assets/img/using-wso2-identity-server/add-authentication-steps.png)   
+    
+    ![add-authentication-steps](../assets/img/using-wso2-identity-server/add-authentication-steps.png)  
+     
     1.  Click **Advanced Configuration** and from next UI, click
         **Add Authentication Step**.
+        
     2.  Under **Local Authenticators** add the “ **basic** ”
         authenticator by selecting it from the combo box and clicking
         **Add Authenticator**.
+        
     3.  Under **Federated Authenticators** select “Secondary” and add
         it.
+        
     4.  Click **Update** to save your changes.
+    
 4.  Click **Update** to save changes to your service provider
     configurations. Now when you log in to the client application it
     can select either the primary IS instance or secondary IS instance
     as the identity provider and therefore has access to both user
     spaces.
+    
 5.  Go to <https://localhost:9443/carbon>, the primary IS instance, and
     create a user named 'primaryuser' and set the password as
     'primepass'.
+    
 6.  Go to <https://localhost:9444/carbon>, the secondary IS instance
     and create a user named 'secondaryuser' and set the password as
     'secondpass'.
+    
 7.  Test your application.
     1.  After copying the "travelocity.war" file to the
         `            <TOMCAT_HOME>/webapps           ` directory, run
         the Tomcat server.
+    
     2.  Go to
         [http://wso2is.local:8080/travelocity.com](http://localhost:8080/travelocity.com)
         . This is the client application.  
+        
         ![client-application](../assets/img/using-wso2-identity-server/client-application.png) 
+    
     3.  Since we are using SAML for authentication, click the link in
         the first line.
+    
     4.  In the resulting screen, log in with the username 'primaryuser'
         and the password 'primepass' for authentication as a local user
         in the primary IS instance.  
           
         ![sign-into-travelocity](../assets/img/using-wso2-identity-server/sign-into-travelocity.png)   
+        
         If you wish to authenticate a user in the secondary IS instance
         which is the secondary IdP, click “Secondary” under **Other
         login options**. In the resulting screen, log in using the

--- a/en/docs/learn/logging-in-to-your-application-via-identity-server-using-facebook-credentials.md
+++ b/en/docs/learn/logging-in-to-your-application-via-identity-server-using-facebook-credentials.md
@@ -25,7 +25,7 @@ and the Identity Server to integrate using a sample app. See the
 following sections for more information.
 
 
-### Configuring the Facebook app
+## Configuring the Facebook app
 
 1.  Go to <https://developers.facebook.com/> and log in using your
     Facebook credentials.
@@ -115,96 +115,19 @@ Now you have finished configuring Facebook as an Identity Provider.
 
 	![submit-fb-app-for-review](../assets/img/tutorials/submit-fb-app-for-review.png)
 
-### Deploying travelocity.com sample app
+## Deploying travelocity sample application
 
-The next step is to deploy the `         travelocity.com        ` sample
+The next step is to configure the `         travelocity.com        ` sample
 app in order to use it in this scenario.
 
-!!! tip "Before you begin!"
-    If you haven't downloaded the samples, refer
-    [this](../../learn/downloading-a-sample)
-    document to download the `         travelocity.com        ` sample
-    application.  
-    Once the samples are downloaded, you can find the
-    `         travelocity.com        ` sample in the
-    `         <IS_SAMPLES>/modules/samples/sso/sso-agent-sample/target        `
-    directory.
-    
 
-1.  Open a terminal window and add the following entry to the
-    `           /etc/hosts          ` file of your machine to configure
-    the hostname.
-
-    ``` bash
-    127.0.0.1   wso2is.local
-    ```
-
-    !!!info "Why is this step needed?"
-		Some browsers do not allow you to create cookies for a naked
-		hostname, such as `            localhost           `. Cookies are
-		required when working with SSO . Therefore, to ensure that the SSO
-		capabilities work as expected in this tutorial, you need to
-		configure the `            etc/host           ` file as explained in
-		this step.
-
-		The `            etc/host           ` file is a read-only file.
-		Therefore, you won't be able to edit it by opening the file via a
-		text editor. Instead, edit the file using the terminal commands.  
-		For example, use the following command if you are working on a
-		Mac/Linux environment.
-
-		``` java
-		sudo nano /etc/hosts
-		```
-
-2.  Deploy this sample web app on a web container.
-    1.  Use the Apache Tomcat server to do this.
-    2.  Since this sample is written based on Servlet 3.0, it needs to
-        be deployed on Tomcat 7.x.
-    3.  Copy the .war file into the webapps folder. For example,
-        `             <APACHE_HOME>/apache-tomcat-7.0.50/webapps            `
-        .
-
-    4.  Start the tomcat server.
-
-3.  Open the `           travelocity.properties          ` file found
-    in the
-    `           <APACHE_HOME>/webapps/travelocity.com/WEB-INF/classes          `
-    directory and configure the following property with the hostname (
-    `           wso2is.local          ` ) that you configured above.
-    Finally restart the tomcat server.
-
-    ``` text
-        #The URL of the SAML 2.0 Assertion Consumer
-        SAML2.AssertionConsumerURL=http://wso2is.local:8080/travelocity.com/home.jsp
-    ```
-
-!!! tip
-    
-    If you wish to change properties like the issuer ID, consumer
-    URL, and IdP URL, you can edit the **travelocity.properties** file found
-    in the `         travelocity.com/WEB-INF/classes        ` directory.
-    Also if the service provider is configured in a tenant you can use
-    "QueryParams" property to send the tenant domain. As an example
-    "QueryParams=tenantDomain=wso2.com".
-    
-    This sample uses the following default values.
-    
-    | Properties                                                                                                                                                                          | Description                                                        |
-    |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-    | `             SAML2.SPEntityId=travelocity.com                         `                                                                                                            | A unique identifier for this SAML 2.0 Service Provider application |
-    | `              SAML2.AssertionConsumerURL=                                             http://wso2is.local:8080/travelocity.com/home.jsp                                          ` | The URL of the SAML 2.0 Assertion Consumer                         |
-    | `              SAML2.IdPURL=                                             https://localhost:9443/samlsso                                          `                                  | The URL of the SAML 2.0 Identity Provider                          |
-    | `             SAML2.IsPassiveAuthn=true                         `                                                                                                                   | Set this to send SAML2 passive authentication requests             |
-    
-    If you edit the **travelocity.properties** file, you must restart the
-    Apache Tomcat server for the changes to take effect.
-    
+Refer to [Deploying the Sample App](../../develop/deploying-the-sample-app/) for the 
+instruction on deploying and configuring travelocity sample application.
 
 Once this is done, the next step is to configure the WSO2 Identity
 Server by adding a service provider and identity provider.
 
-### Configuring the identity provider
+## Configuring the identity provider
 
 Follow the steps given below to [add a new identity
 provider](../../learn/adding-and-configuring-an-identity-provider)
@@ -290,7 +213,7 @@ in WSO2 Identity Server.
 
 You have now added the identity provider.
 
-### Configuring the service provider
+## Configuring the service provider
 
 The next step is to [configure the service
 provider.](../../learn/adding-and-configuring-a-service-provider)
@@ -349,7 +272,7 @@ You have now added and configured the service provider.
 
 	For more information on SSO, see [Single Sign-On](../../learn/single-sign-on).
 
-### Configuring claim mappings for Facebook (optional)
+## Configuring claim mappings for Facebook (optional)
 
 All the basic information of a user/application is stored in the form of
 claims. But for the same information, different Identity Providers(IDP)
@@ -404,7 +327,7 @@ them with Facebook.
     this through **User ID Claim URI** (e.g., email).
 9.  Click **Update** to save changes.
 
-### Configuring requested claims for travelocity.com (optional)
+## Configuring requested claims for travelocity.com (optional)
 
 Generally, the service providers need some information from the Identity
 Provider side after the authentication process in order to provide their
@@ -446,7 +369,7 @@ For that follow the below steps:
 
 Now you have configured the Identity Server.
 
-### Testing the sample
+## Testing the sample
 
 1.  To test the sample, go to the following URL:
     `                     http://wso2is.local:8080/travelocity.com                   `.  

--- a/en/docs/learn/querying-saml-assertions.md
+++ b/en/docs/learn/querying-saml-assertions.md
@@ -61,11 +61,11 @@ authority.
 !!! tip "What's Next?"   
     To query the assertion, you can do one of the following:
     
-    -   Follow the steps under the [Try out
-        scenario](#try-out-scenario) section to try out
+    -   Follow the steps in [Try out
+        scenario](#try-out-scenario) section to try
         an AssertionID request with the travelocity sample application
         **OR**
-    -   Follow the steps under the [Querying an
+    -   Follow the steps in [Querying an
         assertion](#querying-an-assertion) section for
         instructions on querying an assertion with your own application.
     
@@ -120,15 +120,19 @@ AssertionID for the travelocity sample application.
 1.  Follow the steps in the [Configuring WSO2 Identity
     Server](#configuring-wso2-identity-server) section to configure
     the WSO2 Identity Server.
-2.  [Set up the travelocity sample application and configure the service
-    provider.](../../learn/configuring-single-sign-on#configure-the-sso-web-application)  
+2.  [Set up the travelocity sample application](../../develop/deploying-the-sample-app/) and [configure the service
+    provider](../../develop/deploying-the-sample-app/).  
+    
     1.  Expand the **SAML2 Web SSO Configuration** and click
         **Configure**.
+    
     2.  Configure the required fields. Select
         `            soa.cert           ` as the **Certificate Alias**
         and tick the **Enable Assertion Query Request Profile**
         checkbox.  
+    
         ![enable-assertion-query-request](../assets/img/tutorials/enable-assertion-query-request.png)
+        
 3.  Click **Update**.
 4.  You have to use a custom assertion builder with the capability to
     persist assertions to the database for this profile.  

--- a/en/docs/learn/setting-up-a-saml2-bearer-assertion-profile-for-oauth-2.0.md
+++ b/en/docs/learn/setting-up-a-saml2-bearer-assertion-profile-for-oauth-2.0.md
@@ -41,7 +41,7 @@ Server and as well as the Resource Server.
 
 2.  Configure single sign-on with the Travelocity sample.
 
-    See [Configuring Single Sign-On](../../learn/configuring-single-sign-on) to
+    See [Deploying the Sample App](../../develop/deploying-the-sample-app) to
     configure Travelocity application with WSO2 Identity Server.
 
 3.  Navigate to **Main\>Service Providers\>List** and click **Edit** to

--- a/en/docs/setup/configuring-a-sp-and-idp-using-configuration-files.md
+++ b/en/docs/setup/configuring-a-sp-and-idp-using-configuration-files.md
@@ -435,62 +435,9 @@ provider in the **`          service provider IS         `**.
 
 Do the following steps to run the travelocity application.
 
-1.  Check out the single sign on sample from the following GitHub
-    repository. See the [Downloading a Sample](../../learn/downloading-a-sample)
-    topic for more information.
+1.  [Deploy the travelocity](../../develop/deploying-the-sample-app/) application. 
 
-    ``` java
-    https://github.com/wso2/product-is/tree/master/modules/samples/sso
-    ```
-
-2.  Remove the parent entry in the **pom.xml** file that comes along
-    with the sample. Once you are done with this step, the contents of
-    the **pom.xml** file will look similar to the following.
-
-    ``` xml
-        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-            <groupId>org.wso2.is</groupId>
-            <version>5.5.0</version> 
-            <modelVersion>4.0.0</modelVersion>
-            <artifactId>wso2is-identity-samples</artifactId>
-            <packaging>pom</packaging>
-            <name>Identity Server : SSO Samples</name>
-            <modules>
-                <module>SSOAgentSample</module>
-            </modules>
-        </project>
-    ```
-
-3.  In your command line, navigate to
-    `           <SAMPLE_HOME>/sso/          ` in the folder you checked
-    out and build the sample using the following command. You must have
-    Apache Maven installed to do this (see [Installation
-    Prerequisites](_Installation_Prerequisites_) for the appropriate
-    version to use).
-
-    ``` java
-        mvn clean install
-    ```
-
-4.  After successfully building the sample, a .war file named
-    **travelocity.com** can be found inside the
-    `           <SAMPLE_HOME>/sso/sso-agent-sample/target` folder. Deploy this sample web app on
-    a web container. To do this, use the Apache Tomcat server.
-
-    !!! note
-    
-        **Note** : Since this sample is written based on Servlet 3.0 it
-        needs to be deployed on Tomcat 7.x.
-    
-
-    Use the following steps to deploy the web app in the web container:
-
-    1.  Stop the Apache Tomcat server if it is already running.
-    2.  Copy the **travelocity.war** file to the
-        `            <TOMCAT_HOME>/webapps           ` folder.
-    3.  Start the Apache Tomcat server.
-
-5.  When you access the following link to the travelocity application,
+2.  When you access the following link to the travelocity application,
     you are directed to the identity provider for authentication:
     `          http://wso2is.local:8080/travelocity.com/index.jsp         `
 
@@ -639,13 +586,11 @@ scenario.
         OpenId.EnableDumbMode=false
         ```
 
-3.  In the travelocity.properties file, locate and uncomment the
-    following value. Replace the tenant domain (
-    `           tenant.domain          ` ) with your newly created
-    tenant domain.
+3.  In the `travelocity.properties` file update `tenantDomain` query param with the 
+    newly created tenant domain.
 
     ``` java
-    #QueryParams=tenantDomain=tenant.domain
+    QueryParams=tenantDomain=tenant.domain
     ```
 
     !!! tip


### PR DESCRIPTION
## Purpose
In most of the docs where the travelocity is used as a tutorial, same set of instructions are given.  In PR [1], all the common configurations are moved to single documentation. This PR links the newly created document.

[1] - https://github.com/wso2/docs-is/pull/793

## TODO
After merging PR, all the changed documents needs to be edited so those documents allign with the content in PR [1].

[1] - https://github.com/wso2/docs-is/pull/793