### PR TITLE
Change sample values

### DIFF
--- a/en/docs/develop/customizing-the-authentication-endpoint.md
+++ b/en/docs/develop/customizing-the-authentication-endpoint.md
@@ -354,8 +354,8 @@ below steps:
             - Relying party for Oauth2 = OAuth Client Key  
 
         - Following are two sample values for Name and value:
-            - Name : wso2.mydashboard
-            - Value : https://localhost:9443/dashboard/index.jag         
+            - Name : USER_PORTAL
+            - Value : https://localhost:9443/user-portal/overview        
 
         - If you are using travelocity as the sample app, you can use the below values:
             - Name : travelocity.com


### PR DESCRIPTION
Git issue - https://github.com/wso2/product-is/issues/7293

In this issue what happen is when it gets redirect url it gets the url using `resource.getProperty(relyingParty)`
and what we are doing is we configure redirect url in registry against the relyingParty name 

in 5.7.0 its like 

- Name : wso2.mydashboard
- Value : https://localhost:9443/dashboard/index.jag

since now we are moving to USER_PORTAL in 5.10.0 it should change to 

- Name : USER_PORTAL
- Value : https://localhost:9443/user-portal/overview 
