### PR TITLE
update for '5.9.0 what has changed' page

### DIFF
--- a/en/docs/setup/migrating-what-has-changed.md
+++ b/en/docs/setup/migrating-what-has-changed.md
@@ -189,3 +189,6 @@ Scope validation has been enforced for authorization code grant and implicit gra
     [oauth]
     scope_validator.authz_implicit.enable = false
     ```
+
+## Multi factor Authentication using FIDO
+From IS 5.9.0 onwards, WebAuthn API is being used instead of U2F API. If you have used FIDO previously, your devices must be re-enrolled.


### PR DESCRIPTION
Similar note was added in the previous versions (before 5.9.0) so I thought it would be better to mention it again in 5.9.0 changes, which will be included by default in 5.10.0 [in this section](https://is.docs.wso2.com/en/5.10.0/setup/migrating-what-has-changed/) where it says **If you are migrating from an older version of Identity Server** and also the future versions as long as the same structure will be followed.