### PR TITLE
Remove link to cross-site-scripting attacks

### DIFF
--- a/en/docs/administer/product-level-security-guidelines.md
+++ b/en/docs/administer/product-level-security-guidelines.md
@@ -192,8 +192,6 @@ To enable hostname verification:
 
 By default, XSS attacks are prevented in the latest WSO2 Identity Server versions. This is due to output encoding of the displaying values. 
 
-If additional protection is required, an input validation valve can be configured. For instructions, see <a href="../../administer/mitigating-cross-site-scripting-attacks">Mitigating Cross Site Scripting Attacks</a>.
-
 
 ## JSESSIONID length
 


### PR DESCRIPTION
- Removing link to mitigating-cross-site-scripting-attacks as that doc is no longer available in the docs (XSS valve is embedded into WSO2 products in latest versions therefore this doc is no longer needed)