### PR TITLE
Fix script for PROMPT in adaptive-authentication-js-api-reference doc

### DIFF
--- a/en/docs/references/adaptive-authentication-js-api-reference.md
+++ b/en/docs/references/adaptive-authentication-js-api-reference.md
@@ -425,7 +425,7 @@ var onLoginRequest = function(context) {
    executeStep(1, {
        onSuccess: function (context) {
            var username = context.steps[1].subject.username;
-           prompt("genericForm", {"username":username, "inputs":[{"id":fname,"label":"First Name"},{"id":lname,"label":"Last Name"}]}, {
+           prompt("genericForm", {"username":username, "inputs":[{"id":"fname","label":"First Name"},{"id":"lname","label":"Last Name"}]}, {
              onSuccess : function(context) {
                 var fname = context.request.params.fname[0];
                 var lname = context.request.params.lname[0];


### PR DESCRIPTION
## Purpose
> Resolves #1911 

## Goals
> Fix issue of id names not getting applied for the genericForm prompt in Adaptive authentication that causes the authentication process to fail

## Approach
> Surrounding the IDs "fname" and "lname" with quotation marks in the script for PROMPT in adaptive-authentication-js-api-reference.md

## Documentation
> https://is.docs.wso2.com/en/latest/references/adaptive-authentication-js-api-reference/#prompttemplateid-data-eventhandlers
