### PR TITLE
Doc fix forfederated user scope issuance

### DIFF
--- a/en/docs/learn/configuring-local-and-outbound-authentication-for-a-service-provider.md
+++ b/en/docs/learn/configuring-local-and-outbound-authentication-for-a-service-provider.md
@@ -25,6 +25,11 @@ You can configure the following for local and outbound authentication.
     -   **Assert identity using mapped local subject identifier** :
         Select this to use the local subject identifier when asserting
         the identity.
+        
+        !!! note
+            It is mandatory to enable above option to authorise scopes for provisioned 
+            federated users. 
+        
     -   **Always send back the authenticated list of identity
         providers** : Select this to send back the list of identity
         providers that the current user is authenticated by.

--- a/en/docs/learn/configuring-local-and-outbound-authentication-for-a-service-provider.md
+++ b/en/docs/learn/configuring-local-and-outbound-authentication-for-a-service-provider.md
@@ -27,7 +27,7 @@ You can configure the following for local and outbound authentication.
         the identity.
         
         !!! note
-            It is mandatory to enable above option to authorise scopes for provisioned 
+            It is mandatory to enable the above option to authorize scopes for provisioned 
             federated users. 
         
     -   **Always send back the authenticated list of identity


### PR DESCRIPTION
## Purpose
Reflect of fix : https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1511

## Goals
We are mandating scope issuance for federated provisioned users only their identity asserted with the local subject identifier.
