### PR TITLE
Change wso2.is.com to wso2.is

### DIFF
--- a/en/docs/setup/deployment-guide.md
+++ b/en/docs/setup/deployment-guide.md
@@ -419,7 +419,7 @@ Identity Server endpoints. The `hostName` should be resolved to the Load Balance
 
     ```
     [server]
-    hostname = "wso2.is.com"
+    hostname = "wso2.is"
     ```
 
     !!! note 
@@ -427,7 +427,7 @@ Identity Server endpoints. The `hostName` should be resolved to the Load Balance
         the `/etc/hosts` file in each node so that internal calls will not be routed through the Load Balancer.
         
         Example: 
-        `192.168.2.1   wso2.is.com`
+        `192.168.2.1   wso2.is`
 
 ## Enabling artifact synchronization
 
@@ -469,7 +469,7 @@ You can use any load balancer that is available to your system.
 ## Running the cluster
 
 1. Start the load balancer and WSO2 Identity Server nodes.
-2. Access the management console at `https://wso2.is.com/carbon/`. 
+2. Access the management console at `https://wso2.is/carbon/`. 
     Traffic will be served by one of the nodes in the cluster, depending on your load balancer.
 3. Shut down the cluster node 1 and observe that the traffic is served by node 2. 
 3. Start node 1 and shut down node 2. Note that traffic will be served by node 1.


### PR DESCRIPTION
## Background
wso2.is.com is an acquired domain name at the moment. Someone who is following the exact instructions of the documentation might get confused with the redirect to https://www.xant.ai/ from https://wso2.is.com

## Purpose
This PR changes https://wso2.is.com to https://wso2.is
