### PR TITLE
Fix sample event publisher code for mobile verification on update

### DIFF
--- a/en/docs/develop/enable-verification-for-updated-mobile-number.md
+++ b/en/docs/develop/enable-verification-for-updated-mobile-number.md
@@ -25,7 +25,7 @@ When a user updates their mobile number in the user profile, an SMS OTP is sent 
                 <inline>{"api_key"="4c9374",
                     "api_secret"="FtqyPggE93",
                     "from"="NEXMO",
-                    "to"={{mobile}},
+                    "to"={{send-to}},
                     "text"={{body}}
                     }</inline>
             </mapping>


### PR DESCRIPTION
## Purpose
The sample event publisher code given in the mobile verification documentation should be updated by changing `"to"={{mobile}}` to `"to"={{send-to}}` in order to support sending the SMS OTP to the verification pending mobile number instead of the existing mobile number claim value.
