### PR TITLE
Fix symlink for deployment

### DIFF
--- a/en/docs/setup/deployment-guide.md
+++ b/en/docs/setup/deployment-guide.md
@@ -441,14 +441,14 @@ To enable synchronization for runtime artifacts you must have a shared file syst
 Once you have chosen a file system, 
 
 1. Mount it in the nodes that are participating in the cluster.
-2. Create two directories called `Deployment` and `Tenants` in the shared file system.
-3. Create a symlink from the `<IS_HOME>/repository/deployment` path to the `Deployment` directory of the shared 
+2. Create two directories called `Userstores` and `Tenants` in the shared file system.
+3. Create a symlink from the `<IS_HOME>/repository/deployment/userstores` path to the `Userstores` directory of the shared 
 file system that you created in step 2 of this section.
 4. Create a symlink from the `<IS_HOME>/repository/tenants` path to the `Tenants` directory of the shared file 
 system that you created in step 2 of this section.
 
 !!! note
-    Instead of mounting the file system directly to the `<IS_HOME>/repository/deployment` and
+    Instead of mounting the file system directly to the `<IS_HOME>/repository/deployment/userstores` and
      `<IS_HOME>/repository/tenants` paths, a symlink is created to avoid issues that may occur 
      if you delete the product to redeploy it, the file system would get mounted to a non-existing path.
  

--- a/en/docs/setup/deployment-guide.md
+++ b/en/docs/setup/deployment-guide.md
@@ -441,11 +441,8 @@ To enable synchronization for runtime artifacts you must have a shared file syst
 Once you have chosen a file system, 
 
 1. Mount it in the nodes that are participating in the cluster.
-2. Create two directories called `Userstores` and `Tenants` in the shared file system.
-3. Create a symlink from the `<IS_HOME>/repository/deployment/userstores` path to the `Userstores` directory of the shared 
-file system that you created in step 2 of this section.
-4. Create a symlink from the `<IS_HOME>/repository/tenants` path to the `Tenants` directory of the shared file 
-system that you created in step 2 of this section.
+2. If the userstores need to be updated at runtime, create a directory called `Userstores` in the shared file system and create a symlink from the `<IS_HOME>/repository/deployment/userstores` path to the `Userstores` directory. 
+4. If multi-tenancy is required, create a directory called `Tenants` in the shared file system and create a symlink from the `<IS_HOME>/repository/tenants` path to the `Tenants` directory.
 
 !!! note
     Instead of mounting the file system directly to the `<IS_HOME>/repository/deployment/userstores` and


### PR DESCRIPTION
## Purpose
The shared mount must be only for userstores and not for the whole deployment folder. 