### PR TITLE
Add documentation related to account locking for OTP based failed attempts

### DIFF
--- a/en/docs/learn/account-locking-by-failed-login-attempts.md
+++ b/en/docs/learn/account-locking-by-failed-login-attempts.md
@@ -327,3 +327,61 @@ Following are the sample email templates.
        </table>]]>
     ```
     - Footer : ---
+    
+### Configuring WSO2 IS for Failed OTP attempts based account locking
+
+WSO2 Identity Server can be configured to lock a user account when the number of consecutive failed OTP attempts exceeded. 
+First, you need to configure the WSO2 Identity Server for user account locking and disabling according to 
+[Configuring WSO2 IS for account locking](../../learn/account-locking-by-failed-login-attempts/#configuring-wso2-is-for-account-locking).
+
+1. Add following configurations into `<IS_HOME>/repository/conf/deployment.toml` file to enable account locking for 
+each type of OTP attempts.
+
+    - For Email OTP:
+    ```
+    [authentication.authenticator.email_otp.parameters]
+    EnableAccountLockingForFailedAttempts = true
+    ```
+    
+    - For SMS OTP:
+    ```
+    [authentication.authenticator.sms_otp.parameters]
+    EnableAccountLockingForFailedAttempts = true
+    ```
+   
+        !!! note
+            Since `BackupCode = true` in the default configuration, configure the backup code claim according to 
+            [Configuring Backup Codes for SMSOTP](../../learn/configuring-sms-otp/#configuring-backup-codes-for-smsotp). 
+            Otherwise, disable the backup codes for SMS OTP.
+            ```
+            [authentication.authenticator.sms_otp.parameters]
+            BackupCode = false
+            ```
+   
+    - For TOTP:
+    ```
+    [authentication.authenticator.totp.parameters]
+    EnableAccountLockingForFailedAttempts = true
+    ```
+   
+2. Navigate to **Main menu > Identity > Claims > Add > Add Local Claim**.
+3. Click **http://wso2.org/claims**.
+
+4. Once the user account get locked **Account Locked** attribute will be updated as **true**.
+In order to check it via user profile,
+    1. Click **Edit** in **Account Locked**.
+    2. Select **Support by Default** and click **Update**.
+  
+5. **Failed Email OTP Attempts**, **Failed SMS Attempts**, and **Failed TOTP Attempts** attribute values will be incremented 
+for the wrong attempt of Email OTP, SMS OTP, and TOTP attempt respectively. In order to check it via user profile,
+    - For Email OTP:
+        1. Click **Edit** in **Failed Email OTP Attempts**.
+        2. Select **Support by Default** and click **Update**.
+      
+    - For SMS OTP:
+        1. Click **Edit** in **Failed SMS Attempts**.
+        2. Select **Support by Default** and click **Update**.
+      
+    - For TOTP:
+        1. Click **Edit** in **Failed TOTP Attempts**.
+        2. Select **Support by Default** and click **Update**.

--- a/en/docs/learn/account-locking-by-failed-login-attempts.md
+++ b/en/docs/learn/account-locking-by-failed-login-attempts.md
@@ -330,11 +330,11 @@ Following are the sample email templates.
     
 ### Configuring WSO2 IS for Failed OTP attempts based account locking
 
-WSO2 Identity Server can be configured to lock a user account when the number of consecutive failed OTP attempts exceeded. 
+WSO2 Identity Server can be configured to lock a user account when the number of consecutive failed OTP attempts is exceeded. 
 First, you need to configure the WSO2 Identity Server for user account locking and disabling according to 
 [Configuring WSO2 IS for account locking](../../learn/account-locking-by-failed-login-attempts/#configuring-wso2-is-for-account-locking).
 
-1. Add following configurations into `<IS_HOME>/repository/conf/deployment.toml` file to enable account locking for 
+1. Add the following configurations into `<IS_HOME>/repository/conf/deployment.toml` file to enable account locking for 
 each type of OTP attempts.
 
     - For Email OTP:
@@ -352,7 +352,7 @@ each type of OTP attempts.
         !!! note
             Since `BackupCode = true` in the default configuration, configure the backup code claim according to 
             [Configuring Backup Codes for SMSOTP](../../learn/configuring-sms-otp/#configuring-backup-codes-for-smsotp). 
-            Otherwise, disable the backup codes for SMS OTP.
+            Alternatively, you can disable the backup codes for SMS OTP by setting the property to **false**.
             ```
             [authentication.authenticator.sms_otp.parameters]
             BackupCode = false
@@ -364,24 +364,28 @@ each type of OTP attempts.
     EnableAccountLockingForFailedAttempts = true
     ```
    
-2. Navigate to **Main menu > Identity > Claims > Add > Add Local Claim**.
+2. Navigate to **Main > Identity > Claims > Add > Add Local Claim**.
 3. Click **http://wso2.org/claims**.
 
-4. Once the user account get locked **Account Locked** attribute will be updated as **true**.
-In order to check it via user profile,
-    1. Click **Edit** in **Account Locked**.
-    2. Select **Support by Default** and click **Update**.
+4. Once the user account gets locked, the **Account Locked** attribute will be updated to **true**.
+To check this via the user profile:
+    1. Click **Edit** under the **Account Locked** claim.
+    2. Select **Supported by Default** and click **Update**.
+    3. Navigate to the relevant user's user profile and you will see that the attribute has been updated. 
   
 5. **Failed Email OTP Attempts**, **Failed SMS Attempts**, and **Failed TOTP Attempts** attribute values will be incremented 
-for the wrong attempt of Email OTP, SMS OTP, and TOTP attempt respectively. In order to check it via user profile,
+for the wrong attempt of Email OTP, SMS OTP, and TOTP attempt respectively. To check this via the user profile.
     - For Email OTP:
-        1. Click **Edit** in **Failed Email OTP Attempts**.
-        2. Select **Support by Default** and click **Update**.
+        1. Click **Edit** under the **Failed Email OTP Attempts** claim.
+        2. Select **Supported by Default** and click **Update**.
+        3. Navigate to the relevant user's user profile and you will see that the attribute has been updated. 
       
     - For SMS OTP:
-        1. Click **Edit** in **Failed SMS Attempts**.
-        2. Select **Support by Default** and click **Update**.
+        1. Click **Edit** under the **Failed SMS Attempts** claim.
+        2. Select **Supported by Default** and click **Update**.
+        3. Navigate to the relevant user's user profile and you will see that the attribute has been updated. 
       
     - For TOTP:
-        1. Click **Edit** in **Failed TOTP Attempts**.
-        2. Select **Support by Default** and click **Update**.
+        1. Click **Edit** under the **Failed TOTP Attempts** claim.
+        2. Select **Supported by Default** and click **Update**.
+        3. Navigate to the relevant user's user profile and you will see that the attribute has been updated. 


### PR DESCRIPTION
## Purpose
> add documentation related to 
https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/91
https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/79
https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/73

The same document should be added to 5.10.0 docs as well.