### PR TITLE
Change name of the page Running an STS Client.

### DIFF
--- a/en/docs/learn/configuring-ws-trust-security-token-service.md
+++ b/en/docs/learn/configuring-ws-trust-security-token-service.md
@@ -177,7 +177,7 @@ Confirmation](../../learn/configuring-sts-for-obtaining-tokens-with-holder-of-ke
 
     !!! info "Related Topics"
 		Run the STS client after configuring the service provider. For
-		instructions on trying out a sample STS client, see [Running an STS
-		Client](../../learn/running-an-sts-client).
+		instructions on trying out a sample STS client, see [Running the STS
+		Client](../../learn/running-the-sts-client).
 
   

--- a/en/docs/learn/running-the-sts-client.md
+++ b/en/docs/learn/running-the-sts-client.md
@@ -1,4 +1,4 @@
-# Running an STS Client
+# Running the STS Client
 
 The following sample demonstrates the steps required to run a Security
 Token Service (STS) client. The STS provides the service of issuing a
@@ -11,7 +11,7 @@ The WS-Trust STS needs to be configured. You can do this by following
 the instructions found
 [here](../../learn/configuring-ws-trust-security-token-service).
 
-### Running the STS client
+### Setting up and running the client
 
 1.  The code for the sample can be checked out from the GitHub
     repository. To do this, follow the instructions on the [Downloading

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -471,7 +471,7 @@ nav:
           - 'Decrypting OpenID Connect Encrypted ID Tokens': learn/decrypting-openid-connect-encrypted-id-tokens.md
         - 'Writing a Web Service Client for Authentication and User Admin Services': learn/writing-a-web-service-client-for-authentication-and-user-admin-services.md
         - 'Consuming SCIM Rest Endpoints from a JAVA Client Application': learn/consuming-scim-rest-endpoints-from-a-java-client-application.md
-        - 'Running an STS Client': learn/running-an-sts-client.md
+        - 'Running the STS Client': learn/running-the-sts-client.md
         - 'XACML Sample for an Online Trading Application': learn/xacml-sample-for-an-online-trading-application.md
         - 'Log in to the Identity Server using another Identity Server - SAML2': learn/log-in-to-the-identity-server-using-another-identity-server-saml2.md
         - 'Login to Identity Server using another Identity Server - OAuth2': learn/login-to-identity-server-using-another-identity-server-oauth2.md    


### PR DESCRIPTION
- Change the name of the page Running an STS Client to Running the STS Client.

Fixes: https://github.com/wso2/docs-is/issues/1109