### PR TITLE
Add requirements.txt to hold pip dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,68 @@ End-user apps in WSO2 Identity Server
 | :------------ |:------------- 
 | master      | [![Build Status](https://wso2.org/jenkins/view/Dashboard/job/docs/job/docs-is/badge/icon)](https://wso2.org/jenkins/view/Dashboard/job/docs/job/docs-is/) |
 
-## Prerequisite
+## Prerequisites
 
-To run the project on local, it requires [python](https://www.python.org/downloads/) & [mkdocs](https://www.mkdocs.org/)
+To run the project locally, it requires [python](https://www.python.org/downloads/) & [pip](https://pypi.org/project/pip/).
+
+### Install Python
+
+Check if you already has Python installed by running the following command.
+
+```bash
+$ python --version
+Python 2.7.10
+```
+
+If you see something like above, then `Python 2.7.10` is your default version.
+You should also see if you have Python 3 installed. 
+
+```bash
+$ python3 --version
+Python 3.8.0
+```
+
+If you don't seem to have `Python` installed, grab the latest release from the [official downloads page](https://www.python.org/downloads/).
+
+### Install pip
+
+pip is already installed if you are using Python 2 >=2.7.9 or Python 3 >=3.4 downloaded from [python.org](https://www.python.org/) or if you are working in a [Virtual Environment](https://packaging.python.org/tutorials/installing-packages/#creating-and-using-virtual-environments) created by [virtualenv](https://packaging.python.org/key_projects/#virtualenv) or [pyvenv](https://packaging.python.org/key_projects/#venv). Just make sure to [upgrade pip](https://pip.pypa.io/en/stable/installing/#upgrading-pip).
+
+#### Installing with get-pip.py
+
+To install pip with `curl`, execute the following command. Alternatively you can download `get-pip.py` by clicking [here](https://bootstrap.pypa.io/get-pip.py). 
+
+```bash
+$ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+```
+
+Then run the following command in the folder where you have downloaded get-pip.py
+
+```bash
+$ python get-pip.py
+```
 
 ## Run project locally (Dev Mode)
 
-1. Clone repo
-2. Run `mkdocs serve` command in `<Lang folder>`. E.g. `cd en && mkdocs serve`
+**Clone the repo**
+
+```bash
+$ git clone https://github.com/wso2/docs-is.git
+```
+
+**Install the dependencies**
+
+```bash
+$ cd docs-is && pip install -r requirements.txt
+```
+
+**Run mkdocs**
+
+Execute the following command from inside the `<Lang folder>`.
+
+```bash
+$ cd en && mkdocs serve
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ To run the project locally, it requires [python](https://www.python.org/download
 
 ### Install Python
 
-Check if you already has Python installed by running the following command.
+Check if you already have Python installed by running the following command.
 
 ```bash
 $ python --version
 Python 2.7.10
 ```
 
-If you see something like above, then `Python 2.7.10` is your default version.
-You should also see if you have Python 3 installed. 
+If you receive a response similar to the one shown above, `Python 2.7.10` is your default version.
+
+You should also check if you have Python 3 installed. 
 
 ```bash
 $ python3 --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs>=1.1
+mkdocs-material>=4.6.3
+markdown-include>=0.5.1
+pymdown-extensions>=6.3


### PR DESCRIPTION
## Purpose
[REAME.md](https://github.com/wso2/docs-is/tree/master) only specifies `python` and `mkdocs` as perquisites for setting up the repo in local environment. But when trying to run the project, `mkdocs` starts complaining about the following missing packages.

1. `pymdownx.emoji`
2. `mkdocs-material`
3. `markdown-include`

There should be a better way to get these dependencies installed.

## Goals
This PR introduces a `requirements.txt` which could contain the list of `pip` dependencies required to run the project in dev environments.

Resolves #1606 
