### PR TITLE
Remove scim2 claim adding instructions

### DIFF
--- a/en/docs/learn/forced-password-reset.md
+++ b/en/docs/learn/forced-password-reset.md
@@ -163,39 +163,29 @@ template for this option can be configured in the
 
 ### Using SCIM 2.0 API
 
-1. Login to the Management Console.
-2. Add a new external claim by following `main` -> `Claims` -> `Add` ->
-   `Add External Claim`.
-3. Use following values and add.
+Use following SCIM 2.0 Request to trigger a password reset.
     
-	| Field              | Value                                                                       |
-    |--------------------|-----------------------------------------------------------------------------|
-    | Dialect URI*       |urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:forcePasswordReset|
-    |External Claim URI* |forcePasswordReset                                                           | 
-    |Mapped Local Claim* |http://wso2.org/claims/identity/adminForcedPasswordReset                     |
-    
-4. Use following SCIM 2.0 Request to trigger a password reset
-    
-    You need to set the **forcePasswordReset** attribute under the`
-    urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema as
-    true in the SCIM2 user create request. 
-    ```java
-    POST https://<host>:<port>/scim2/Users/<users-scim-id>
+You need to set the **forcePasswordReset** attribute under the 
+`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema as
+true in the SCIM2 user create request. 
 
-        {"schemas": 
-        ["urn:ietf:params:scim:api:messages:2.0:PatchOp","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
-         "Operations": [
-            {"op": "add",
-            "value": {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"forcePasswordReset": true}
-        }}]
-        }
+```java
+POST https://<host>:<port>/scim2/Users/<users-scim-id>
+
+    {"schemas": 
+    ["urn:ietf:params:scim:api:messages:2.0:PatchOp","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
+     "Operations": [
+        {"op": "add",
+        "value": {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"forcePasswordReset": true}
+    }}]
+    }
+```
+
+!!! Example "A sample curl commands is given below:" 
+
+    ``` java 
+    curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"], "Operations": [ {"op": "add","value": {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"forcePasswordReset": true}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/c02857fd-2a51-427f-bf25-a9f76b85659d
     ```
-    
-    !!! Example "A sample curl commands is given below:" 
-    
-        ``` java 
-        curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"], "Operations": [ {"op": "add","value": {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"forcePasswordReset": true}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/c02857fd-2a51-427f-bf25-a9f76b85659d
-        ```
 
 ### Using SOAP Based admin services
 

--- a/en/docs/learn/forced-password-reset.md
+++ b/en/docs/learn/forced-password-reset.md
@@ -163,11 +163,10 @@ template for this option can be configured in the
 
 ### Using SCIM 2.0 API
 
-Use following SCIM 2.0 Request to trigger a password reset.
+Use the following SCIM 2.0 request to trigger a password reset.
     
-You need to set the **forcePasswordReset** attribute under the 
-`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema as
-true in the SCIM2 user create request. 
+Set the **forcePasswordReset** attribute under the `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema as
+**true** in the SCIM2 user create request. 
 
 ```java
 POST https://<host>:<port>/scim2/Users/<users-scim-id>
@@ -181,7 +180,7 @@ POST https://<host>:<port>/scim2/Users/<users-scim-id>
     }
 ```
 
-!!! Example "A sample curl commands is given below:" 
+!!! Example "A sample curl command is given below:" 
 
     ``` java 
     curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"], "Operations": [ {"op": "add","value": {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"forcePasswordReset": true}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/c02857fd-2a51-427f-bf25-a9f76b85659d


### PR DESCRIPTION
With the fix for wso2/product-is#10020 the needed scim claim will be available by default. Therefore no need for these instructions