### PR TITLE
Update quick-start-guide.md

### DIFF
--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -319,13 +319,12 @@ Let's use the command-line to check the MFA functionality.
 First deploy the sample authenticator dependency and web application in
     WSO2 Identity Server.
 
-1.  Download the [sample-auth.war](https://github.com/wso2/samples-is/releases/download/v4.2.0/sample-auth.war) file and paste it inside the `             <IS_HOME>/repository/deployment/server/webapps            `
-        folder.  
-        This `             .war            ` file contains the WEB UI
-        for the sample authenticators used in this tutorial.
+1.  Download the [sample-auth.war](https://github.com/wso2/samples-is/releases/download/v4.2.0/sample-auth.war) file and paste it inside the `<IS_HOME>/repository/deployment/server/webapps` folder.  
 
-2.     Add the followings to the `deployment.tom`l file in the
-       `<IS_HOME>/repository/conf` directory and restart the server.
+    This `.war` file contains the WEB UI for the sample authenticators used in this tutorial.
+
+2.     Add the following configurations to the `deployment.tom`l file in the `<IS_HOME>/repository/conf` directory and restart the server.
+
        ```toml
        [[resource.access_control]]
        context = "(.*)/sample-auth/(.*)"

--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -319,15 +319,12 @@ Let's use the command-line to check the MFA functionality.
 First deploy the sample authenticator dependency and web application in
     WSO2 Identity Server.
 
-   1.  Download the [org.wso2.carbon.identity.sample.extension.authenticators-5.9.0.jar](../../assets/attachments/org.wso2.carbon.identity.sample.extension.authenticators-5.9.0.jar) file and paste inside the
-        `              <IS_HOME>/repository/components/dropins             ` directory.
-
-   2.  Download the [sample-auth.war](https://github.com/wso2/samples-is/releases/download/v4.2.0/sample-auth.war) file and paste it inside the `             <IS_HOME>/repository/deployment/server/webapps            `
+1.  Download the [sample-auth.war](https://github.com/wso2/samples-is/releases/download/v4.2.0/sample-auth.war) file and paste it inside the `             <IS_HOME>/repository/deployment/server/webapps            `
         folder.  
         This `             .war            ` file contains the WEB UI
         for the sample authenticators used in this tutorial.
 
-3.     Add the followings to the `deployment.tom`l file in the
+2.     Add the followings to the `deployment.tom`l file in the
        `<IS_HOME>/repository/conf` directory and restart the server.
        ```toml
        [[resource.access_control]]


### PR DESCRIPTION
This PR removes the step that instructs the user to download the org.wso2.carbon.identity.sample.extension.authenticators jar file as it is available by default in the <IS_HOME/repository/components/dropins folder from 5.10.0 onwards.
