### PR TITLE
Removing SCIM 1.1 APIs from main page

### DIFF
--- a/en/docs/develop/using-apis.md
+++ b/en/docs/develop/using-apis.md
@@ -5,6 +5,5 @@ The following sections list out key APIs relevant for Developers:
 -	[Calling Admin Services](../../develop/calling-admin-services)
 -	[REST APIs](../../develop/rest-apis)
 -	[SOAP APIs](../../develop/soap-apis) 
--	[SCIM 1.1 APIs](../../develop/scim-1.1-apis)
 -	[Managing Tenants with APIs](../../develop/managing-tenants-with-apis)
 -	[Entitlement with APIs](../../develop/entitlement-with-apis/) 


### PR DESCRIPTION
## Purpose
> fix https://github.com/wso2/docs-is/issues/1152