### PR TITLE
Provide the link to the list of REST APIs

### DIFF
--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -7,7 +7,7 @@
 <ul>
     <li><b><a href="../../learn/passwordless-authentication-using-fido2">Passwordless authentication support</a></b></li>
     <li><b><a href="../../learn/user-portal">An improved User Portal</a></b></li>
-    <li><b><a href="../../develop/application-rest-api">New RESTful APIs for user self-services and server management</a></b></li>
+    <li><b><a href="../../develop/rest-apis">New RESTful APIs for user self-services and server management</a></b></li>
     <li><b><a href="../../develop/scope-based-authorization-for-internal-rest-apis">Scope based authorization for internal REST APIs</a></b></li>
     <li><b>Introduce a unique user identifier across the system
 </b><br>


### PR DESCRIPTION
## Purpose
> This link for "New RESTful APIs for user self-services and server management" heading to the Application Management Rest API Definition - v1 page only. But there were a list of REST APIs introduced in IS 5.10.0. So at least we should point to the root page
