### PR TITLE
Fix missing caret icon in the left side navbar - attempt 2

### DIFF
--- a/en/theme/material/partials/nav-item.html
+++ b/en/theme/material/partials/nav-item.html
@@ -13,7 +13,7 @@
       <div class="nav__link-text">
         {{ nav_item.title }}
       </div>
-      <img class="nav__link-icon" src="assets/img/icons/landing-page/arrow_down.svg">
+      <img class="nav__link-icon" src="../../../assets/img/icons/landing-page/arrow_down.svg">
     </label>
     <nav class="md-nav" data-md-component="collapsible" data-md-level="{{ level }}">
       <label class="md-nav__title" for="{{ path }}">


### PR DESCRIPTION
## Purpose
This PR fixes the missing caret icon from on-prem docs when deployed in staging

## Approach
Changed the path of the caret icon to match the path in staging
