### PR TITLE
Update response/request format and sample UI

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -1733,16 +1733,11 @@ h5 {
     border-left-color: #465867;
 }
 
-.md-typeset img {
-    border: #dadada solid 1px;
-    padding: 15px;
+.padding-img {
+    padding: 15px !important;
 }
 
-.no-padding-img {
-    padding: 0px !important;
-}
-
-.no-border-img {
-    border: none !important;
+.border-img {
+    border: #dadada solid 1px !important;
 }
 

--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -732,7 +732,7 @@ html .md-footer-meta.md-typeset a,
 
 .md-tabs .md-tabs__link.md-tabs__link--active {
     opacity: 1 !important;
-    color: #fa6400;
+    color: #ff7300;
 }
 
 .md-tabs {
@@ -766,7 +766,7 @@ html .md-footer-meta.md-typeset a,
 }
 
 .md-nav--secondary > ul li.md-nav__item.active {
-    border-color: #fa6400 !important;
+    border-color: #ff7300 !important;
 }
 
 .md-sidebar--secondary .md-nav--secondary > ul ul {
@@ -1268,7 +1268,7 @@ html .md-footer-meta.md-typeset a,
 }
 
 .get-started-btn {
-    background-color: #fa6400 !important;
+    background-color: #ff7300 !important;
     color: #ffffff !important; 
     float: left !important;
     text-align: center;
@@ -1288,14 +1288,14 @@ html .md-footer-meta.md-typeset a,
 
 .get-started-btn:hover {
     background-color:#ffffff !important;
-    border: 1px solid #fa6400;
+    border: 1px solid #ff7300;
     border-radius: 2px;
-    color: #fa6400!important;
+    color: #ff7300!important;
 }
 
 .download-btn {
     background-color: #ffffff !important;
-    color: #fa6400 !important; 
+    color: #ff7300 !important; 
     float: left !important;
     text-align: center;
     padding: 10px 20px 10px 20px;
@@ -1314,9 +1314,9 @@ html .md-footer-meta.md-typeset a,
 
 .download-btn:hover {
     background-color:#ffffff !important;
-    border: 1px solid #fa6400;
+    border: 1px solid #ff7300;
     border-radius: 2px;
-    color: #fa6400!important;
+    color: #ff7300!important;
 }
 
 .iam-secondary-heading {
@@ -1366,7 +1366,7 @@ html .md-footer-meta.md-typeset a,
     font-size: 15px;
     text-decoration: none;
     font-weight: 600;
-    color: #fa6400 !important;
+    color: #ff7300 !important;
     transition: 0.5s;
 }
 
@@ -1425,7 +1425,7 @@ html .md-footer-meta.md-typeset a,
     text-decoration: none;
     vertical-align: bottom;
     transition: 0.5s;
-    color: #fa6400 !important;
+    color: #ff7300 !important;
 }
 
 .learn-more-text:hover {
@@ -1483,7 +1483,7 @@ html .md-footer-meta.md-typeset a,
 
 .md-tabs .md-tabs__item.md-tabs__item--active,
 .md-tabs .md-tabs__item.md-tabs__item:hover {
-    border-bottom: #fa6400 solid 3px;
+    border-bottom: #ff7300 solid 3px;
 }
 
 .scenario-dropdown {
@@ -1568,7 +1568,7 @@ html, body {
 }
 
 .md-nav--secondary > ul li.md-nav__item.active {
-    color: #fa6400;
+    color: #ff7300;
 }
 
 /* Hiding additional arrow in mobile view */
@@ -1716,7 +1716,29 @@ h5 {
 
 /* Customizing superfence tabs */
 .superfences-tabs>input:checked+label {
-    color: #fa6400;
-    border-bottom: 3px solid #fa6400;
+    color: #ff7300;
+    border-bottom: 3px solid #ff7300;
+}
+
+/* custom CSS for code snippets inside admonitions */
+/* .admonition > .codehilite {
+    background-color: #fff !important;
+} */
+
+.admonition > .codehilite > .md-clipboard:before {
+    color: #adadad;
+}
+
+.md-typeset .admonition.abstract {
+    border-left-color: #465867;
+}
+
+.md-typeset img {
+    border: #dadada solid 1px;
+    padding: 15px;
+}
+
+.no-border-padding-img {
+    padding: 0px !important;
 }
 

--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -1738,7 +1738,11 @@ h5 {
     padding: 15px;
 }
 
-.no-border-padding-img {
+.no-padding-img {
     padding: 0px !important;
+}
+
+.no-border-img {
+    border: none !important;
 }
 

--- a/en/docs/deploy/change-the-hostname.md
+++ b/en/docs/deploy/change-the-hostname.md
@@ -118,7 +118,7 @@ This section guides you through changing the hostname of WSO2 Identity Server.
     keytool -import -alias newcert -file pkn.pem -keystore client-truststore.jks -storepass wso2carbon
     ```
 
-    !!! abstract ""
+    !!! info ""
         If you create a new client-trust-store, in-place of the
         default `client-truststore.jks`, place the new trust-store in
         `<IS_HOME>/repository/resources/security/` folder and add following

--- a/en/docs/deploy/change-the-hostname.md
+++ b/en/docs/deploy/change-the-hostname.md
@@ -118,7 +118,7 @@ This section guides you through changing the hostname of WSO2 Identity Server.
     keytool -import -alias newcert -file pkn.pem -keystore client-truststore.jks -storepass wso2carbon
     ```
 
-    !!! info ""
+    !!! info
         If you create a new client-trust-store, in-place of the
         default `client-truststore.jks`, place the new trust-store in
         `<IS_HOME>/repository/resources/security/` folder and add following

--- a/en/docs/fragments/authorization-code-grant.md
+++ b/en/docs/fragments/authorization-code-grant.md
@@ -36,48 +36,62 @@ to configure authentication for an OAuth/OpenID Connect application.
     !!! tip
         You can also use the WSO2 Identity Server Playground sample as the browser-based application to obtain the request. For instructions on using the Playground app, see [Authorization Code Grant with OAuth 2.0 Playground](../../../quick-starts/auth-code-playground).
 
-    ``` tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?
-    response_type=code&
-    client_id=<oauth_client_key>&
-    redirect_uri=<callback_url>&
-    scope=<scope>
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?
-    response_type=code&
-    client_id=0rhQErXIX49svVYoXJGt0DWBuFca&
-    redirect_uri=http://wso2is.local:8080/playground2/oauth2client
-    ```
+    !!! abstract ""
+        **Request Format**    
+        ```
+        https://<host>:<port>/oauth2/authorize?
+        response_type=code&
+        client_id=<oauth_client_key>&
+        redirect_uri=<callback_url>&
+        scope=<scope>
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?
+        response_type=code&
+        client_id=0rhQErXIX49svVYoXJGt0DWBuFca&
+        redirect_uri=http://wso2is.local:8080/playground2/oauth2client
+        ```
 
     !!! note
         `scope` is an optional parameter that can used to define any scope you wish to obtain the token for. To use the application with OpenID Connect, enter the value `openid` as the scope.
     
     You will receive an authorization code. 
 
-    ``` tab="Response Format"
-    <callback_url>?code=<code>
-    ```
-    
-    ``` tab="Sample Response"
-    http://wso2is.local:8080/playground2/oauth2client?code=9142d4cad58c66d0a5edfad8952192
-    ```
+    !!! abstract ""
+        **Response Format**
+        ```
+        <callback_url>?code=<code>
+        ```
+        ---
+        **Sample Response**
+        ```
+        http://wso2is.local:8080/playground2/oauth2client?code=9142d4cad58c66d0a5edfad8952192
+        ```
 
 2. Run the following curl command using the authorization code received, to obtain the access token. 
 
-    ``` tab="Request Format"
-    curl -v -X POST --basic -u <oauth_client_key>:<oauth_client_secret> -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=authorization_code&code=<authorization_code>&redirect_uri=<callback_url> <token_endpoint>
-    ```
-
-    ``` tab="Sample Request"
-    curl -v -X POST --basic -u 7wYeybBGCVfLxPmS0z66WNMffyMa:WYfwHUsbsEvwtqmDLuaxF_VCQJwa -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=authorization_code&code=a0996a17-4a34-3d99-bfcd-6bd1faa604d0&redirect_uri=http://wso2is.local:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -v -X POST --basic -u <oauth_client_key>:<oauth_client_secret> -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=authorization_code&code=<authorization_code>&redirect_uri=<callback_url> <token_endpoint>
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -v -X POST --basic -u 7wYeybBGCVfLxPmS0z66WNMffyMa:WYfwHUsbsEvwtqmDLuaxF_VCQJwa -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=authorization_code&code=a0996a17-4a34-3d99-bfcd-6bd1faa604d0&redirect_uri=http://wso2is.local:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
+        ```
 
 3. You will receive the following response with the access token and refresh token. 
 
     ```
-    {"access_token":"317c19b3-73e3-3906-8627-d1c952856b5d","refresh_token":"52569186-163f-3c9c-b2f4-539a0e8529ce","token_type":"Bearer","expires_in":3600}
+    {
+        "access_token":"317c19b3-73e3-3906-8627-d1c952856b5d",
+        "refresh_token":"52569186-163f-3c9c-b2f4-539a0e8529ce",
+        "token_type":"Bearer",
+        "expires_in":3600
+    }
     ```
 
 !!! info "Related topics"

--- a/en/docs/guides/access-delegation/authorization-code-with-pkce.md
+++ b/en/docs/guides/access-delegation/authorization-code-with-pkce.md
@@ -28,53 +28,67 @@ Make the following requests via your application to connect your application to 
         Now click **Generate Code Challenge**. 
         Make note of the two values. The code challenge you get here is the base64 URL encoded value of the SHA256 hashed code_verifier so the code challenge method will be `S256`.
 
-    ```tab="Request Format"
-    https://<host>/oauth2/authorize?response_type=code
-    &redirect_uri=<redirect_uri>
-    &client_id=<OAuth Client Key>
-    &code_challenge=<PKCE_code_challenge>
-    &code_challenge_method=<PKCE_code_challenge_method>
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=code
-    &redirect_uri=https://localhost/callback
-    &client_id=YYVdAL3lLcmrubZ2IkflCAuLwk0a
-    &code_challenge=5vEtIy2T-G65yXHc8g5zcJDQXICBzZMrtERq0zhx7hM
-    &code_challenge_method=S256
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>/oauth2/authorize?response_type=code
+        &redirect_uri=<redirect_uri>
+        &client_id=<OAuth Client Key>
+        &code_challenge=<PKCE_code_challenge>
+        &code_challenge_method=<PKCE_code_challenge_method>
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=code
+        &redirect_uri=https://localhost/callback
+        &client_id=YYVdAL3lLcmrubZ2IkflCAuLwk0a
+        &code_challenge=5vEtIy2T-G65yXHc8g5zcJDQXICBzZMrtERq0zhx7hM
+        &code_challenge_method=S256
+        ```
     
     You will receive an authorization code. 
     
-    ```tab="Response Format"
-    <callback_url>?code=<code>
-    ```
-        
-    ```tab="Sample Response"
-    http://wso2is.local:8080/playground2/oauth2client?code=9142d4cad58c66d0a5edfad8952192
-    ```
+    !!! abstract ""
+        **Response Format**
+        ```
+        <callback_url>?code=<code>
+        ```
+        ---
+        **Sample Response**
+        ```curl
+        http://wso2is.local:8080/playground2/oauth2client?code=9142d4cad58c66d0a5edfad8952192
+        ```
     
 2. Obtain the access token by sending a token request to the token endpoint using the `authorization_code` received in step 1, and the `<OAuth Client Key>` and `<OAuth Client Secret>` obtained when configuring the service provider.
 
-    ```tab="Request Format"
-    curl -i -X POST -u <OAuth Client Key>:<Client Secret> -k -d 
-    'grant_type=authorization_code&redirect_uri=<redirect_uri>
-    &code=<authorization_code>&code_verifier=<PKCE_code_verifier>' 
-    https://localhost:9443/oauth2/token
-    ```
-
-    ```tab="Sample Request"
-    curl -i -X POST -u YYVdAL3lLcmrubZ2IkflCAuLwk0a:azd39swy3Krt59fLjewYuD_EylIa -k -d 
-    'grant_type=authorization_code
-    &redirect_uri=https://localhost/callback&code=d827ec7e-1b8e-3d81-a4c0-2f7ff67ce844
-    &code_verifier=aYr1jbrAHhZDC5WBi8wQPdraATAvvKy93S22rkPDkkRTHzzaAMVOJ5MHgRPgoKf8xDBJPE08'
-    https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -i -X POST -u <OAuth Client Key>:<Client Secret> -k -d 
+        'grant_type=authorization_code&redirect_uri=<redirect_uri>
+        &code=<authorization_code>&code_verifier=<PKCE_code_verifier>' 
+        https://localhost:9443/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -i -X POST -u YYVdAL3lLcmrubZ2IkflCAuLwk0a:azd39swy3Krt59fLjewYuD_EylIa -k -d 
+        'grant_type=authorization_code
+        &redirect_uri=https://localhost/callback&code=d827ec7e-1b8e-3d81-a4c0-2f7ff67ce844
+        &code_verifier=aYr1jbrAHhZDC5WBi8wQPdraATAvvKy93S22rkPDkkRTHzzaAMVOJ5MHgRPgoKf8xDBJPE08'
+        https://localhost:9443/oauth2/token
+        ```
     
 3. You will receive the following response with the access token and refresh token.
 
     ```
-    {"access_token":"35c52563-f46b-3364-8d3d-007e526e0ab3","refresh_token":"52569186-163f-3c9c-b2f4-539a0e8529ce","token_type":"Bearer","expires_in":3600}
+    {
+        "access_token":"35c52563-f46b-3364-8d3d-007e526e0ab3",
+        "refresh_token":"52569186-163f-3c9c-b2f4-539a0e8529ce",
+        "token_type":"Bearer",
+        "expires_in":3600
+    }
     ```
     
 !!! info "Related topics"

--- a/en/docs/guides/access-delegation/client-credentials.md
+++ b/en/docs/guides/access-delegation/client-credentials.md
@@ -36,18 +36,25 @@ Send the following request using a browser-based application to obtain the acces
 !!! tip
     You can also use the WSO2 Identity Server Playground sample as the browser-based application to obtain the request. For instructions on using the Playground app, see [Client Credentials Grant with OAuth 2.0 Playground](../../../quick-starts/client-credentials-playground).
 
-``` tab="Request Format"
-curl -v -X POST --basic -u <oauth_client_key>:<oauth_client_secret> -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=client_credentials" <token_endpoint>
-```
-
-```tab="Sample Request"
-curl -v -X POST --basic -u 7wYeybBGCVfLxPmS0z66WNMffyMa:WYfwHUsbsEvwtqmDLuaxF_VCQJwa -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=client_credentials" https://localhost:9443/oauth2/token
-```
+!!! abstract ""
+    **Request Format**
+    ```curl
+    curl -v -X POST --basic -u <oauth_client_key>:<oauth_client_secret> -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=client_credentials" <token_endpoint>
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -v -X POST --basic -u 7wYeybBGCVfLxPmS0z66WNMffyMa:WYfwHUsbsEvwtqmDLuaxF_VCQJwa -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=client_credentials" https://localhost:9443/oauth2/token
+    ```
 
 You will receive the following response with the access token.
 
 ```
-{"access_token":"16ab408c-0f31-3321-8bed-313e836df373","token_type":"Bearer","expires_in":2986}
+{
+    "access_token":"16ab408c-0f31-3321-8bed-313e836df373",
+    "token_type":"Bearer",
+    "expires_in":2986
+}
 ```
 
 !!! info "Related topics"

--- a/en/docs/guides/access-delegation/configure-jwt-grant.md
+++ b/en/docs/guides/access-delegation/configure-jwt-grant.md
@@ -111,34 +111,38 @@ You have successfully added the identity provider. Next, configure the applicati
     - **iat:** This is the epoch of the token issuance time (e.g., 1575024942).
     - **jit:** This is the epoch of the token expiry time (e.g., 1575107914).
 
-    ```tab="Example"
-    {
-    "alg": "RS256",
-    "type": "JWT"
-    }
+	!!! example "Example"
+		```
+		{
+		"alg": "RS256",
+		"type": "JWT"
+		}
 
-    {
-    "iss": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
-    "sub": "NCkZofT51NVKK2UuQSvxPJhQOWwa", 
-    "aud": "https://localhost:9443/oauth2/token"
-    "iat": "1575024942",
-    "jit": "1575107914"
-    }
+		{
+		"iss": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
+		"sub": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
+		"aud": "https://localhost:9443/oauth2/token"
+		"iat": "1575024942",
+		"jit": "1575107914"
+		}
 
-    {
-    <Signature>
-    }
-    ```
+		{
+		<Signature>
+		}
+		```
 
 2. Run the following curl command on a terminal window to obtain the access token and refresh token.
 
-	``` powershell tab="Request Format"
-	curl -i -X POST -u (Base64encoded<client_id>:<client_secret>) -k -d 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<jwt_token>' -H 'Content-Type: application/x-www-form-urlencoded' <token_endpoint>
-	``` 
-
-	``` powershell tab="Sample Request"
-	curl -i -X POST -H 'Content-Type: application/x-www-form-urlencoded' -u bBhEoE2wIpU1zB8HA3GfvZz8xxAa:RKgXUC3pTRQg9xPpNwyuTPGtnSQa -k -d 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE0NTgxNjY5ODUsInN1YiI6ImFkbWluIiwibmJmIjoxNDU4MTA2OTg1LCJhdWQiOlsiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwid3NvMi1JUyJdLCJpc3MiOiJqd3RJRFAiLCJqdGkiOiJUb2tlbjU2NzU2IiwiaWF0IjoxNDU4MTA2OTg1fQ.ZcxdoTVEsWoil80ne42QzmsfelMWyjRZJEjUK1c2vMZJjjtrZnsWExyCA5tN6iXYFAXC_7rkFuuNSgOlBi51MNLPZw3WcgGI52j6apGEW92V2tib9zRRWOeLQLAdo8ae8KzLp7kuKZ2XunfQ2WYU9TvvLDm_vp5ruuYz3ZZrJOc' https://localhost:9443/oauth2/token 
-	```
+	!!! abstract ""
+    	**Request Format**
+		```powershell
+		curl -i -X POST -u (Base64encoded<client_id>:<client_secret>) -k -d 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<jwt_token>' -H 'Content-Type: application/x-www-form-urlencoded' <token_endpoint>
+		``` 
+		---
+		**Sample Request**
+		``` powershell
+		curl -i -X POST -H 'Content-Type: application/x-www-form-urlencoded' -u bBhEoE2wIpU1zB8HA3GfvZz8xxAa:RKgXUC3pTRQg9xPpNwyuTPGtnSQa -k -d 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE0NTgxNjY5ODUsInN1YiI6ImFkbWluIiwibmJmIjoxNDU4MTA2OTg1LCJhdWQiOlsiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwid3NvMi1JUyJdLCJpc3MiOiJqd3RJRFAiLCJqdGkiOiJUb2tlbjU2NzU2IiwiaWF0IjoxNDU4MTA2OTg1fQ.ZcxdoTVEsWoil80ne42QzmsfelMWyjRZJEjUK1c2vMZJjjtrZnsWExyCA5tN6iXYFAXC_7rkFuuNSgOlBi51MNLPZw3WcgGI52j6apGEW92V2tib9zRRWOeLQLAdo8ae8KzLp7kuKZ2XunfQ2WYU9TvvLDm_vp5ruuYz3ZZrJOc' https://localhost:9443/oauth2/token 
+		```
 
 !!! tip
     If you have configured the service provider and identity provider in a tenant, add the tenant domain as a query parameter to the access token endpoint. For example, if the tenant domain is wso2.com, the access token endpoint should be `https://localhost:9443/oauth2/token tenantDomain=wso2.com.`

--- a/en/docs/guides/access-delegation/configure-jwt-grant.md
+++ b/en/docs/guides/access-delegation/configure-jwt-grant.md
@@ -111,25 +111,24 @@ You have successfully added the identity provider. Next, configure the applicati
     - **iat:** This is the epoch of the token issuance time (e.g., 1575024942).
     - **jit:** This is the epoch of the token expiry time (e.g., 1575107914).
 
-	!!! example "Example"
-		```
-		{
-		"alg": "RS256",
-		"type": "JWT"
-		}
+	```
+	{
+	"alg": "RS256",
+	"type": "JWT"
+	}
 
-		{
-		"iss": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
-		"sub": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
-		"aud": "https://localhost:9443/oauth2/token"
-		"iat": "1575024942",
-		"jit": "1575107914"
-		}
+	{
+	"iss": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
+	"sub": "NCkZofT51NVKK2UuQSvxPJhQOWwa",
+	"aud": "https://localhost:9443/oauth2/token"
+	"iat": "1575024942",
+	"jit": "1575107914"
+	}
 
-		{
-		<Signature>
-		}
-		```
+	{
+	<Signature>
+	}
+	```
 
 2. Run the following curl command on a terminal window to obtain the access token and refresh token.
 

--- a/en/docs/guides/access-delegation/configure-kerberos-grant.md
+++ b/en/docs/guides/access-delegation/configure-kerberos-grant.md
@@ -121,13 +121,16 @@ This page guides you through the flow involved in exchanging a Kerberos ticket f
 
 Use one of the following curl commands to request for the OAuth token using the kerberos token.
 
-``` java tab="Request 1"
-curl -v -X POST -H "Authorization: Basic <base64 encoded client id:client secret value>" -k -d "grant_type=kerberos&kerberos_realm=<kerberos realm>&kerberos_token=<kerberos token>" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-```
-
-``` java tab="Request 2"
-curl -u <client id>:<client secret> -k -d "grant_type=kerberos&kerberos_realm=<kerberos realm>&kerberos_token=<kerberos token>" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-```
+!!! abstract ""
+    **Request 1**
+    ```curl
+    curl -v -X POST -H "Authorization: Basic <base64 encoded client id:client secret value>" -k -d "grant_type=kerberos&kerberos_realm=<kerberos realm>&kerberos_token=<kerberos token>" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+    ```
+    ---
+    **Request 2**
+    ```curl
+    curl -u <client id>:<client secret> -k -d "grant_type=kerberos&kerberos_realm=<kerberos realm>&kerberos_token=<kerberos token>" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+    ```
 
 You will receive the following response.
 
@@ -143,15 +146,16 @@ The Kerberos client receives the OAuth2 token.
 
 The Kerberos Grant then validates the received token with the provided Identity Provider (IdP) credentials and if it is a valid token, it issues an OAuth2 token to the client.
 
-``` java tab="Example"
-{  
-    "access_token":"636ce45f-c7f6-3a95-907f-d1f8aca28403",
-    "refresh_token":"831271d9-16ba-3bad-af18-b9f6592a8677",
-    "scope":"my_scope",
-    "token_type":"Bearer",
-    "expires_in":521
-}
-```
+!!! example "Example"
+    ``` java
+    {
+        "access_token":"636ce45f-c7f6-3a95-907f-d1f8aca28403",
+        "refresh_token":"831271d9-16ba-3bad-af18-b9f6592a8677",
+        "scope":"my_scope",
+        "token_type":"Bearer",
+        "expires_in":521
+    }
+    ```
 
 !!! info "Related topics"
     - [Concept: Kerberos grant](../../../references/concepts/authorization/kerberos-grant/)

--- a/en/docs/guides/access-delegation/configure-refresh-token.md
+++ b/en/docs/guides/access-delegation/configure-refresh-token.md
@@ -53,18 +53,26 @@ A refresh token can be obtained when using one of the [OAuth 2.0 grant types](oa
 
 Run the following cURL command to try out the refresh token grant and obtain an access token.
 
-``` tab="Request Format"
-curl -k -d "grant_type=refresh_token&refresh_token=<refresh_token>" -H "Authorization: Basic <Base64Encoded(Client_Id:Client_Secret)>" -H "Content-Type: application/x-www-form-urlencoded" https://<IS_HOST>:<IS_PORT>/oauth2/token
-```
-
-``` tab="Sample Request"
-curl -k -d "grant_type=refresh_token&refresh_token=3c285b4f-ec29-3751-9ced-74c92061b327" -H "Authorization: Basic N3dZZXliQkdDVmZMeFBtUzB6NjZXTk1mZnlNYTpXWWZ3SFVzYnNFdnd0cW1ETHVheEZfVkNRSndh" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -k -d "grant_type=refresh_token&refresh_token=<refresh_token>" -H "Authorization: Basic <Base64Encoded(Client_Id:Client_Secret)>" -H "Content-Type: application/x-www-form-urlencoded" https://<IS_HOST>:<IS_PORT>/oauth2/token
+    ```
+    ---
+     **Sample Request**
+    ```curl
+    curl -k -d "grant_type=refresh_token&refresh_token=3c285b4f-ec29-3751-9ced-74c92061b327" -H "Authorization: Basic N3dZZXliQkdDVmZMeFBtUzB6NjZXTk1mZnlNYTpXWWZ3SFVzYnNFdnd0cW1ETHVheEZfVkNRSndh" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+    ```
 
 You will receive an access token with the response.
 
 ``` 
-{"access_token":"b9ed0658-f187-3d39-a4f1-6d42522e1eee","refresh_token":"3426ff78-62a5-32fa-be6e-74ab69d4cbf4","token_type":"Bearer","expires_in":3600}
+{
+    "access_token":"b9ed0658-f187-3d39-a4f1-6d42522e1eee",
+    "refresh_token":"3426ff78-62a5-32fa-be6e-74ab69d4cbf4",
+    "token_type":"Bearer",
+    "expires_in":3600
+}
 ```
 
 !!! info "Related topics"

--- a/en/docs/guides/access-delegation/implicit.md
+++ b/en/docs/guides/access-delegation/implicit.md
@@ -35,19 +35,22 @@ Send the following request using a browser-based application to obtain the ID to
 !!! tip
     You can also use the WSO2 Identity Server Playground sample as the browser-based application to obtain the request. For instructions on using the Playground app, see [Implicit Grant with OAuth 2.0 Playground](../../../quick-starts/implicit-playground).
 
-``` tab="Request Format"
-https://<host>:<port>/oauth2/authorize?
-response_type=token&
-&client_id=<client-ID>
-&redirect_uri=<callback-url>
-```
-
-```tab="Sample Request"
-https://localhost:9443/oauth2/authorize?
-response_type=token&
-client_id=0rhQErXIX49svVYoXJGt0DWBuFca&
-redirect_uri=http://wso2is.local:8080/playground2/oauth2client
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    https://<host>:<port>/oauth2/authorize?
+    response_type=token&
+    &client_id=<client-ID>
+    &redirect_uri=<callback-url>
+    ```
+    ---
+     **Sample Request**
+    ```curl
+    https://localhost:9443/oauth2/authorize?
+    response_type=token&
+    client_id=0rhQErXIX49svVYoXJGt0DWBuFca&
+    redirect_uri=http://wso2is.local:8080/playground2/oauth2client
+    ```
 
 You will receive the ID token. 
 

--- a/en/docs/guides/access-delegation/microprofile-jwt.md
+++ b/en/docs/guides/access-delegation/microprofile-jwt.md
@@ -42,13 +42,16 @@ Now the generated ID token using this client is compatible with the MP-JWT speci
 
 Run the following curl command using the generated client ID and client secret. 
 
-```tab="Request Format"
-curl --user <client_key>:<client_secret>  -k -d "grant_type=password&username=<username>&password=<password>&scope=openid" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-```
-
-```tab="Sample Request"
-curl --user N_nhS_UXctKHofSyLju1rbt_Cbwa:AOkWrH42XKRSsFongXpUnR6mpHYa   -k -d "grant_type=password&username=admin&password=admin&scope=openid" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl --user <client_key>:<client_secret>  -k -d "grant_type=password&username=<username>&password=<password>&scope=openid" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl --user N_nhS_UXctKHofSyLju1rbt_Cbwa:AOkWrH42XKRSsFongXpUnR6mpHYa   -k -d "grant_type=password&username=admin&password=admin&scope=openid" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+    ```
 
 You can also send the above command with an authorization header instead of the clientID and client secret. To do this encode the `clientid:clientsecret` combination using base64 encoding and send the request as seen below. 
 
@@ -58,13 +61,20 @@ curl -H "Authorization: Basic <BASE64 ENCODED COMBINED CLIENT ID:CLIENT SECRET>"
 
 You will receive a response with the JWT token. 
 
-```tab="Response"
-{"access_token":"ac4d1b89-9f8a-3bbd-87d5-735ecb10eccb","refresh_token":"dac0e46b-4038-34d1-9c74-ee3fa6d6f3ee","scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoibDlVMXZ4dzV3VDJlV3VVS3VWY2lEQSIsImF1ZCI6IllteEQwakRPSWZpQmtEOFRQTFlPZnhOU0lnNGEiLCJzdWIiOiJhZG1pbiIsInVwbiI6ImFkbWluIiwibmJmIjoxNTg3NDU4NDUxLCJhenAiOiJZbXhEMGpET0lmaUJrRDhUUExZT2Z4TlNJZzRhIiwiYW1yIjpbInBhc3N3b3JkIl0sImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImdyb3VwcyI6WyJBcHBsaWNhdGlvblwvVXNlciBQb3J0YWwiLCJBcHBsaWNhdGlvblwvcGlja3VwLWRpc3BhdGNoIiwiSW50ZXJuYWxcL2V2ZXJ5b25lIiwiQXBwbGljYXRpb25cL3BpY2t1cC1tYW5hZ2VyIiwiYWRtaW4iLCJBcHBsaWNhdGlvblwvbXAtand0Il0sImV4cCI6MTU4NzQ2MjA1MSwiaWF0IjoxNTg3NDU4NDUxfQ.BT0lEaHYgulsxm0lDFyahuZqD2y_pZxPbeS2qKytIQy8ObOm0GlVwMmP2FHM4PgKqf3FaQAMcdx-MYWF4cfV3hf7D8iTz62IQaCBgPQ0SdkqiuhRgnKm5wRh1neKsOozmFKaizJtr6kX2NohUFmt6dyQgIenFLD4KGDBzfutBLyTOjfWcot8sT2P-cHQv1gvsVBZLD00QDQ612WjM70moqS6Vc7KSZ1pUd0K87VUwY8oAvNd4ZB2oX6oGG4krFPdKGhi570qeZEqvwXpxF5x0KzhKFoEjyhrux6Ot7MTX1llPgwvRRnebNemNGMyVcytDXHKNoZVTvFx47XU7C1Tow","token_type":"Bearer","expires_in":3600}
+```
+{
+    "access_token":"ac4d1b89-9f8a-3bbd-87d5-735ecb10eccb",
+    "refresh_token":"dac0e46b-4038-34d1-9c74-ee3fa6d6f3ee",
+    "scope":"openid",
+    "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoibDlVMXZ4dzV3VDJlV3VVS3VWY2lEQSIsImF1ZCI6IllteEQwakRPSWZpQmtEOFRQTFlPZnhOU0lnNGEiLCJzdWIiOiJhZG1pbiIsInVwbiI6ImFkbWluIiwibmJmIjoxNTg3NDU4NDUxLCJhenAiOiJZbXhEMGpET0lmaUJrRDhUUExZT2Z4TlNJZzRhIiwiYW1yIjpbInBhc3N3b3JkIl0sImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImdyb3VwcyI6WyJBcHBsaWNhdGlvblwvVXNlciBQb3J0YWwiLCJBcHBsaWNhdGlvblwvcGlja3VwLWRpc3BhdGNoIiwiSW50ZXJuYWxcL2V2ZXJ5b25lIiwiQXBwbGljYXRpb25cL3BpY2t1cC1tYW5hZ2VyIiwiYWRtaW4iLCJBcHBsaWNhdGlvblwvbXAtand0Il0sImV4cCI6MTU4NzQ2MjA1MSwiaWF0IjoxNTg3NDU4NDUxfQ.BT0lEaHYgulsxm0lDFyahuZqD2y_pZxPbeS2qKytIQy8ObOm0GlVwMmP2FHM4PgKqf3FaQAMcdx-MYWF4cfV3hf7D8iTz62IQaCBgPQ0SdkqiuhRgnKm5wRh1neKsOozmFKaizJtr6kX2NohUFmt6dyQgIenFLD4KGDBzfutBLyTOjfWcot8sT2P-cHQv1gvsVBZLD00QDQ612WjM70moqS6Vc7KSZ1pUd0K87VUwY8oAvNd4ZB2oX6oGG4krFPdKGhi570qeZEqvwXpxF5x0KzhKFoEjyhrux6Ot7MTX1llPgwvRRnebNemNGMyVcytDXHKNoZVTvFx47XU7C1Tow",
+    "token_type":"Bearer",
+    "expires_in":3600
+}
 ```
 
 The decoded ID token is shown below. 
 
-``` tab="Decoded ID token"
+```
 {
   "x5t": "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",
   "kid": "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",

--- a/en/docs/guides/access-delegation/oauth-dynamic-client-registration.md
+++ b/en/docs/guides/access-delegation/oauth-dynamic-client-registration.md
@@ -8,35 +8,39 @@ This page guides you through using [OAuth Dynamic Client Registration](../../../
 
 Use the following curl command to register an OAuth application with a specified client ID and client secret. 
 
-```tab="Request Format"
-curl -k -X POST -H "Authorization: Basic <Base64_encoded_username:password>" -H 
-"Content-Type: application/json" -d '{
- "client_name": "<application_name>",
- "grant_types": ["<grant_types>"], 
- "ext_param_client_id":"<client_id>", 
- "ext_param_client_secret":"<client_secret>" }' 
-"https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.0/register"
-```
-
-```tab="Sample Request"
-curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H 
-"Content-Type: application/json" -d '{
- "client_name": "application1",
- "grant_types": ["password"], 
- "ext_param_client_id":"provided_client_id0001", 
- "ext_param_client_secret":"provided_client_secret0001" }' 
-"https://localhost:9443/api/identity/oauth2/dcr/v1.0/register"
-```
-
-**Sample Response**
-
-```
-"HTTP/1.1 201 Created"
-{"client_name”:"application1",
-"client_id":"provided_client_id0001",
-"client_secret":"provided_client_secret0001",
-"redirect_uris":[""]}
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -k -X POST -H "Authorization: Basic <Base64_encoded_username:password>" -H 
+    "Content-Type: application/json" -d '{
+    "client_name": "<application_name>",
+    "grant_types": ["<grant_types>"], 
+    "ext_param_client_id":"<client_id>", 
+    "ext_param_client_secret":"<client_secret>" }' 
+    "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.0/register"
+    ```
+    ---
+     **Sample Request**
+    ```curl
+    curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H 
+    "Content-Type: application/json" -d '{
+    "client_name": "application1",
+    "grant_types": ["password"], 
+    "ext_param_client_id":"provided_client_id0001", 
+    "ext_param_client_secret":"provided_client_secret0001" }' 
+    "https://localhost:9443/api/identity/oauth2/dcr/v1.0/register"
+    ```
+    ---
+    **Sample Response**
+    ```
+    "HTTP/1.1 201 Created"
+    {
+        "client_name":"application1",
+        "client_id":"provided_client_id0001",
+        "client_secret":"provided_client_secret0001",
+        "redirect_uris":[""]
+    }
+    ```
 
 -----
 
@@ -44,34 +48,38 @@ curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H
 
 Use the following curl command to update an OAuth application.
 
-```tab="Request Format"
-curl -X PUT -H "Authorization: Basic <Base64_encoded_username:password>" -H
-"Content-Type: application/json" -d '{
-  "redirect_uris":["<callback_url>"],
-  "client_name": "<application_name>",
-  "grant_types": ["<grant_types>"] }'
-"https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register"
-```
-
-```tab="Sample Request"
-curl -X PUT -H "Authorization: Basic YWRtaW46YWRtaW4=" -H
-"Content-Type: application/json" -d '{
-  "redirect_uris":["https://client.example.org/callback"],
-  "client_name": "application1",
-  "grant_types": ["password"] }'
-"https://localhost:9443/api/identity/oauth2/dcr/v1.1/register"
-```
-
-**Sample Response**
-
-```
-"HTTP/1.1 200 OK"
-{ "client_id": "s6BhdRkqt3",
-"client_secret":"ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
-"client_secret_expires_at": 1577858400,
-"redirect_uris":["https://client.example.org/callback"],
-"client_name":"application_owner_application_1" }
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -X PUT -H "Authorization: Basic <Base64_encoded_username:password>" -H
+    "Content-Type: application/json" -d '{
+    "redirect_uris":["<callback_url>"],
+    "client_name": "<application_name>",
+    "grant_types": ["<grant_types>"] }'
+    "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register"
+    ```
+    ---
+     **Sample Request**
+    ```
+    curl -X PUT -H "Authorization: Basic YWRtaW46YWRtaW4=" -H
+    "Content-Type: application/json" -d '{
+    "redirect_uris":["https://client.example.org/callback"],
+    "client_name": "application1",
+    "grant_types": ["password"] }'
+    "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register"
+    ```
+    ---
+    **Sample Response**
+    ```
+    "HTTP/1.1 200 OK"
+    { 
+        "client_id": "s6BhdRkqt3",
+        "client_secret":"ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
+        "client_secret_expires_at": 1577858400,
+        "redirect_uris":["https://client.example.org/callback"],
+        "client_name":"application_owner_application_1"
+    }
+    ```
 
 ----
 
@@ -79,24 +87,28 @@ curl -X PUT -H "Authorization: Basic YWRtaW46YWRtaW4=" -H
 
 Use the following curl command to retrieve OAuth application information using the client ID. 
 
-```tab="Request Format"
-curl -X GET -H "Authorization: Basic <Base64_encoded_username:password>" -H "Content-Type: application/json" -d '{}' "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register/<client_id>"
-```
-
-```tab="Sample Request"
-curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{}' "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register/s6BhdRkqt3"
-```
-
-**Sample Response**
-
-```
-"HTTP/1.1 200 OK"
-{ "client_id": "s6BhdRkqt3",
-"client_secret":"ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
-"client_secret_expires_at": 1577858400,
-"redirect_uris":["https://client.example.org/callback"],
-"client_name":"application1" }
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -X GET -H "Authorization: Basic <Base64_encoded_username:password>" -H "Content-Type: application/json" -d '{}' "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register/<client_id>"
+    ```
+    ---
+     **Sample Request**
+    ```
+    curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{}' "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register/s6BhdRkqt3"
+    ```
+    ---
+    **Sample Response**
+    ```
+    "HTTP/1.1 200 OK"
+    { 
+        "client_id": "s6BhdRkqt3",
+        "client_secret":"ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
+        "client_secret_expires_at": 1577858400,
+        "redirect_uris":["https://client.example.org/callback"],
+        "client_name":"application1"
+    }
+    ```
 
 ----
 
@@ -104,24 +116,28 @@ curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: applica
 
 Use the following curl command to retrieve OAuth application information using the client name. 
 
-```tab="Request Format"
-curl -X GET -H "Authorization: Basic <Base64_encoded_username:password>" -H "Content-Type: application/json" -d '{}' "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register?client_name=<client_name>"
-```
-
-```tab="Sample Request"
-curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{}' "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register?client_name=application1"
-```
-
-**Sample Response**
-
-```
-"HTTP/1.1 200 OK"
-{ "client_id": "s6BhdRkqt3",
-"client_secret":"ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
-"client_secret_expires_at": 1577858400,
-"redirect_uris":["https://client.example.org/callback"],
-"client_name":"application1" }
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -X GET -H "Authorization: Basic <Base64_encoded_username:password>" -H "Content-Type: application/json" -d '{}' "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register?client_name=<client_name>"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{}' "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register?client_name=application1"
+    ```
+    ---
+    **Sample Response**
+    ```
+    "HTTP/1.1 200 OK"
+    { 
+        "client_id": "s6BhdRkqt3",
+        "client_secret":"ZJYCqe3GGRvdrudKyZS0XhGv_Z45DuKhCUk0gBR1vZk",
+        "client_secret_expires_at": 1577858400,
+        "redirect_uris":["https://client.example.org/callback"],
+        "client_name":"application1"
+    }
+    ```
 
 ----
 
@@ -129,19 +145,21 @@ curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: applica
 
 Use the following curl command to delete an OAuth application using the client ID. 
 
-```tab="Request Format"
-curl -X DELETE -H "Authorization: Basic <Base64_encoded_username:password>" -H "Content-Type: application/json" -d '{}' "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register/<client_id>"
-```
-
-```tab="Sample Request"
-curl -X DELETE -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{}' "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register/s6BhdRkqt3"
-```
-
-**Sample Response**
-
-```
-"HTTP/1.1 204 No Content"
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -X DELETE -H "Authorization: Basic <Base64_encoded_username:password>" -H "Content-Type: application/json" -d '{}' "https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/dcr/v1.1/register/<client_id>"
+    ```
+    ---
+     **Sample Request**
+    ```curl
+    curl -X DELETE -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{}' "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register/s6BhdRkqt3"
+    ```
+    ---
+    **Sample Response**
+    ```
+    "HTTP/1.1 204 No Content"
+    ```
 
 !!! info "Related topics"
     - To see the swagger definition of this REST API, see [OAuth Dynamic Client Registration APIs](../../../develop/apis/use-the-openid-connect-dynamic-client-registration-rest-apis/).

--- a/en/docs/guides/access-delegation/oidc-basic-client-profile.md
+++ b/en/docs/guides/access-delegation/oidc-basic-client-profile.md
@@ -21,13 +21,16 @@ relevant responses that the WSO2 Identity Server would generate for the
 
 1. Use the following authorization request with `code` as the response_type to obtain the authorization code from the authorization endpoint.
 
-    ```tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?response_type=code&client_id=<oauth_client_key>&nonce=<nonce_value>&redirect_uri=<redirect_uri>&scope=openid
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=code&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?response_type=code&client_id=<oauth_client_key>&nonce=<nonce_value>&redirect_uri=<redirect_uri>&scope=openid
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=code&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
+        ```
 
     You will receive the authorization code upon successful authorization. 
 
@@ -37,18 +40,28 @@ relevant responses that the WSO2 Identity Server would generate for the
 
 2. Send the code to the token endpoint using the following curl command to request for an access token, refresh token, and id_token.
 
-    ``` tab="Request Format"
-    curl -k -v --basic -u <oauth_client_key>:<oauth_client_secret> -d "grant_type=<grant_type>&code=<code>&redirect_uri=<redirect_uri>" https://<host>:<port>/oauth2/token
-    ```
-
-    ``` tab="Sample Request"
-    curl -k -v --basic -u N_nhS_UXctKHofSyLju1rbt_Cbwa:AOkWrH42XKRSsFongXpUnR6mpHYa -d "grant_type=authorization_code&code=99b34587–5483–374d-8b25–50485498e761&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -k -v --basic -u <oauth_client_key>:<oauth_client_secret> -d "grant_type=<grant_type>&code=<code>&redirect_uri=<redirect_uri>" https://<host>:<port>/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -k -v --basic -u N_nhS_UXctKHofSyLju1rbt_Cbwa:AOkWrH42XKRSsFongXpUnR6mpHYa -d "grant_type=authorization_code&code=99b34587–5483–374d-8b25–50485498e761&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
+        ```
 
     You will receive the following response from the token endpoint.
 
     ```
-    {"access_token":"80c7c0d7-070a-38ff-a1f4-d21a444cdb67","refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d","scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjZTA5YTM1NjBhYzI4ZDc3YWNlZjJjYzQxZGUyNjEzZDMxY2NmOGQwYTgxYjRhNzY2ZTlhYTFmZDRlNjhhMzA5IiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibzhIX0Fqc3FOSWkyd3g5LWVzcFo0dyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODc0NTM5LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzgxMzksImlhdCI6MTYxNTg3NDUzOSwibm9uY2UiOiJhc2QifQ.LIoD9ltfqsxysMaC1b0kX-Ot4qL5GycpF5R-GIB_wBkQvN5BVEQZ4XV2t0t9GaQv1gSApsd6CtUAvV0haAqaNDElVcDQrmsyyHNzN0051biTQWQkoC4wwtO6_w1MSmgbH_aNVjQkBWt2vnaWtn6bt9sdZVxGRSb3_Amxdty_rDmiOzhJPwxZbkdPp1US0jmAn2XOoQQyH7e__qoXSjjoBAKXQtncJWAKtteDUBQTqVLj13TdS8dYqnEQByKNvhpz8rZjGaBV9pxtOWoqnbc3IMA4lX47Mpxl22ZqhIn0J6WCQ7nJtEkfx6XNHdatWZyG2x20pxbZkgya6sKAEoy3zw","token_type":"Bearer","expires_in":2286}
+    {
+        "access_token":"80c7c0d7-070a-38ff-a1f4-d21a444cdb67",
+        "refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d",
+        "scope":"openid",
+        "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjZTA5YTM1NjBhYzI4ZDc3YWNlZjJjYzQxZGUyNjEzZDMxY2NmOGQwYTgxYjRhNzY2ZTlhYTFmZDRlNjhhMzA5IiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibzhIX0Fqc3FOSWkyd3g5LWVzcFo0dyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODc0NTM5LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzgxMzksImlhdCI6MTYxNTg3NDUzOSwibm9uY2UiOiJhc2QifQ.LIoD9ltfqsxysMaC1b0kX-Ot4qL5GycpF5R-GIB_wBkQvN5BVEQZ4XV2t0t9GaQv1gSApsd6CtUAvV0haAqaNDElVcDQrmsyyHNzN0051biTQWQkoC4wwtO6_w1MSmgbH_aNVjQkBWt2vnaWtn6bt9sdZVxGRSb3_Amxdty_rDmiOzhJPwxZbkdPp1US0jmAn2XOoQQyH7e__qoXSjjoBAKXQtncJWAKtteDUBQTqVLj13TdS8dYqnEQByKNvhpz8rZjGaBV9pxtOWoqnbc3IMA4lX47Mpxl22ZqhIn0J6WCQ7nJtEkfx6XNHdatWZyG2x20pxbZkgya6sKAEoy3zw",
+        "token_type":"Bearer",
+        "expires_in":2286
+    }
     ```
 
     The returned ID token carries the user details. It follows the following format:
@@ -83,13 +96,13 @@ relevant responses that the WSO2 Identity Server would generate for the
     !!! tip
         Alternatively, you can get user information by running the following cURL command on the terminal.
     
-        -   **cURL Command**
+        **cURL Command**
 
         ```
         curl -k -H "Authorization: Bearer <Acess_token>" https://localhost:9443/oauth2/userinfo?schema=openid
         ```
         
-        -   **Response**
+        **Response**
         
         ```
         {  

--- a/en/docs/guides/access-delegation/oidc-hybrid-flow.md
+++ b/en/docs/guides/access-delegation/oidc-hybrid-flow.md
@@ -30,13 +30,16 @@ This `response_type` requests a code and an access token from the authorization 
   
 1. Use the following authorization request with `code token` as the `response_type`. 
 
-    ```tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?response_type=code token&client_id=<oauth_client_key>&nonce=asd&redirect_uri=<redirect_uri>&scope=openid
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=code token&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?response_type=code token&client_id=<oauth_client_key>&nonce=asd&redirect_uri=<redirect_uri>&scope=openid
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=code token&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
+        ```
 
     You will receive the following sample response upon successful authorization. 
 
@@ -46,18 +49,28 @@ This `response_type` requests a code and an access token from the authorization 
 
 2. Send the code to the token endpoint using the following curl command to request for an access token, refresh token, and id\_token.
 
-    ``` tab="Request Format"
-    curl -k -v --basic -u <oauth_client_key>:<oauth_client_secret> -d "grant_type=<grant_type>&code=<code>&redirect_uri=<redirect_uri>" https://<host>:<port>/oauth2/token
-    ```
-
-    ``` tab="Sample Request"
-    curl -k -v --basic -u N_nhS_UXctKHofSyLju1rbt_Cbwa:AOkWrH42XKRSsFongXpUnR6mpHYa -d "grant_type=authorization_code&code=99b34587–5483–374d-8b25–50485498e761&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -k -v --basic -u <oauth_client_key>:<oauth_client_secret> -d "grant_type=<grant_type>&code=<code>&redirect_uri=<redirect_uri>" https://<host>:<port>/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -k -v --basic -u N_nhS_UXctKHofSyLju1rbt_Cbwa:AOkWrH42XKRSsFongXpUnR6mpHYa -d "grant_type=authorization_code&code=99b34587–5483–374d-8b25–50485498e761&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
+        ```
 
     You will receive the following response from the token endpoint.
 
     ```
-    {"access_token":"1940a308-d492–3660-a9f8–46723cc582e9","refresh_token":"6b96cc3a-00da-3d7d-acd1–5aaf76dcd9d4","scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJmZDI3NTk4ZWI5ZTBmYTAxN2I1NmNlYjllZjIwZDk2OTk1M2Q2YWZmMTc3NDg5YWEwNGNjZjA1MTY0OTI1YjlkIiwiYXRfaGFzaCI6IjViYlowOHpFQjVlNVNINUJCRFdmaVEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibURSRmNLcDFid19fZG1MaTRRRC1tQSIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODY4OTMzLCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzI1MzMsImlhdCI6MTYxNTg2ODkzMywibm9uY2UiOiJhc2QifQ.cODLbsrcaZpf6NUwI19Nb2LRCcv5Qxwmz3YbarVyrXnEoD0_ZB-CfJPogCD4JKXekzjOEE28ykBx8GlZaMtHY7z5K4DuIlxwWlmjs6grqzZbUhUme3YhBqM7l2cmBXZ3yp4czudh4rTdzuu1zjvJfwBAiMjTc2FDAliV4fGSYK4e8ZzLxuqCqxPzp0cMuyBEWD_447Nun9LJfcJW4cmb32AMcMizE2sQgc1T4vIPXrihJJ8Vz4n6ekWA59JG5z10b-1Thrq4FshM3vGPLEVfWVlBXyDwI-u4YALXThJFJhmdxAB9Rsx-LSqHjBew39Yatti91SF9lqscMgQmQKuYPw","token_type":"Bearer","expires_in":299494}
+    {
+        "access_token":"1940a308-d492–3660-a9f8–46723cc582e9",
+        "refresh_token":"6b96cc3a-00da-3d7d-acd1–5aaf76dcd9d4",
+        "scope":"openid",
+        "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJmZDI3NTk4ZWI5ZTBmYTAxN2I1NmNlYjllZjIwZDk2OTk1M2Q2YWZmMTc3NDg5YWEwNGNjZjA1MTY0OTI1YjlkIiwiYXRfaGFzaCI6IjViYlowOHpFQjVlNVNINUJCRFdmaVEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibURSRmNLcDFid19fZG1MaTRRRC1tQSIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODY4OTMzLCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzI1MzMsImlhdCI6MTYxNTg2ODkzMywibm9uY2UiOiJhc2QifQ.cODLbsrcaZpf6NUwI19Nb2LRCcv5Qxwmz3YbarVyrXnEoD0_ZB-CfJPogCD4JKXekzjOEE28ykBx8GlZaMtHY7z5K4DuIlxwWlmjs6grqzZbUhUme3YhBqM7l2cmBXZ3yp4czudh4rTdzuu1zjvJfwBAiMjTc2FDAliV4fGSYK4e8ZzLxuqCqxPzp0cMuyBEWD_447Nun9LJfcJW4cmb32AMcMizE2sQgc1T4vIPXrihJJ8Vz4n6ekWA59JG5z10b-1Thrq4FshM3vGPLEVfWVlBXyDwI-u4YALXThJFJhmdxAB9Rsx-LSqHjBew39Yatti91SF9lqscMgQmQKuYPw",
+        "token_type":"Bearer",
+        "expires_in":299494
+    }
     ```
 
 3. Optionally, you can decrypt the `id_token`. It will be similar to the decrypted `id_token` shown below.
@@ -91,13 +104,16 @@ This `response_type` requests a code and an id\_token from the authorization end
 
 1. Use the following authorization request with `code id_token` as the `response_type`. 
 
-    ```tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?response_type=code id_token&client_id=<oauth_client_key>&nonce=asd&redirect_uri=<redirect_uri>&scope=openid
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=code id_token&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?response_type=code id_token&client_id=<oauth_client_key>&nonce=asd&redirect_uri=<redirect_uri>&scope=openid
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=code id_token&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
+        ```
 
     You will receive the following response upon successful authorization:
 
@@ -108,7 +124,7 @@ This `response_type` requests a code and an id\_token from the authorization end
     !!! note
         You will not receive an Id Token if the `nonce` value is a not present in the request.
         
-3. Optionally, you can decrypt the `id_token`. It will be similar to the decrypted `id_token` shown below.
+2. Optionally, you can decrypt the `id_token`. It will be similar to the decrypted `id_token` shown below.
 
     ``` 
     {
@@ -136,15 +152,22 @@ This `response_type` requests a code and an id\_token from the authorization end
         The `c_hash` value is mandatory when an id_token is issued with code, and the `response_type` is equal to `code id_token` or `code id_token token` .
 
 
-4. You can send the code to the token endpoint to request for an access token, refresh token and id\_token. For this you can use the same curl command provided for the code token specified [above](#curl).
+3. You can send the code to the token endpoint to request for an access token, refresh token and id\_token. For this you can use the same curl command provided for the code token specified [above](#curl).
     
     You will receive the following response from the token endpoint.
 
     ```
-    {"access_token":"97696e2a-46e3-34d4-b29e-5ef601c8c2ca","refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d","scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjYWFkOWRlYjM2NjQxMjdiMDJkNWM5ZTQzNWQ2NDcyMzI0ZTc4MmMyMjIwZWY2NDQ0ZWQ5YWZlNDJlYTU3OTNmIiwiYXRfaGFzaCI6IjViYlowOHpFQjVlNVNINUJCRFdmaVEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoic090SW44SV9UMEV1RGdaQVBsUGxVZyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODY5NTE2LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzMxMTYsImlhdCI6MTYxNTg2OTUxNiwibm9uY2UiOiJhc2QifQ.IimyN_iztv0ImkJXRYMBYqSWpGw7RBbhq20Xj1CDhX_gR3XP02ph2gTBuJwJthHY_taW8g-2eDrjhTpJ_KgbX4ntumAY0zpw1KpqaMfn_41uR4DNTkJmRsx0CA_wcK5y4o3dXRhStTkwzBh5_qwCCmVq5jD4WzYhA8bnLloHEJMZQuoE6pS5TfbtC6lLmtx7OGseZNT1SgId31rFDvP2fUlkdWLlJJPooCdd-S9YVopt7hekQykg9VZ6HzPI2o_9ZB5WgmcYYVonP0Rd6fiUyAykMd2CoiMoNcCL0nc8fdaQZq9DAFVRWdnLitJ-GJqr4jrz4C2dteU_FKYMS_Sq3Q","token_type":"Bearer","expires_in":2926} 
+    {
+        "access_token":"97696e2a-46e3-34d4-b29e-5ef601c8c2ca",
+        "refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d",
+        "scope":"openid",
+        "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjYWFkOWRlYjM2NjQxMjdiMDJkNWM5ZTQzNWQ2NDcyMzI0ZTc4MmMyMjIwZWY2NDQ0ZWQ5YWZlNDJlYTU3OTNmIiwiYXRfaGFzaCI6IjViYlowOHpFQjVlNVNINUJCRFdmaVEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoic090SW44SV9UMEV1RGdaQVBsUGxVZyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODY5NTE2LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzMxMTYsImlhdCI6MTYxNTg2OTUxNiwibm9uY2UiOiJhc2QifQ.IimyN_iztv0ImkJXRYMBYqSWpGw7RBbhq20Xj1CDhX_gR3XP02ph2gTBuJwJthHY_taW8g-2eDrjhTpJ_KgbX4ntumAY0zpw1KpqaMfn_41uR4DNTkJmRsx0CA_wcK5y4o3dXRhStTkwzBh5_qwCCmVq5jD4WzYhA8bnLloHEJMZQuoE6pS5TfbtC6lLmtx7OGseZNT1SgId31rFDvP2fUlkdWLlJJPooCdd-S9YVopt7hekQykg9VZ6HzPI2o_9ZB5WgmcYYVonP0Rd6fiUyAykMd2CoiMoNcCL0nc8fdaQZq9DAFVRWdnLitJ-GJqr4jrz4C2dteU_FKYMS_Sq3Q",
+        "token_type":"Bearer",
+        "expires_in":2926
+    } 
     ```
 
-5. You can decrypt this `id_token` as well. It will be similar to the decrypted `id_token` shown below.
+4. You can decrypt this `id_token` as well. It will be similar to the decrypted `id_token` shown below.
 
     ``` 
     {
@@ -165,7 +188,7 @@ This `response_type` requests a code and an id\_token from the authorization end
     }
     ```
 
-6. If there are two id\_tokens issued, where one id\_token is from authorization endpoint and other is from token endpoint, be sure to perform the [neccessary validations](#id_token-validations), which are based on the OpenID Connect specification.
+5. If there are two id\_tokens issued, where one id\_token is from authorization endpoint and other is from token endpoint, be sure to perform the [neccessary validations](#id_token-validations), which are based on the OpenID Connect specification.
 
 -----
 
@@ -175,13 +198,16 @@ This `response_type` requests a code, an access token, and an id\_token from the
 
 1. Use the following authorization request with `code id_token token` as the `response_type`. 
 
-    ```tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?response_type=code id_token token&client_id=<oauth_client_key>&nonce=asd&redirect_uri=<redirect_uri>&scope=openid
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=code id_token token&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?response_type=code id_token token&client_id=<oauth_client_key>&nonce=asd&redirect_uri=<redirect_uri>&scope=openid
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=code id_token token&client_id=N_nhS_UXctKHofSyLju1rbt_Cbwa&nonce=asd&redirect_uri=http://localhost:8080/playground2/oauth2client&scope=openid
+        ```
 
     You will receive the following upon successful authorization. 
 
@@ -214,7 +240,14 @@ This `response_type` requests a code, an access token, and an id\_token from the
     You will receive the following response from the token endpoint. 
 
     ``` 
-    {"access_token":"97696e2a-46e3-34d4-b29e-5ef601c8c2ca","refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d","scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiI1YjU2ZTU1ODhiZjcyMGRhNDYxYzA1YTk5ZGRhNzFmOTI1MDdhMGZlNGY2YjA1ZTc1MDdiZWM3NjFmMDNmZjllIiwiYXRfaGFzaCI6IjViYlowOHpFQjVlNVNINUJCRFdmaVEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoiZEN5eW5lZTA1QkptQmtRNHZab3M2QSIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODcwNzYxLCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzQzNjEsImlhdCI6MTYxNTg3MDc2MSwibm9uY2UiOiJhc2QifQ.SVlEYFEPd5JvdjnkjuSJrZDB1DYA-8BNLXjX2olbFtLEXK10DSrmDn5kXi3W8Txv5MVpOJnKaMHsgZeZEj67EMXatXj_UidvPBRslbhA8SHkUMJ1ZwbukOhIKLzBVXAJjupYvQpbRWfJ6wx3C38W9KvQKvUKK0pBL06idFi56AWNPydZIq4KDqGC2-YPSCftMWGAYA-T380-ITUVOrtZKHZE-sl8U-Ie-TjR6kNgZqyrNBcmefM1w2CzAwngFz0Oj-hO3rLnEN5rk8bkPFLNnB2o6Wva2Gc72EqG8Wsf0T19o6d9qubNzRs30S1T-IFhur37XE8evQ8dZWMCSscKXQ","token_type":"Bearer","expires_in":1681}
+    {
+        "access_token":"97696e2a-46e3-34d4-b29e-5ef601c8c2ca",
+        "refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d",
+        "scope":"openid",
+        "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiI1YjU2ZTU1ODhiZjcyMGRhNDYxYzA1YTk5ZGRhNzFmOTI1MDdhMGZlNGY2YjA1ZTc1MDdiZWM3NjFmMDNmZjllIiwiYXRfaGFzaCI6IjViYlowOHpFQjVlNVNINUJCRFdmaVEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoiZEN5eW5lZTA1QkptQmtRNHZab3M2QSIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODcwNzYxLCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzQzNjEsImlhdCI6MTYxNTg3MDc2MSwibm9uY2UiOiJhc2QifQ.SVlEYFEPd5JvdjnkjuSJrZDB1DYA-8BNLXjX2olbFtLEXK10DSrmDn5kXi3W8Txv5MVpOJnKaMHsgZeZEj67EMXatXj_UidvPBRslbhA8SHkUMJ1ZwbukOhIKLzBVXAJjupYvQpbRWfJ6wx3C38W9KvQKvUKK0pBL06idFi56AWNPydZIq4KDqGC2-YPSCftMWGAYA-T380-ITUVOrtZKHZE-sl8U-Ie-TjR6kNgZqyrNBcmefM1w2CzAwngFz0Oj-hO3rLnEN5rk8bkPFLNnB2o6Wva2Gc72EqG8Wsf0T19o6d9qubNzRs30S1T-IFhur37XE8evQ8dZWMCSscKXQ",
+        "token_type":"Bearer",
+        "expires_in":1681
+    }
     ```
 
 4. If there are two id\_tokens issued, where one id\_token is from authorization endpoint and other is from token endpoint, be sure to perform the [neccessary validations](#id_token-validations), which are based on the OpenID Connect specification.

--- a/en/docs/guides/access-delegation/oidc-implicit-client-profile.md
+++ b/en/docs/guides/access-delegation/oidc-implicit-client-profile.md
@@ -20,26 +20,32 @@ relevant responses that the WSO2 Identity Server would generate for the
 
 1. Send the following request using a browser-based application.
 
-    ``` tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?response_type=id_token&client_id=<oauth_client_key>&redirect_uri=<callback_url>&nonce=<nonce_value>&scope=openid
-    ```
-
-    ``` tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=id_token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&nonce=abc&scope=openid
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?response_type=id_token&client_id=<oauth_client_key>&redirect_uri=<callback_url>&nonce=<nonce_value>&scope=openid
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=id_token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&nonce=abc&scope=openid
+        ```
 
     !!! note
         The `nonce` value is a mandatory to receive an Id Token.
     
 2. You will receive the following response upon successful authorization. 
 
-    ``` tab="Resonse Format"
-    <callback_url>#id_token=<id_token>
-    ```
-    
-    ``` tab="Sample Response"
-    http://localhost:8080/playground2/oauth2client#id_token=eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJkODM1YmE4ZjIxNjdmNGJiNDg1OGQzMmVmNmNmYzdmYmZiMWEyNzExYzA0YTA5ZmZjMTk3MjQ4ZWMyNjg5ZmNhIiwiYXVkIjoiQ1Z5UWVNNVAzM2dmTjgwdnVyM05jeHpQZ0h3YSIsInN1YiI6ImFkbWluIiwiYXpwIjoiQ1Z5UWVNNVAzM2dmTjgwdnVyM05jeHpQZ0h3YSIsImFtciI6WyJCYXNpY0F1dGhlbnRpY2F0b3IiXSwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwiZXhwIjoxNjE1ODc1OTg0LCJpYXQiOjE2MTU4NzIzODQsIm5vbmNlIjoiYWJjIn0.iHkj_Ve1wiYeYATGyt4nd3ko0b0X73Dah2AzgHBtnQJeQtXoo3dxgPTIFcgfrs9lpCCoDmQeZB-I-PUp6rXAPCY0Sen8u1tCs-VfuamOgeIxlvKY7AqGMjA7dOUO66GVtHs0M3WMzeNS22esZr4GbtgZi3Po5GkUqsctUHKVcfSJr0J2JaaGUSap8d1NoJNyxkwu5wD6AA78NjTN-iqxusdjJQSpZFXBnZU99qfnNB0kxK5hc44SlntkQ-o2oBTWSlhDAzXm3kjp-eOdoBWoReSvGHqHqawxRMXiZL_UT80l7F6QQ9UgxXOqdfuL5gzt5fEz9ftwpZfjp0Sm3quQHw&session_state=a68c4f52124d15131f944c201e57d3eebbff0f5154f8503214c688c52f8963b3.6DPeIkygVpE7VTHtKrfbLw
-    ```
+    !!! abstract ""
+        **Resonse Format**
+        ```
+        <callback_url>#id_token=<id_token>
+        ```
+        ---
+        **Sample Response**
+        ```curl
+        http://localhost:8080/playground2/oauth2client#id_token=eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJkODM1YmE4ZjIxNjdmNGJiNDg1OGQzMmVmNmNmYzdmYmZiMWEyNzExYzA0YTA5ZmZjMTk3MjQ4ZWMyNjg5ZmNhIiwiYXVkIjoiQ1Z5UWVNNVAzM2dmTjgwdnVyM05jeHpQZ0h3YSIsInN1YiI6ImFkbWluIiwiYXpwIjoiQ1Z5UWVNNVAzM2dmTjgwdnVyM05jeHpQZ0h3YSIsImFtciI6WyJCYXNpY0F1dGhlbnRpY2F0b3IiXSwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwiZXhwIjoxNjE1ODc1OTg0LCJpYXQiOjE2MTU4NzIzODQsIm5vbmNlIjoiYWJjIn0.iHkj_Ve1wiYeYATGyt4nd3ko0b0X73Dah2AzgHBtnQJeQtXoo3dxgPTIFcgfrs9lpCCoDmQeZB-I-PUp6rXAPCY0Sen8u1tCs-VfuamOgeIxlvKY7AqGMjA7dOUO66GVtHs0M3WMzeNS22esZr4GbtgZi3Po5GkUqsctUHKVcfSJr0J2JaaGUSap8d1NoJNyxkwu5wD6AA78NjTN-iqxusdjJQSpZFXBnZU99qfnNB0kxK5hc44SlntkQ-o2oBTWSlhDAzXm3kjp-eOdoBWoReSvGHqHqawxRMXiZL_UT80l7F6QQ9UgxXOqdfuL5gzt5fEz9ftwpZfjp0Sm3quQHw&session_state=a68c4f52124d15131f944c201e57d3eebbff0f5154f8503214c688c52f8963b3.6DPeIkygVpE7VTHtKrfbLw
+        ```
 
     Given below is the Base64 decoded value of the Id Token:
     
@@ -69,27 +75,32 @@ relevant responses that the WSO2 Identity Server would generate for the
 
 1. Send the following request using a browser-based application.
 
-    ``` tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?response_type=id_token token&client_id=<oauth_client_key>&redirect_uri=<callback_url>&nonce=<nonce_value>&scope=openid
-
-    ```
-
-    ``` tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=id_token token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://wso2is.local:8080/playground2/oauth2client&nonce=abc&scope=openid
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?response_type=id_token token&client_id=<oauth_client_key>&redirect_uri=<callback_url>&nonce=<nonce_value>&scope=openid
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        https://localhost:9443/oauth2/authorize?response_type=id_token token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://wso2is.local:8080/playground2/oauth2client&nonce=abc&scope=openid
+        ```
 
     !!! note
         The `nonce` value is a mandatory to receive an Id Token.
 
 2. You will receive the following sample response upon successful authorization. Note that both the access token and the ID Token are returned to the client.
 
-    ``` tab="Response Format"
-    <callback_url>#access_token=<access_token>&id_token=<id_token>
-    ```
-    
-    ``` tab="Sample Response"
-    http://wso2is.local:8080/playground2/oauth2client#access_token=80c7c0d7-070a-38ff-a1f4-d21a444cdb67&id_token=eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiI5YWI1MzhiZDIxNDhmMmFhMTdlMmUxZTA1YzliMWQwOGQ2NGY0ZjIwYzk5YmViNTBhYmJhNDRlMjgzZjhlNTRmIiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwic3ViIjoiYWRtaW4iLCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzY4MjUsImlhdCI6MTYxNTg3MzIyNSwibm9uY2UiOiJhYmMifQ.Z3HbYG0tBu30X5BYJ9hvCGQ9O8wUGXC6GWz3e9xQJHqu15AuRIcM2zbkvbHc-pul5DdwmqfU-R8Ilkp9e0fgrAOOtPCoSRqKO8yNeXhOQ0pj8HBQtLgB9iys3HzL-HPcIolMVNv6VWEhMBP253JXo-7n1DvLJqHE0Q5xK7W8BwudTh5kd0NNl6PEud0aaBJChETdMG231bpHEGCmJMhAkb9WsZyztvkuMVsAt50uRMG1DX0gMOKW1ZcAMAe_z3RdADXVMGu1VZ5HNUoTBl8VosHOFGwrcpndoxiyGAkWIhj7kdQ1AZVUse1RlKH9IW2AZI7VXkPvnU-tmcXCsIJsKg&token_type=Bearer&expires_in=3599&session_state=a49751e21bf6fbf8624cffa0904fd77706c48a09ae187672e4dd09cab84d9e9f.G_NOFmMsySRgYgkmQizt6g
-    ```
+    !!! abstract ""
+        **Response Format**
+        ```
+        <callback_url>#access_token=<access_token>&id_token=<id_token>
+        ```
+        ---
+        **Sample Response**
+        ```curl
+        http://wso2is.local:8080/playground2/oauth2client#access_token=80c7c0d7-070a-38ff-a1f4-d21a444cdb67&id_token=eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiI5YWI1MzhiZDIxNDhmMmFhMTdlMmUxZTA1YzliMWQwOGQ2NGY0ZjIwYzk5YmViNTBhYmJhNDRlMjgzZjhlNTRmIiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwic3ViIjoiYWRtaW4iLCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzY4MjUsImlhdCI6MTYxNTg3MzIyNSwibm9uY2UiOiJhYmMifQ.Z3HbYG0tBu30X5BYJ9hvCGQ9O8wUGXC6GWz3e9xQJHqu15AuRIcM2zbkvbHc-pul5DdwmqfU-R8Ilkp9e0fgrAOOtPCoSRqKO8yNeXhOQ0pj8HBQtLgB9iys3HzL-HPcIolMVNv6VWEhMBP253JXo-7n1DvLJqHE0Q5xK7W8BwudTh5kd0NNl6PEud0aaBJChETdMG231bpHEGCmJMhAkb9WsZyztvkuMVsAt50uRMG1DX0gMOKW1ZcAMAe_z3RdADXVMGu1VZ5HNUoTBl8VosHOFGwrcpndoxiyGAkWIhj7kdQ1AZVUse1RlKH9IW2AZI7VXkPvnU-tmcXCsIJsKg&token_type=Bearer&expires_in=3599&session_state=a49751e21bf6fbf8624cffa0904fd77706c48a09ae187672e4dd09cab84d9e9f.G_NOFmMsySRgYgkmQizt6g
+        ```
 
 !!! info "Related topics"
     - [Concept: OpenID Connect Implicit Client](../../../references/concepts/authentication/implicit-client-profile/)

--- a/en/docs/guides/access-delegation/password-grant.md
+++ b/en/docs/guides/access-delegation/password-grant.md
@@ -36,18 +36,27 @@ Send the following request using a browser-based application to obtain the acces
 !!! tip
     You can also use the WSO2 Identity Server Playground sample as the browser-based application to obtain the request. For instructions on using the Playground app, see [Password Grant with OAuth 2.0 Playground](../../../quick-starts/password-playground).
 
-``` tab="Request Format"
-curl -v -X POST --basic -u <client_ID>:<client_secret> -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=password&username=<username>&password=<password>" <token_endpoint>
-```
 
-```tab="Sample Request"
-curl -v -X POST --basic -u 7wYeybBGCVfLxPmS0z66WNMffyMa:WYfwHUsbsEvwtqmDLuaxF_VCQJwa -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=password&username=admin&password=admin" https://localhost:9443/oauth2/token
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    curl -v -X POST --basic -u <client_ID>:<client_secret> -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=password&username=<username>&password=<password>" <token_endpoint>
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -v -X POST --basic -u 7wYeybBGCVfLxPmS0z66WNMffyMa:WYfwHUsbsEvwtqmDLuaxF_VCQJwa -H "Content-Type:application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=password&username=admin&password=admin" https://localhost:9443/oauth2/token
+    ```
 
 You will receive the following response with the access token and refresh token. 
 
 ```
-{"access_token":"16ab408c-0f31-3321-8bed-313e836df373","refresh_token":"3c285b4f-ec29-3751-9ced-74c92061b327","token_type":"Bearer","expires_in":3600}
+{
+    "access_token":"16ab408c-0f31-3321-8bed-313e836df373",
+    "refresh_token":"3c285b4f-ec29-3751-9ced-74c92061b327",
+    "token_type":"Bearer",
+    "expires_in":3600
+}
 ```
 
 !!! info "Related topics"

--- a/en/docs/guides/access-delegation/saml2-bearer-assertion-profile.md
+++ b/en/docs/guides/access-delegation/saml2-bearer-assertion-profile.md
@@ -46,23 +46,29 @@ This guide assumes you have your own application. If you wish to try out this fl
 
 1. Use the following curl command to exchange the SAML assertion for an OAuth access token.
 
-    ``` java tab="Request Format"
-    curl -k -d "grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer&assertion=<base64-URL_encoded_assertion>&scope=<scope>" -H "Authorization: Basic <base64_encoded_clientid:clientsecret>" -H "Content-Type: application/x-www-form-urlencoded" https://<host>:<port>/oauth2/token
-    ```
-    
-    ``` java tab="Sample Request"
-    curl -k -d "grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer&assertion=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZczpUcmFuc2Zvcm1zPgo8ZHM6VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3zOlRyYW5zZm9ybXMaW&scope=PRODUCTION" -H "Authorization: Basic TGZkcWt3eVNGVVNZVjNtUkNNaE5vNmw1cWZJYTpOb0JQZjZkZGhxS2pXdEpNWHVibU04bndqNW9h" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```curl
+        curl -k -d "grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer&assertion=<base64-URL_encoded_assertion>&scope=<scope>" -H "Authorization: Basic <base64_encoded_clientid:clientsecret>" -H "Content-Type: application/x-www-form-urlencoded" https://<host>:<port>/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -k -d "grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer&assertion=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZczpUcmFuc2Zvcm1zPgo8ZHM6VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3zOlRyYW5zZm9ybXMaW&scope=PRODUCTION" -H "Authorization: Basic TGZkcWt3eVNGVVNZVjNtUkNNaE5vNmw1cWZJYTpOb0JQZjZkZGhxS2pXdEpNWHVibU04bndqNW9h" -H "Content-Type: application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+        ```
     
 2. Use the introspection endpoint of WSO2 Identity Server to get the token information.
 
-    ``` java tab="Request Format"
-    curl -k -u <username>:<password> -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=<access token>' https://<IS_HOST>:<IS_PORT>/oauth2/introspect
-    ```
-
-    ``` java tab="Sample Request"
-    curl -k -u admin:admin -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=f3116b04-924f-3f1a-b323-4f0988b94f9f' https://localhost:9443/oauth2/introspect
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```curl
+        curl -k -u <username>:<password> -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=<access token>' https://<IS_HOST>:<IS_PORT>/oauth2/introspect
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -k -u admin:admin -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=f3116b04-924f-3f1a-b323-4f0988b94f9f' https://localhost:9443/oauth2/introspect
+        ```
 
 !!! info "Related topics"
     -   [Concept: SAML2 Bearer Assertion Profile for OAuth 2.0](../../../references/concepts/authorization/saml2-bearer-assertion-profile)

--- a/en/docs/guides/access-delegation/uma.md
+++ b/en/docs/guides/access-delegation/uma.md
@@ -103,18 +103,21 @@ values to obtain the Protection API Access Token (PAT). -->
             is the password grant type. Therefore, you need to pass the
             resource owners credentials in the curl command. 
 
-    ``` tab="Request Format"
-    curl -u <CLIENT_ID>:<CLIENT_SECRET> -k -d "grant_type=password&username=<USERNAME>&password=<PASSWORD>&scope=uma_protection internal_application_mgt_view" -H "Content-Type:application/x-www-form-urlencoded" https://<IS_HOST>:<IS_PORT>/oauth2/token
-      
-    ```
-    
-    ``` tab="Sample Request"
-    curl -u hwbR3jd2fikSApLKfv_wiwRWNSwa:q7Kb74s5dcK3FBh1MUWAJqvdrs8a -k -d "grant_type=password&username=larry&password=larry123&scope=uma_protection internal_application_mgt_view" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -u <CLIENT_ID>:<CLIENT_SECRET> -k -d "grant_type=password&username=<USERNAME>&password=<PASSWORD>&scope=uma_protection internal_application_mgt_view" -H "Content-Type:application/x-www-form-urlencoded" https://<IS_HOST>:<IS_PORT>/oauth2/token
+        
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -u hwbR3jd2fikSApLKfv_wiwRWNSwa:q7Kb74s5dcK3FBh1MUWAJqvdrs8a -k -d "grant_type=password&username=larry&password=larry123&scope=uma_protection internal_application_mgt_view" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+        ```
 
     You will get a response similar to the following:
 
-    ``` java
+    ```
     {
         "access_token":"b8df48ff-feab-3632-b3dc-68ae6b4c62e2",
         "refresh_token":"1037ccad-f45a-38e7-96ad-40c00fbc7ca4",
@@ -137,34 +140,38 @@ Now, you need to register the resource.
             the [access token you got in the previous
             section](#obtain-the-protection-api-access-token-pat).
     
-    ``` tab="Request Format"
-    curl -X POST \
-    https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/uma/resourceregistration/v1.0/resource \
-    -H 'Authorization: Bearer <PAT>' \
-    -H 'Content-Type: application/json' \
-    -d '<RESOURCE_PAYLOAD>'
-    ```
-    
-    ```tab="Sample Request"
-    curl -X POST \
-    https://localhost:9443/api/identity/oauth2/uma/resourceregistration/v1.0/resource \
-    -H 'Authorization: Bearer 64658549-47c1-3b5a-8637-c629f16c4118' \
-    -H 'Content-Type: application/json' \
-    -d '{
-          "resource_scopes": [
-            "view",
-            "download"
-          ],
-          "description": "Collection of digital photographs",
-          "icon_uri": "http://www.example.com/icons/flower.png",
-          "name": "Photo Album",
-          "type": "http://www.example.com/rsrcs/photoalbum"
-        }'
-    ```
+
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -X POST \
+        https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/uma/resourceregistration/v1.0/resource \
+        -H 'Authorization: Bearer <PAT>' \
+        -H 'Content-Type: application/json' \
+        -d '<RESOURCE_PAYLOAD>'
+        ```
+        ---
+        **Sample Request**
+        ```curl      
+        curl -X POST \
+        https://localhost:9443/api/identity/oauth2/uma/resourceregistration/v1.0/resource \
+        -H 'Authorization: Bearer 64658549-47c1-3b5a-8637-c629f16c4118' \
+        -H 'Content-Type: application/json' \
+        -d '{
+            "resource_scopes": [
+                "view",
+                "download"
+            ],
+            "description": "Collection of digital photographs",
+            "icon_uri": "http://www.example.com/icons/flower.png",
+            "name": "Photo Album",
+            "type": "http://www.example.com/rsrcs/photoalbum"
+            }'
+        ```
 
     You will get a response similar to the following:
 
-    ``` java
+    ```
     {
         "_id": "ceaa6506-1da9-456b-88d8-027797d2e081"
     }
@@ -293,17 +300,20 @@ contains an invalid token.
             resources and the relevant scopes. The sample request used
             in this guide contains a single permission.
     
-    ```tab="Request Format"
-    curl -X POST https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/uma/permission/v1.0/permission -H 'authorization: Bearer <PAT>' -H "Content-Type: application/json" -d '["<PERMISSION_PAYLOAD>"]' -k
-    ```
-        
-    ```tab="Sample Request"
-    curl -X POST https://localhost:9443/api/identity/oauth2/uma/permission/v1.0/permission -H 'authorization: Bearer b8df48ff-feab-3632-b3dc-68ae6b4c62e2' -H "Content-Type: application/json" -d '[{"resource_id":"ceaa6506-1da9-456b-88d8-027797d2e081","resource_scopes":["view"]}]' -k
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -X POST https://<IS_HOST>:<IS_PORT>/api/identity/oauth2/uma/permission/v1.0/permission -H 'authorization: Bearer <PAT>' -H "Content-Type: application/json" -d '["<PERMISSION_PAYLOAD>"]' -k
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -X POST https://localhost:9443/api/identity/oauth2/uma/permission/v1.0/permission -H 'authorization: Bearer b8df48ff-feab-3632-b3dc-68ae6b4c62e2' -H "Content-Type: application/json" -d '[{"resource_id":"ceaa6506-1da9-456b-88d8-027797d2e081","resource_scopes":["view"]}]' -k
+        ```
       
     You will get a response similar to the following:
 
-    ``` java
+    ```
     {"ticket":"97f476f2-72d0-4540-aa08-a4784bd2053e"}
     ```
 
@@ -323,17 +333,20 @@ party username is required.
     client](#configure-service-provider-to-act-as-the-client).  Since the grant type used here is the password grant type, you need 
     to specify the requesting party credentials in the curl command.
     
-    ```tab="Request Format"
-    curl -u <CLIENT_ID>:<CLIENT_SECRET> -k -d "grant_type=password&username=<USERNAME>&password=<PASSWORD>&scope=openid" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-    ```
-            
-    ```tab="Sample Request"
-    curl -u IRBYPhUyAtYjjUIgjZySI800fUMa:6m_9dkM8e7RSxs77JW0dbf9ECr0a -k -d "grant_type=password&username=sam&password=sam123&scope=openid" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -u <CLIENT_ID>:<CLIENT_SECRET> -k -d "grant_type=password&username=<USERNAME>&password=<PASSWORD>&scope=openid" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```curl
+        curl -u IRBYPhUyAtYjjUIgjZySI800fUMa:6m_9dkM8e7RSxs77JW0dbf9ECr0a -k -d "grant_type=password&username=sam&password=sam123&scope=openid" -H "Content-Type:application/x-www-form-urlencoded" https://localhost:9443/oauth2/token
+        ```
       
     You will get a response similar to the following:
 
-    ``` java
+    ```
         {
            "access_token":"f2999d40-af06-3779-b157-731d6540c5de",
            "refresh_token":"f95adb62-34ae-311e-83c1-6b136eb49017",
@@ -442,7 +455,7 @@ This is how UMA works.
     
     Following is a sample response when the above configuration is disabled.
     
-    ``` java
+    ```
     {
       "nbf": 1553411123,
       "active": true,

--- a/en/docs/guides/adaptive-auth/adaptive-auth-with-function-lib.md
+++ b/en/docs/guides/adaptive-auth/adaptive-auth-with-function-lib.md
@@ -44,60 +44,34 @@ or
 exports.<function_name_for_outside> = <function_name_in _the_script>
 ```
 
-!!! example "Example"
-    ```javascript
-    function getAge(birthDate) {
-        var today = new Date();
-        var age = today.getFullYear() - birthDate.getFullYear();
-        var m = today.getMonth() - birthDate.getMonth();
-        if (m < 0 || (m === 0 && today.getDate() <    birthDate.getDate())) {
-            age--;
-        }
-        return age;
-    };
+```javascript
+function getAge(birthDate) {
+    var today = new Date();
+    var age = today.getFullYear() - birthDate.getFullYear();
+    var m = today.getMonth() - birthDate.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() <    birthDate.getDate())) {
+        age--;
+    }
+    return age;
+};
 
-    var validateDOB = function (dob) {
-        return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-    };
-        
-    module.exports.getAge = getAge;
-    //or 
-    //exports.getAge = getAge;
-    module.exports.validateDOB = validateDOB;
-    //or
-    //exports.validateDOB = validateDOB;
-    ```
+var validateDOB = function (dob) {
+    return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+};
+    
+module.exports.getAge = getAge;
+//or 
+//exports.getAge = getAge;
+module.exports.validateDOB = validateDOB;
+//or
+//exports.validateDOB = validateDOB;
+```
 
 **Option 2**
 
-!!! example "Example"
-    ```javascript
-    var ageModule = {
-        getAge : function (birthDate) {
-            var today = new Date();
-            var age = today.getFullYear() - birthDate.getFullYear();
-            var m = today.getMonth() - birthDate.getMonth();
-            if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
-                age--;
-            }
-            return age;
-        },
-        
-        validateDOB : function (dob) {
-            return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-        }
-    };
-        
-    module.exports = ageModule;
-    ```
-
-
-**Option 3**
-
-!!! example "Example"
-    ```javascript
-    var ageModule = { };
-    ageModule.getAge = function (birthDate) {
+```javascript
+var ageModule = {
+    getAge : function (birthDate) {
         var today = new Date();
         var age = today.getFullYear() - birthDate.getFullYear();
         var m = today.getMonth() - birthDate.getMonth();
@@ -105,14 +79,37 @@ exports.<function_name_for_outside> = <function_name_in _the_script>
             age--;
         }
         return age;
-    };
-
-    ageModule.validateDOB = function (dob) {
+    },
+    
+    validateDOB : function (dob) {
         return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-    };
-        
-    module.exports = ageModule;
-    ```
+    }
+};
+    
+module.exports = ageModule;
+```
+
+
+**Option 3**
+
+```javascript
+var ageModule = { };
+ageModule.getAge = function (birthDate) {
+    var today = new Date();
+    var age = today.getFullYear() - birthDate.getFullYear();
+    var m = today.getMonth() - birthDate.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+        age--;
+    }
+    return age;
+};
+
+ageModule.validateDOB = function (dob) {
+    return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+};
+    
+module.exports = ageModule;
+```
 
 ----
 

--- a/en/docs/guides/adaptive-auth/adaptive-auth-with-function-lib.md
+++ b/en/docs/guides/adaptive-auth/adaptive-auth-with-function-lib.md
@@ -44,34 +44,60 @@ or
 exports.<function_name_for_outside> = <function_name_in _the_script>
 ```
 
-```javascript tab="Example"
-function getAge(birthDate) {
-    var today = new Date();
-    var age = today.getFullYear() - birthDate.getFullYear();
-    var m = today.getMonth() - birthDate.getMonth();
-    if (m < 0 || (m === 0 && today.getDate() <    birthDate.getDate())) {
-        age--;
-    }
-    return age;
-};
+!!! example "Example"
+    ```javascript
+    function getAge(birthDate) {
+        var today = new Date();
+        var age = today.getFullYear() - birthDate.getFullYear();
+        var m = today.getMonth() - birthDate.getMonth();
+        if (m < 0 || (m === 0 && today.getDate() <    birthDate.getDate())) {
+            age--;
+        }
+        return age;
+    };
 
-var validateDOB = function (dob) {
-    return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-};
-    
-module.exports.getAge = getAge;
-//or 
-//exports.getAge = getAge;
-module.exports.validateDOB = validateDOB;
-//or
-//exports.validateDOB = validateDOB;
-```
+    var validateDOB = function (dob) {
+        return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    };
+        
+    module.exports.getAge = getAge;
+    //or 
+    //exports.getAge = getAge;
+    module.exports.validateDOB = validateDOB;
+    //or
+    //exports.validateDOB = validateDOB;
+    ```
 
 **Option 2**
 
-```javascript
-var ageModule = {
-    getAge : function (birthDate) {
+!!! example "Example"
+    ```javascript
+    var ageModule = {
+        getAge : function (birthDate) {
+            var today = new Date();
+            var age = today.getFullYear() - birthDate.getFullYear();
+            var m = today.getMonth() - birthDate.getMonth();
+            if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+                age--;
+            }
+            return age;
+        },
+        
+        validateDOB : function (dob) {
+            return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        }
+    };
+        
+    module.exports = ageModule;
+    ```
+
+
+**Option 3**
+
+!!! example "Example"
+    ```javascript
+    var ageModule = { };
+    ageModule.getAge = function (birthDate) {
         var today = new Date();
         var age = today.getFullYear() - birthDate.getFullYear();
         var m = today.getMonth() - birthDate.getMonth();
@@ -79,37 +105,14 @@ var ageModule = {
             age--;
         }
         return age;
-    },
-    
-    validateDOB : function (dob) {
+    };
+
+    ageModule.validateDOB = function (dob) {
         return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-    }
-};
-    
-module.exports = ageModule;
-```
-
-
-**Option 3**
-
-```javascript
-var ageModule = { };
-ageModule.getAge = function (birthDate) {
-    var today = new Date();
-    var age = today.getFullYear() - birthDate.getFullYear();
-    var m = today.getMonth() - birthDate.getMonth();
-    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
-        age--;
-    }
-    return age;
-};
-
-ageModule.validateDOB = function (dob) {
-    return dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-};
-    
-module.exports = ageModule;
-```
+    };
+        
+    module.exports = ageModule;
+    ```
 
 ----
 
@@ -185,19 +188,23 @@ Follow the instructions below to delete a function library.
 
 5. Add the following on top of the script/ before the usage of functions in the function library.
 
-    ```tab="Format"
-    var <module_name> = require('<function library name>');
-    ```
-
-    ```tab="Example"
-    var ageModule = require('age_based.js');)
-    ```
+    !!! abstract ""
+        **Format**
+        ```
+        var <module_name> = require('<function library name>');
+        ```
+        ---
+        **Example**
+        ```
+        var ageModule = require('age_based.js');)
+        ```
 
 6. Use the functions exported in the loaded function library.
     
-    ```tab="Example"
-    ageModule.getAge(birthday)
-    ```
+    !!! example "Example"
+        ```
+        ageModule.getAge(birthday)
+        ```
     
 !!! info "Related topics"
     - [Concept: Adaptive-Authentication](../../../references/concepts/authentication/adaptive-authentication)

--- a/en/docs/guides/adaptive-auth/work-with-acr-amr.md
+++ b/en/docs/guides/adaptive-auth/work-with-acr-amr.md
@@ -65,26 +65,32 @@ Send the following requests via your application to connect your application to 
 
 1. To initiate the authentication flow, update the placeholders and send the following request to the authorization endpoint.
 
-    ```tab="Request Format"
-    https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=code&scope=openid&client_id=<CLIENT_ID>
-    &redirect_uri=<CALLBACK_URL>&acr_values=<ACR_VALUES>
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?response_type=code&scope=openid&client_id=Q7zSTBiNb3vwe8dWhUMEBh5sE4ka&redirect_uri=http://localhost:8080/playground2/oauth2client&acr_values=LOA1+LOA2+LOA3
-    ```		
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=code&scope=openid&client_id=<CLIENT_ID>
+        &redirect_uri=<CALLBACK_URL>&acr_values=<ACR_VALUES>
+        ```
+        ---
+        **Sample Request**
+        ```
+        https://localhost:9443/oauth2/authorize?response_type=code&scope=openid&client_id=Q7zSTBiNb3vwe8dWhUMEBh5sE4ka&redirect_uri=http://localhost:8080/playground2/oauth2client&acr_values=LOA1+LOA2+LOA3
+        ```		
 		    
 2. Log in using `admin` as the username and password. 
 
 3. Provide your consent to share the necessary data. Note that you get redirected to a URL similar to the following.
 
-    ```tab="Request Format"
-    <CALLBACK_URL>?code=<<AUTHORIZATION_CODE>>
-    ```
-
-    ```tab="Sample Request"
-    <CALLBACK_URL>?code=e1934548d0a0883dd5734e24412310
-    ```	
+    !!! abstract ""
+        **Request Format**
+        ```
+        <CALLBACK_URL>?code=<<AUTHORIZATION_CODE>>
+        ```
+        ---
+        **Sample Request**
+        ```
+        <CALLBACK_URL>?code=e1934548d0a0883dd5734e24412310
+        ```	
     
 4. Copy the `AUTHORIZATION_CODE` for later use.
 
@@ -94,62 +100,84 @@ Send the following requests via your application to connect your application to 
 
 		The `CLIENT_SECRET` and `CALLBACK_URL` are the client secret and callback URL of the service provider that you configured for the application in WSO2 Identity Server.
 
-	  ``` tab="Format"
-	  curl -v -X POST --basic -u <CLIENT_ID>:<CLIENT_SECRET> -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "client_id=<CLIENT_ID>&grant_type=authorization_code&code=<AUTHORIZATION_CODE>&redirect_uri=<CALLBACK_URL>" https://<IS_HOST>:<IS_PORT>/oauth2/token
-	  ```
-
-	  ``` tab="Example"
-	  curl -v -X POST --basic -u 5vOQZVfoOHLmtXbNHJpYXc7ZLuca:O9LF9cMgKAoowYu4YQrHpmnjRBwa -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "client_id=Q7zSTBiNb3vwe8dWhUMEBh5sE4ka&grant_type=authorization_code&code=86650268-5637-311c-9a08-4066727d656f&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
-	  ```
+    !!! abstract ""
+        **Format**
+        ```
+        curl -v -X POST --basic -u <CLIENT_ID>:<CLIENT_SECRET> -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "client_id=<CLIENT_ID>&grant_type=authorization_code&code=<AUTHORIZATION_CODE>&redirect_uri=<CALLBACK_URL>" https://<IS_HOST>:<IS_PORT>/oauth2/token
+        ```
+        ---
+        **Example**
+        ```
+        curl -v -X POST --basic -u 5vOQZVfoOHLmtXbNHJpYXc7ZLuca:O9LF9cMgKAoowYu4YQrHpmnjRBwa -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "client_id=Q7zSTBiNb3vwe8dWhUMEBh5sE4ka&grant_type=authorization_code&code=86650268-5637-311c-9a08-4066727d656f&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
+        ```
 
 	An access token similar to the following appears. 
 	
-	  ``` tab="Format"
-      {"access_token":"1b87d316-a107-3174-a71d-ac438a54719b","refresh_token":"60a66d57-0e48-3896-98e7-00213acee104","scope":"openid","id_token":"<ID_TOKEN>","token_type":"Bearer","expires_in":2554}
-      ```
-    
-      ``` tab="Example"
-      {"access_token":"1b87d316-a107-3174-a71d-ac438a54719b","refresh_token":"60a66d57-0e48-3896-98e7-00213acee104",
-      "scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoiVFdlYWp5dE1TQU0zX1k3Q09mQm4yUSIsImF1ZCI6IjV2T1FaVmZvT0hMbXRYYk5ISnBZWGM3Wkx1Y2EiLCJhY3IiOiJhY3IyIiwiY19oYXNoIjoiVFN1b0Z2eHlybEdCZkxQZW1ZbEt3USIsInN1YiI6ImFkbWluIiwibmJmIjoxNTkxOTQ0ODk1LCJhenAiOiI1dk9RWlZmb09ITG10WGJOSEpwWVhjN1pMdWNhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE1OTE5NDg0OTUsImlhdCI6MTU5MTk0NDg5NSwic2lkIjoiMjBmODlmYzctNDRkZC00MjNkLTlkNDktZGRjMTVlNWVmNGRlIn0.d7WpY220UTZ10zCg-DBmKr-0f0k2tbYk00xqJoTmN2oNmP5u6x8_kUIASSeeP2p1LDeHuT6IQb045YCJDStsiSpwD0XUtTrFPJoRFUiIDgzXBQCBz8pzCjv2w-AMj8hJu965nSbwqCt-20OjKDPb187jiMyAxYMpU0o9Zk470whrkZQkC2SA16KhKdrIwpHHiiOI0pX-LdSsrZFzsw2ZWQmlzdRh4xoN6wTsLI9jhxz52mqs0Ghea9MlVFeVuIf6BeFN8ZpwzsnpVbSO9g4ZCZVYz3dtuiIaBQgoYy3E0SMG1QdxGgg7nYg0NQd-wfInYuhik0BSSrLKmJhff5YHaQ","token_type":"Bearer","expires_in":2554}
-      ```
+    !!! abstract ""
+        **Format**
+        ```
+        {
+            "access_token":"1b87d316-a107-3174-a71d-ac438a54719b",
+            "refresh_token":"60a66d57-0e48-3896-98e7-00213acee104",
+            "scope":"openid",
+            "id_token":"<ID_TOKEN>",
+            "token_type":"Bearer",
+            "expires_in":2554
+        }
+        ```
+        ---
+        **Example**
+        ```
+        {
+            "access_token":"1b87d316-a107-3174-a71d-ac438a54719b",
+            "refresh_token":"60a66d57-0e48-3896-98e7-00213acee104",
+            "scope":"openid",
+            "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoiVFdlYWp5dE1TQU0zX1k3Q09mQm4yUSIsImF1ZCI6IjV2T1FaVmZvT0hMbXRYYk5ISnBZWGM3Wkx1Y2EiLCJhY3IiOiJhY3IyIiwiY19oYXNoIjoiVFN1b0Z2eHlybEdCZkxQZW1ZbEt3USIsInN1YiI6ImFkbWluIiwibmJmIjoxNTkxOTQ0ODk1LCJhenAiOiI1dk9RWlZmb09ITG10WGJOSEpwWVhjN1pMdWNhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE1OTE5NDg0OTUsImlhdCI6MTU5MTk0NDg5NSwic2lkIjoiMjBmODlmYzctNDRkZC00MjNkLTlkNDktZGRjMTVlNWVmNGRlIn0.d7WpY220UTZ10zCg-DBmKr-0f0k2tbYk00xqJoTmN2oNmP5u6x8_kUIASSeeP2p1LDeHuT6IQb045YCJDStsiSpwD0XUtTrFPJoRFUiIDgzXBQCBz8pzCjv2w-AMj8hJu965nSbwqCt-20OjKDPb187jiMyAxYMpU0o9Zk470whrkZQkC2SA16KhKdrIwpHHiiOI0pX-LdSsrZFzsw2ZWQmlzdRh4xoN6wTsLI9jhxz52mqs0Ghea9MlVFeVuIf6BeFN8ZpwzsnpVbSO9g4ZCZVYz3dtuiIaBQgoYy3E0SMG1QdxGgg7nYg0NQd-wfInYuhik0BSSrLKmJhff5YHaQ",
+            "token_type":"Bearer",
+            "expires_in":2554
+        }
+        ```
     	        
 6. Copy the `ID_TOKEN` and decode with Base64. The decoded `ID_TOKEN` will look similar to the following. 
 
-	 ``` tab="Format"
-	 {
-	  "at_hash": "<Access token hash value>",
-	  "aud": "<Audience that the ID token is intended for>",
-	  "c_hash": "<Code hash value>",
-	  "sub": "<Subject>",
-	  "acr": "<ACR>", 
-	  "nbf": <Epoch time before which the JWT must not be accepted for processing>,
-	  "azp": "<Authorized party>",
-	  "amr": [<Authentications Method Reference>],
-	  "iss": "<The token endpoint that issued the token>",
-	  "exp": <Epoch time of the token expiration date/time>,
-	  "iat": <Epoch time of the token issuance date/time>
-	 }
-	 ```
-
-	 ``` tab="Example"
-	 {
-      "at_hash": "6OXwfxJaTWYC56RccEhSJg",
-      "aud": "EUVvhKM28RkwTQL9A52kqXnfCj8a",
-      "acr": "LOA2",
-      "c_hash": "lDj9nihZGSUmgNmz_lxxXA",
-      "sub": "admin",
-      "nbf": 1548396413,
-      "azp": "EUVvhKM28RkwTQL9A52kqXnfCj8a",
-      "amr": [
-              "DemoFaceIdAuthenticator",
-              "BasicAuthenticator",
-              "DemoFingerprintAuthenticator"
-      ],
-      "iss": "https://localhost:9443/oauth2/token",
-      "exp": 1548400013,
-      "iat": 1548396413
-     }
-	 ```
+    !!! abstract ""
+        **Format**
+        ```
+        {
+            "at_hash": "<Access token hash value>",
+            "aud": "<Audience that the ID token is intended for>",
+            "c_hash": "<Code hash value>",
+            "sub": "<Subject>",
+            "acr": "<ACR>", 
+            "nbf": <Epoch time before which the JWT must not be accepted for processing>,
+            "azp": "<Authorized party>",
+            "amr": [<Authentications Method Reference>],
+            "iss": "<The token endpoint that issued the token>",
+            "exp": <Epoch time of the token expiration date/time>,
+            "iat": <Epoch time of the token issuance date/time>
+        }
+        ```
+        ---
+        **Example**
+        ```
+        {
+            "at_hash": "6OXwfxJaTWYC56RccEhSJg",
+            "aud": "EUVvhKM28RkwTQL9A52kqXnfCj8a",
+            "acr": "LOA2",
+            "c_hash": "lDj9nihZGSUmgNmz_lxxXA",
+            "sub": "admin",
+            "nbf": 1548396413,
+            "azp": "EUVvhKM28RkwTQL9A52kqXnfCj8a",
+            "amr": [
+                    "DemoFaceIdAuthenticator",
+                    "BasicAuthenticator",
+                    "DemoFingerprintAuthenticator"
+            ],
+            "iss": "https://localhost:9443/oauth2/token",
+            "exp": 1548400013,
+            "iat": 1548396413
+        }
+        ```
 	
 	Note that the AMR values in this example are `DemoFaceIdAuthenticator`, `BasicAuthenticator`, and `DemoFingerprintAuthenticator`.
 	These are the authenticators that are used in the authentication process.

--- a/en/docs/guides/basic-auth-request-path.md
+++ b/en/docs/guides/basic-auth-request-path.md
@@ -41,14 +41,16 @@ Send the following requests via your application using the `<SEC_TOKEN>` in the 
     
 Replace the ` <SEC_TOKEN>`, `<CLIENT_ID>`, `<IS_HOST>`, `<IS_PORT>` and `<CALLBACK_URL>` tags with the relevant values.
 
-    
-```tab="Request Format"
-curl -v -X POST -H "Authorization: Basic <SEC_TOKEN>" -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "response_type=code&client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&scope=openid&prompt=none"  http://<IS_HOST>:<IS_PORT>/oauth2/authorize
-```
-
-```tab="Response Format"
-Location: <callback_url>?code=<code>&session_state=<session_state>
-```
+!!! abstract ""
+    **Request Format**   
+    ```
+    curl -v -X POST -H "Authorization: Basic <SEC_TOKEN>" -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "response_type=code&client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&scope=openid&prompt=none"  http://<IS_HOST>:<IS_PORT>/oauth2/authorize
+    ```
+    ---
+    **Response Format**
+    ```
+    Location: <callback_url>?code=<code>&session_state=<session_state>
+    ```
 
 !!! note
     RequestPath authentication will only skip prompting the login page and not the consent page.

--- a/en/docs/guides/identity-lifecycles/add-user-roles.md
+++ b/en/docs/guides/identity-lifecycles/add-user-roles.md
@@ -28,13 +28,28 @@ The sample request given below adds a group named "engineer" with the user "Mark
 curl -v -k --user {IS_USERNAME}:{IS_PASSWORD} --data '{"displayName": {GROUP_NAME},"members": {MEMBERS_OF_THE_GROUP}}' --header "Content-Type:application/json" https://{IS_IP}:{IS_PORT}/wso2/scim2/Groups
 ```
 
-``` tab="Sample Request"
-curl -v -k --user admin:admin --data '{"displayName": "engineer","members": [{"value":"008bba85-451d-414b-87de-c03b5a1f4217","Mark": "Mark"}]}' --header "Content-Type:application/json" https://localhost:9443/wso2/scim2/Groups
-```
-
-``` tab="Sample Response"
-{"id":"7bac6a86-1f21-4937-9fb1-5be4a93ef469","schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"PRIMARY/engineer","members":[{"value":"008bba85-451d-414b-87de-c03b5a1f4217","display":"Mark"}],"meta":{"lastModified":"2020-04-26T18:31:57","created":"2020-04-26T18:31:57","location":"https://localhost:9443/scim2/Groups/7bac6a86-1f21-4937-9fb1-5be4a93ef469"}}
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    curl -v -k --user admin:admin --data '{"displayName": "engineer","members": [{"value":"008bba85-451d-414b-87de-c03b5a1f4217","Mark": "Mark"}]}' --header "Content-Type:application/json" https://localhost:9443/wso2/scim2/Groups
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "id":"7bac6a86-1f21-4937-9fb1-5be4a93ef469",
+        "schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName":"PRIMARY/engineer",
+        "members":[
+            {"value":"008bba85-451d-414b-87de-c03b5a1f4217","display":"Mark"}
+        ],
+        "meta":{
+            "lastModified":"2020-04-26T18:31:57",
+            "created":"2020-04-26T18:31:57",
+            "location":"https://localhost:9443/scim2/Groups/7bac6a86-1f21-4937-9fb1-5be4a93ef469"
+        }
+    }
+    ```
 
 You receive a response with the payload as indicated above and a
 response status `           201 CREATED          `.

--- a/en/docs/guides/identity-lifecycles/admin-creation-workflow.md
+++ b/en/docs/guides/identity-lifecycles/admin-creation-workflow.md
@@ -30,13 +30,44 @@ curl -v -k --user [username]:[password] --data '{"schemas":[],"name":{"familyNam
 
 Below is a sample request to create a user and its corresponding response using SCIM 2.0. 
 
-```tab="Sample Request"
-curl -v -k --user admin:admin --data '{"schemas":[],"name":{"familyName":"jackson","givenName":"kim"},"userName":"kim","password":"kimwso2","emails":[{"primary":true,"value":"kim.jackson@gmail.com","type":"home"},{"value":"kim_j@wso2.com","type":"work"}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users
-```
-
-```tab="Sample Response"
-{"emails":[{"type":"home","value":"kim.jackson@gmail.com","primary":true},{"type":"work","value":"kim_j@wso2.com"}],"meta":{"created":"2018-08-15T14:55:23Z","location":"https://localhost:9443/scim2/Users/c8c821ba-1200-495e-a775-79b260e717bd","lastModified":"2018-08-15T14:55:23Z","resourceType":"User"},"schemas":["urn:ietf:params:scim:schemas:core:2.0:User","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],"name":{"familyName":"jackson","givenName":"kim"},"id":"c8c821ba-1200-495e-a775-79b260e717bd","userName":"kim"}
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    curl -v -k --user admin:admin --data '{"schemas":[],"name":{"familyName":"jackson","givenName":"kim"},"userName":"kim","password":"kimwso2","emails":[{"primary":true,"value":"kim.jackson@gmail.com","type":"home"},{"value":"kim_j@wso2.com","type":"work"}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "emails":[
+            {
+                "type":"home",
+                "value":"kim.jackson@gmail.com",
+                "primary":true
+            },
+            {
+                "type":"work",
+                "value":"kim_j@wso2.com"
+            }
+        ],
+        "meta":{
+            "created":"2018-08-15T14:55:23Z",
+            "location":"https://localhost:9443/scim2/Users/c8c821ba-1200-495e-a775-79b260e717bd",
+            "lastModified":"2018-08-15T14:55:23Z",
+            "resourceType":"User"
+        },
+        "schemas":[
+            "urn:ietf:params:scim:schemas:core:2.0:User",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        ],
+        "name":{
+            "familyName":"jackson",
+            "givenName":"kim"
+        },
+        "id":"c8c821ba-1200-495e-a775-79b260e717bd",
+        "userName":"kim"
+    }
+    ```
 
 
 !!! info "Related topics"

--- a/en/docs/guides/identity-lifecycles/delete-users.md
+++ b/en/docs/guides/identity-lifecycles/delete-users.md
@@ -20,13 +20,16 @@ This section guides you through deleting an exisiting user in WSO2 Identity Serv
 
 ## Delete a user using SCIM 2.0 REST API
 
-```curl tab="Request"
-curl -v -k --user {IS_USERNAME}:{IS_PASSWORD} -X DELETE https://{IS_IP}:{IS_PORT}/wso2/scim/Users/{SCIM_USER_ID} -H "Accept: application/json"
-```
-
-```curl tab="Sample Request"
-curl -v -k --user admin:admin -X DELETE https://localhost:9443/wso2/scim/Users/b228b59d-db19-4064-b637-d33c31209fae -H "Accept: application/json"
-```
+!!! abstract ""
+    **Request**
+    ```
+    curl -v -k --user {IS_USERNAME}:{IS_PASSWORD} -X DELETE https://{IS_IP}:{IS_PORT}/wso2/scim/Users/{SCIM_USER_ID} -H "Accept: application/json"
+    ```
+    ---
+     **Sample Request**
+    ```curl
+    curl -v -k --user admin:admin -X DELETE https://localhost:9443/wso2/scim/Users/b228b59d-db19-4064-b637-d33c31209fae -H "Accept: application/json"
+    ```
 
 You receive a response with status `200 OK` and the user will be deleted from the userstore.
     

--- a/en/docs/guides/identity-lifecycles/enable-account.md
+++ b/en/docs/guides/identity-lifecycles/enable-account.md
@@ -100,13 +100,16 @@ steps below.
 
 1.	In order to update the status of a user account, we need to obtain the SCIM ID of that particular user. Therefore, we first call the GET users API to get the user details. The following curl command gives details of alk the users including the SCIM IDs. 
 
-	``` curl tab="Request"
-	curl -v -k --user <username>:<password> 'https://<HOST>:<PORT>/scim2/Users'
-	```
-
-	``` curl tab="Sample"
-	curl -v -k --user admin:admin 'https://localhost:9443/scim2/Users'
-	```
+    !!! abstract ""
+        **Request**
+        ```
+        curl -v -k --user <username>:<password> 'https://<HOST>:<PORT>/scim2/Users'
+        ```
+        ---
+        **Sample**
+        ```curl
+        curl -v -k --user admin:admin 'https://localhost:9443/scim2/Users'
+        ```
 
 	Alternatively, you can also obtain it from the management console. 
 

--- a/en/docs/guides/identity-lifecycles/enable-email-account-verification-for-an-updated-email-address.md
+++ b/en/docs/guides/identity-lifecycles/enable-email-account-verification-for-an-updated-email-address.md
@@ -74,13 +74,16 @@ This feature can also be invoked via a PUT/PATCH request to SCIM 2.0 /Users endp
 
 Given below is a sample request and the relevant response for updating the email address via a PATCH operation to SCIM 2.0 Users endpoint.
 
-```curl tab="Request"
-curl -v -k --user [username]:[password] -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations":[{"op":[operation], "value":{ "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"verifyEmail": [true/false]}, "emails":[{"primary":true, "value":[new email]}]}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/[user ID]
-```
-
-```curl tab="Example" 
-curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations":[{"op":"replace","value":{ "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"verifyEmail": "true"}, "emails":[{"primary":true,"value":"kim.jackson.new@gmail.com"}]}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/1e624046-520c-4628-a245-091e04b03f21
-```
+!!! abstract ""
+    **Request**
+    ```
+    curl -v -k --user [username]:[password] -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations":[{"op":[operation], "value":{ "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"verifyEmail": [true/false]}, "emails":[{"primary":true, "value":[new email]}]}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/[user ID]
+    ```
+    ---
+    **Example**
+    ```curl
+    curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations":[{"op":"replace","value":{ "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"verifyEmail": "true"}, "emails":[{"primary":true,"value":"kim.jackson.new@gmail.com"}]}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/1e624046-520c-4628-a245-091e04b03f21
+    ```
 
 **Sample Response**
 
@@ -143,13 +146,16 @@ curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: applic
 
 **Sample**
 
-```curl tab="Request"
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user":{"username": "admin","realm": "PRIMARY"},"properties": [{"key":"RecoveryScenario","value":"EMAIL_VERIFICATION_ON_UPDATE"}]}' "https://localhost:9443/api/identity/user/v1.0/resend-code" -k -v
-```
-
-```curl tab="Response"
-HTTP/1.1 201 Created
-```
+!!! abstract ""
+    **Request**
+    ```
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user":{"username": "admin","realm": "PRIMARY"},"properties": [{"key":"RecoveryScenario","value":"EMAIL_VERIFICATION_ON_UPDATE"}]}' "https://localhost:9443/api/identity/user/v1.0/resend-code" -k -v
+    ```
+    ---
+    **Response**
+    ```curl
+    HTTP/1.1 201 Created
+    ```
 
 !!! info "Related topics"
     See [Using the SCIM 2.0 Rest APIs](../../../develop/apis/scim2-rest-apis) for instructions on using SCIM 2.0 REST APIs.

--- a/en/docs/guides/identity-lifecycles/enable-verification-for-updated-mobile-number.md
+++ b/en/docs/guides/identity-lifecycles/enable-verification-for-updated-mobile-number.md
@@ -78,61 +78,59 @@ When a user updates their mobile number in the user profile, an SMS OTP is sent 
  
 Given below is a sample request and the relevant response for updating the mobile number via a PATCH operation to SCIM 2.0 Users endpoint.
 
-**Request**
-
-```curl
-curl -v -k --user [username]:[password] -X PATCH -d '{"schemas":[],"Operations":[{"op":[operation],
-"value":{[attributeName]:[attribute value]}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/[user ID]
-```
-
-**Sample Request**
-
-```curl
-curl -v -k --user bob:pass123 -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-"Operations":[{"op":"replace","value":{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"verifyMobile": "true"},
-"phoneNumbers":[{"type":"mobile","value":"0123456789"}]}}]}' 
---header "Content-Type:application/json" https://localhost:9443/scim2/Users/1e624046-520c-4628-a245-091e04b03f21
-```
-
-**Sample Response**
-
-```
-{
-    "emails": [
-        "bobsmith@abc.com"
-    ],
-    "meta": {
-        "location": "https://localhost:9443/scim2/Users/6d433ee7-7cd4-47a3-810b-bc09023bc2ce",
-        "lastModified": "2020-10-12T13:35:24.579Z",
-        "resourceType": "User"
-    },
-    "schemas": [
-        "urn:ietf:params:scim:schemas:core:2.0:User",
-        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-    ],
-    "roles": [
-        {
-            "type": "default",
-            "value": "Internal/everyone"
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -v -k --user [username]:[password] -X PATCH -d '{"schemas":[],"Operations":[{"op":[operation],
+    "value":{[attributeName]:[attribute value]}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/[user ID]
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -v -k --user bob:pass123 -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations":[{"op":"replace","value":{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {"verifyMobile": "true"},
+    "phoneNumbers":[{"type":"mobile","value":"0123456789"}]}}]}' 
+    --header "Content-Type:application/json" https://localhost:9443/scim2/Users/1e624046-520c-4628-a245-091e04b03f21
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "emails": [
+            "bobsmith@abc.com"
+        ],
+        "meta": {
+            "location": "https://localhost:9443/scim2/Users/6d433ee7-7cd4-47a3-810b-bc09023bc2ce",
+            "lastModified": "2020-10-12T13:35:24.579Z",
+            "resourceType": "User"
+        },
+        "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:User",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        ],
+        "roles": [
+            {
+                "type": "default",
+                "value": "Internal/everyone"
+            }
+        ],
+        "name": {
+            "givenName": "Bob",
+            "familyName": "Smith"
+        },
+        "id": "6d433ee7-7cd4-47a3-810b-bc09023bc2ce",
+        "userName": "bob123",
+        "phoneNumbers": [
+            {
+                "type": "mobile",
+                "value": "0111111111"
+            }
+        ],
+        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+            "pendingMobileNumber": "0123456789"
         }
-    ],
-    "name": {
-        "givenName": "Bob",
-        "familyName": "Smith"
-    },
-    "id": "6d433ee7-7cd4-47a3-810b-bc09023bc2ce",
-    "userName": "bob123",
-    "phoneNumbers": [
-        {
-            "type": "mobile",
-            "value": "0111111111"
-        }
-    ],
-    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
-        "pendingMobileNumber": "0123456789"
     }
-}
-```
+    ```
 
 Upon receiving the response given above, the user will receive an SMS notification with a verification code to the new mobile number. 
  
@@ -141,56 +139,51 @@ Upon receiving the response given above, the user will receive an SMS notificati
 The user can submit the SMS OTP code using the validate-code API.
 Given below is a sample request and the relevant response to submit the received verification code.
 
-**Request**
-
-```curl
-curl -k -v -X POST -H "Authorization: <Base64Encoded_username:password>" -H "Content-Type: application/json" -d 
-'{ "code": "<validation_code>","properties": []}' "https://localhost:9443/api/identity/user/v1.0/me/validate-code"
-```
-
-**Sample Request**
-
-```curl
-curl -k -v -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "123ABC","properties": []}'
- "https://localhost:9443/api/identity/user/v1.0/me/validate-code"
-```
-
-**Response**
-
-```
-"HTTP/1.1 202 Accepted"
-```
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -k -v -X POST -H "Authorization: <Base64Encoded_username:password>" -H "Content-Type: application/json" -d 
+    '{ "code": "<validation_code>","properties": []}' "https://localhost:9443/api/identity/user/v1.0/me/validate-code"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -k -v -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "123ABC","properties": []}'
+    "https://localhost:9443/api/identity/user/v1.0/me/validate-code"
+    ```
+    ---
+    **Response**
+    ```
+    "HTTP/1.1 202 Accepted"
+    ```
 
 ### Resend the verification code
 
 The user can request to resend a new SMS OTP code using the resend-code API.
 Given below is a sample request and the relevant response to request a new verification code.
 
-**Request**
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic <Base64Encoded_username:password>" -H "Content-Type: application/json" -d '{"properties": []}' 
+    "https://localhost:9443/api/identity/user/v1.0/me/resend-code"
+    ```
 
-```curl
-curl -X POST -H "Authorization: Basic <Base64Encoded_username:password>" -H "Content-Type: application/json" -d '{"properties": []}' 
-"https://localhost:9443/api/identity/user/v1.0/me/resend-code"
-```
-
-The verification scenario should be specified in the properties parameter of the request body as follows :
-
-```
-"properties": [{"key":"RecoveryScenario","value": "MOBILE_VERIFICATION_ON_UPDATE"}]
-```
-
-**Sample Request**
-
-```curl
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"properties": [{"key":"RecoveryScenario","value": "MOBILE_VERIFICATION_ON_UPDATE"}]}' 
-"https://localhost:9443/api/identity/user/v1.0/me/resend-code"
-```
-
-**Response**
-
-```
-"HTTP/1.1 201 Created"
-```
+    The verification scenario should be specified in the properties parameter of the request body as follows :
+    ```
+    "properties": [{"key":"RecoveryScenario","value": "MOBILE_VERIFICATION_ON_UPDATE"}]
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"properties": [{"key":"RecoveryScenario","value": "MOBILE_VERIFICATION_ON_UPDATE"}]}' 
+    "https://localhost:9443/api/identity/user/v1.0/me/resend-code"
+    ```
+    ---
+    **Response**
+    ```
+    "HTTP/1.1 201 Created"
+    ```
 
 ---
 

--- a/en/docs/guides/identity-lifecycles/import-users.md
+++ b/en/docs/guides/identity-lifecycles/import-users.md
@@ -15,13 +15,32 @@ curl -v -k --user [username]:[password] --data '{"failOnErrors": [value],"schema
 
 Below is a sample request and its corresponding response using SCIM 2.0. 
 
-```tab="Sample Request"
-curl -v -k --user admin:admin --data '{"failOnErrors":1,"schemas":["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],"Operations":[{"method": "POST","path": "/Users","bulkId": "qwerty","data":{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName": "Kris","password":"krispass"}},{"method": "POST","path": "/Users","bulkId":"ytrewq","data":{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],"userName":"Jesse","password":"jessepass","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"employeeNumber": "11250","manager": {"value": "bulkId:qwerty"}}}}]}' --header "Content-Type:application/scim+json" https://localhost:9443/scim2/Bulk
-```
-
-```tab="Sample Response"
-{"schemas":["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],"Operations":[{"bulkId":"qwerty","method":"POST","location":"https://localhost:9443/scim2/Users/81cbba1b-c259-485d-8ba4-79afb03e5bd1","status":{"code":201}},{"bulkId":"ytrewq","method":"POST","location":"https://localhost:9443/scim2/Users/b489dacc-fc89-449c-89f6-7acc37422031","status":{"code":201}}]}
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    curl -v -k --user admin:admin --data '{"failOnErrors":1,"schemas":["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],"Operations":[{"method": "POST","path": "/Users","bulkId": "qwerty","data":{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName": "Kris","password":"krispass"}},{"method": "POST","path": "/Users","bulkId":"ytrewq","data":{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],"userName":"Jesse","password":"jessepass","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"employeeNumber": "11250","manager": {"value": "bulkId:qwerty"}}}}]}' --header "Content-Type:application/scim+json" https://localhost:9443/scim2/Bulk
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "schemas":["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],
+        "Operations":[
+            {
+                "bulkId":"qwerty",
+                "method":"POST",
+                "location":"https://localhost:9443/scim2/Users/81cbba1b-c259-485d-8ba4-79afb03e5bd1",
+                "status":{"code":201}
+            },
+            {
+                "bulkId":"ytrewq",
+                "method":"POST",
+                "location":"https://localhost:9443/scim2/Users/b489dacc-fc89-449c-89f6-7acc37422031",
+                "status":{"code":201}
+            }
+        ]
+    }
+    ```
 
 ---
 

--- a/en/docs/guides/identity-lifecycles/lock-account.md
+++ b/en/docs/guides/identity-lifecycles/lock-account.md
@@ -49,13 +49,16 @@ account locking, follow the instructions given below.
 
 1. In order to update the lock status of a user account, we need to obtain the SCIM ID of that particular user. Therefore, we first call the GET users API to get the user details.
 
-	``` curl tab="Request"
-	curl -v -k --user <username>:<password> 'https://<HOST>:<PORT>/scim2/Users'
-	```
-
-	``` curl tab="Sample"
-	curl -v -k --user admin:admin 'https://localhost:9443/scim2/Users'
-	```
+    !!! abstract ""
+        **Request**
+        ```
+        curl -v -k --user <username>:<password> 'https://<HOST>:<PORT>/scim2/Users'
+        ```
+        ---
+        **Sample**
+        ```
+        curl -v -k --user admin:admin 'https://localhost:9443/scim2/Users'
+        ```
 
 	Alternatively, you can also obtain it from the management console. 
 

--- a/en/docs/guides/identity-lifecycles/recover-username.md
+++ b/en/docs/guides/identity-lifecycles/recover-username.md
@@ -16,13 +16,16 @@ You can use the following CURL command to recover a username using REST API.
 curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '[{"uri": "http://wso2.org/claims/givenname","value": "[USERNAME]"},{"uri": "[CLAIM URI]", "value": "[CLAIM VALUE]"},{"uri": "[CLAIM2 URI]","value": "[CLAIM2 VALUE]" }]' "https://localhost:9443/api/identity/recovery/v0.9/recover-username/"
 ```
 
-```curl tab="Sample Request"
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '[{"uri": "http://wso2.org/claims/givenname","value": "kim"},{"uri": "http://wso2.org/claims/emailaddress", "value": "kim.anderson@gmail.com"},{"uri": "http://wso2.org/claims/lastname","value": "Anderson" }]' "https://localhost:9443/api/identity/recovery/v0.9/recover-username/"
-```
-
-```curl tab="Sample Response"
-"HTTP/1.1 202 Accepted" 
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '[{"uri": "http://wso2.org/claims/givenname","value": "kim"},{"uri": "http://wso2.org/claims/emailaddress", "value": "kim.anderson@gmail.com"},{"uri": "http://wso2.org/claims/lastname","value": "Anderson" }]' "https://localhost:9443/api/identity/recovery/v0.9/recover-username/"
+    ```
+    ---
+    **Sample Response**
+    ```
+    "HTTP/1.1 202 Accepted" 
+    ```
 
 !!! info "Related topics"
     -   [Concept: Users](../../../references/concepts/user-management/users/)

--- a/en/docs/guides/identity-lifecycles/search-users.md
+++ b/en/docs/guides/identity-lifecycles/search-users.md
@@ -44,13 +44,28 @@ curl -v -k --user [username]:[password] --data '{"schemas": ["urn:ietf:params:sc
 
 Below is a sample request and its corresponding response to search for users using SCIM 2.0. 
 
-```tab="Sample Request"
-curl -v -k --user admin:admin --data '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:SearchRequest"],"attributes": ["name.familyName", "userName"],"filter":"userName sw ki and name.familyName co ack","domain":"PRIMARY","startIndex": 1,"count": 10}' --header "Content-Type:application/scim+json"  'https://localhost:9443/scim2/Users/.search'
-```
-
-```tab="Sample Response"
-{"totalResults":1,"startIndex":1,"itemsPerPage":1,"schemas":["urn:ietf:params:scim:api:messages:2.0:ListResponse"],"Resources":[{"name":{"familyName":"jackson"},"id":"c8c821ba-1200-495e-a775-79b260e717bd","userName":"kim"}]}
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    curl -v -k --user admin:admin --data '{"schemas": ["urn:ietf:params:scim:api:messages:2.0:SearchRequest"],"attributes": ["name.familyName", "userName"],"filter":"userName sw ki and name.familyName co ack","domain":"PRIMARY","startIndex": 1,"count": 10}' --header "Content-Type:application/scim+json"  'https://localhost:9443/scim2/Users/.search'
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "totalResults":1,
+        "startIndex":1,
+        "itemsPerPage":1,
+        "schemas":["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+        "Resources":[
+            {
+                "name":{"familyName":"jackson"},
+                "id":"c8c821ba-1200-495e-a775-79b260e717bd",
+                "userName":"kim"
+            }
+        ]
+    }
+    ```
 
 
 !!! info "Related topics"

--- a/en/docs/guides/identity-lifecycles/self-registration-workflow.md
+++ b/en/docs/guides/identity-lifecycles/self-registration-workflow.md
@@ -257,13 +257,16 @@ The following CURL command can be used to self register.
 curl -X POST -H "Authorization: Basic <Base64Encoded_username:password>" -H "Content-Type: application/json" -d '{"user": {"username": "<username>","realm": "<user_store>", "password": "<password>","claims": [{"uri": "<claim_URI>","value": "<claim_value>" },{"uri": "<claim_URI2>","value": "<claim_value2>"},{"uri": "<claim_URI3>","value": "<claim_value3>"},{"uri": "<claim_URI4>","value": "<claim_value4>"} ] },"properties": []}' "https://localhost:9443/api/identity/user/v1.0/me"
 ```
 
-```curl tab="Sample Request"
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user": {"username": "kim","realm": "PRIMARY", "password": "Password12!","claims": [{"uri": "http://wso2.org/claims/givenname","value": "kim" },{"uri": "http://wso2.org/claims/emailaddress","value": "kim.anderson@gmail.com"},{"uri": "http://wso2.org/claims/lastname","value": "Anderson"},{"uri": "http://wso2.org/claims/mobile","value": "+947721584558"} ] },"properties": [{"key":"callback","value": "https://localhost:9443/authenticationendpoint/login.do"}]}' "https://localhost:9443/api/identity/user/v1.0/me"
-```
-
-```curl tab="Sample Response"
-"HTTP/1.1 201 Created"
-``` 
+!!! abstract ""
+    **Sample Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user": {"username": "kim","realm": "PRIMARY", "password": "Password12!","claims": [{"uri": "http://wso2.org/claims/givenname","value": "kim" },{"uri": "http://wso2.org/claims/emailaddress","value": "kim.anderson@gmail.com"},{"uri": "http://wso2.org/claims/lastname","value": "Anderson"},{"uri": "http://wso2.org/claims/mobile","value": "+947721584558"} ] },"properties": [{"key":"callback","value": "https://localhost:9443/authenticationendpoint/login.do"}]}' "https://localhost:9443/api/identity/user/v1.0/me"
+    ```
+    ---
+    **Sample Response**
+    ```curl
+    "HTTP/1.1 201 Created"
+    ``` 
 
 
 !!! info "Related topics"

--- a/en/docs/guides/identity-lifecycles/update-profile.md
+++ b/en/docs/guides/identity-lifecycles/update-profile.md
@@ -32,13 +32,38 @@ curl -v -k --user [username]:[password] -X PATCH -d '{"schemas":[],"Operations":
 
 Below is a sample request and its corresponding response using SCIM 2.0. 
 
-```tab="Sample Request"
-curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"add","value":{"nickName":"shaggy"}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/c8c821ba-1200-495e-a775-79b260e717bd
-```
-
-```tab="Sample Response"
-{"emails":[{"type":"work","value":"kim_j@wso2.com"},{"type":"home","value":"kim.jack@gmail.com"}],"meta":{"created":"2018-08-15T14:55:23Z","location":"https://localhost:9443/scim2/Users/c8c821ba-1200-495e-a775-79b260e717bd","lastModified":"2018-08-16T14:46:07Z","resourceType":"User"},"nickName":"shaggy","schemas":["urn:ietf:params:scim:schemas:core:2.0:User","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],"roles":[{"type":"default","value":"Internal/everyone"}],"name":{"givenName":"kim","familyName":"jackson"},"id":"c8c821ba-1200-495e-a775-79b260e717bd","userName":"kim"}
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"add","value":{"nickName":"shaggy"}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/c8c821ba-1200-495e-a775-79b260e717bd
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "emails":[
+            {"type":"work","value":"kim_j@wso2.com"},
+            {"type":"home","value":"kim.jack@gmail.com"}
+        ],
+        "meta":{
+            "created":"2018-08-15T14:55:23Z",
+            "location":"https://localhost:9443/scim2/Users/c8c821ba-1200-495e-a775-79b260e717bd",
+            "lastModified":"2018-08-16T14:46:07Z",
+            "resourceType":"User"
+        },
+        "nickName":"shaggy",
+        "schemas":[
+            "urn:ietf:params:scim:schemas:core:2.0:User",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        ],
+        "roles":[
+            {"type":"default","value":"Internal/everyone"}
+        ],
+        "name":{"givenName":"kim","familyName":"jackson"},
+        "id":"c8c821ba-1200-495e-a775-79b260e717bd",
+        "userName":"kim"
+    }
+    ```
 
 !!! info "Related topics"
     - [Concept: Users](../../../references/concepts/user-management/users)

--- a/en/docs/guides/login/client-side-app.md
+++ b/en/docs/guides/login/client-side-app.md
@@ -36,38 +36,44 @@ Make the following requests via your application to connect your application to 
         Now click **Generate Code Challenge**.
         Note the two values. The code challenge you get here is the base64 URL encoded value of the SHA256 hashed `code_verifier` so the code challenge method will be `S256`.    
     
-    ```tab="Request Format"
-    https://<host>/oauth2/authorize?scope=openid&response_type=code
-    &redirect_uri=<redirect_uri>
-    &client_id=<OAuth Client Key>
-    &code_challenge=<PKCE_code_challenge>
-    &code_challenge_method=<PKCE_code_challenge_method>
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?scope=openid&response_type=code
-    &redirect_uri=https://localhost/callback
-    &client_id=YYVdAL3lLcmrubZ2IkflCAuLwk0a
-    &code_challenge=5vEtIy2T-G65yXHc8g5zcJDQXICBzZMrtERq0zhx7hM
-    &code_challenge_method=S256
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        https://<host>/oauth2/authorize?scope=openid&response_type=code
+        &redirect_uri=<redirect_uri>
+        &client_id=<OAuth Client Key>
+        &code_challenge=<PKCE_code_challenge>
+        &code_challenge_method=<PKCE_code_challenge_method>
+        ```
+        ---
+        **Sample Request**
+        ```
+        https://localhost:9443/oauth2/authorize?scope=openid&response_type=code
+        &redirect_uri=https://localhost/callback
+        &client_id=YYVdAL3lLcmrubZ2IkflCAuLwk0a
+        &code_challenge=5vEtIy2T-G65yXHc8g5zcJDQXICBzZMrtERq0zhx7hM
+        &code_challenge_method=S256
+        ```
     
 2. Obtain the access token by sending a token request to the token endpoint using the `authorization_code` recieved in step 1, and the `<OAuth Client Key>` and `<OAuth Client Secret>` obtained when configuring the service provider.
 
-    ```tab="Request Format"
-    curl -i -X POST -u <OAuth Client Key>:<Client Secret> -k -d 
-    'grant_type=authorization_code&redirect_uri=<redirect_uri>
-    &code=<authorization_code>&code_verifier=<PKCE_code_verifier>' 
-    https://localhost:9443/oauth2/token
-    ```
-
-    ```tab="Sample Request"
-    curl -i -X POST -u YYVdAL3lLcmrubZ2IkflCAuLwk0a:azd39swy3Krt59fLjewYuD_EylIa -k -d 
-    'grant_type=authorization_code
-    &redirect_uri=https://localhost/callback&code=d827ec7e-1b8e-3d81-a4c0-2f7ff67ce844
-    &code_verifier=aYr1jbrAHhZDC5WBi8wQPdraATAvvKy93S22rkPDkkRTHzzaAMVOJ5MHgRPgoKf8xDBJPE08'
-    https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -i -X POST -u <OAuth Client Key>:<Client Secret> -k -d 
+        'grant_type=authorization_code&redirect_uri=<redirect_uri>
+        &code=<authorization_code>&code_verifier=<PKCE_code_verifier>' 
+        https://localhost:9443/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```
+        curl -i -X POST -u YYVdAL3lLcmrubZ2IkflCAuLwk0a:azd39swy3Krt59fLjewYuD_EylIa -k -d 
+        'grant_type=authorization_code
+        &redirect_uri=https://localhost/callback&code=d827ec7e-1b8e-3d81-a4c0-2f7ff67ce844
+        &code_verifier=aYr1jbrAHhZDC5WBi8wQPdraATAvvKy93S22rkPDkkRTHzzaAMVOJ5MHgRPgoKf8xDBJPE08'
+        https://localhost:9443/oauth2/token
+        ```
 
 3. Validate the ID token. For the token request, you will receive a response containing the access token, scope, and ID token. The ID token contains basic user information. To check what is encoded within the ID token, you can use a tool such as <https://devtoolzone.com/decoder/jwt>.
 

--- a/en/docs/guides/login/log-into-salesforce-using-is.md
+++ b/en/docs/guides/login/log-into-salesforce-using-is.md
@@ -15,7 +15,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     for the first time.
     4. You will be navigated to the lightening theme of Salesforce.
     
-       ![welcome-to-lightening.png](../../assets/img/guides/welcome-to-lightening.png){:class="no-border-padding-img"}
+       ![welcome-to-lightening.png](../../assets/img/guides/welcome-to-lightening.png)
        
     !!! note    
         This document is explained using the Salesforce lightning theme. If
@@ -23,7 +23,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
 
         ![lighteninig-experience](../../assets/img/guides/switch-to-lightening.png)
 
-4.  Once you are logged in, create a new domain and access it. To do
+2.  Once you are logged in, create a new domain and access it. To do
     this, do the following steps.  
     1.  Search for **My Domain** in the search bar that is on the left
         navigation panel.  

--- a/en/docs/guides/login/log-into-salesforce-using-is.md
+++ b/en/docs/guides/login/log-into-salesforce-using-is.md
@@ -15,7 +15,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     for the first time.
     4. You will be navigated to the lightening theme of Salesforce.
     
-       ![welcome-to-lightening.png](../../assets/img/guides/welcome-to-lightening.png) 
+       ![welcome-to-lightening.png](../../assets/img/guides/welcome-to-lightening.png){:class="no-border-padding-img"}
        
     !!! note    
         This document is explained using the Salesforce lightning theme. If

--- a/en/docs/guides/login/oidc-discovery.md
+++ b/en/docs/guides/login/oidc-discovery.md
@@ -89,41 +89,46 @@ Sample requests and responses are given below.
 
 **Super tenant**
 
-```tab="Request"
-curl -v -k https://localhost:9443/.well-known/webfinger?resource='acct:admin@localhost&rel=http://openid.net/specs/connect/1.0/issuer'
-```
-
-```tab="Response"
-{
-   "subject": "acct:admin@localhost",
-   "links": [
-      {
-         "rel": "http://openid.net/specs/connect/1.0/issuer",
-         "href": "https://localhost:9443/oauth2/token"
-      }
-   ]
-}
-```
+!!! abstract ""
+    **Request**
+    ```
+    curl -v -k https://localhost:9443/.well-known/webfinger?resource='acct:admin@localhost&rel=http://openid.net/specs/connect/1.0/issuer'
+    ```
+    ---
+    **Response**
+    ```
+    {
+      "subject": "acct:admin@localhost",
+      "links": [
+         {
+            "rel": "http://openid.net/specs/connect/1.0/issuer",
+            "href": "https://localhost:9443/oauth2/token"
+         }
+      ]
+    }
+    ```
 
 **Tenant-specific**
 
 The following sample request is for a tenant called as `wso2.com`.
 
-```tab="Request"
-curl -v -k https://localhost:9443/.well-known/webfinger?resource='acct:admin%40wso2.com@localhost&rel=http://openid.net/specs/connect/1.0/issuer'
-```
-
-```tab="Response"
-{
-   "subject": "acct:admin@wso2.com@localhost",
-   "links": [
-      {
-         "rel": "http://openid.net/specs/connect/1.0/issuer",
-         "href": "https://localhost:9443/t/wso2.com/oauth2/token"
-      }
-   ]
-}
-```
+!!! abstract ""
+    **Request**
+    ```
+    curl -v -k https://localhost:9443/.well-known/webfinger?resource='acct:admin%40wso2.com@localhost&rel=http://openid.net/specs/connect/1.0/issuer'
+    ```
+    **Response**
+    ```
+    {
+    "subject": "acct:admin@wso2.com@localhost",
+    "links": [
+        {
+            "rel": "http://openid.net/specs/connect/1.0/issuer",
+            "href": "https://localhost:9443/t/wso2.com/oauth2/token"
+        }
+    ]
+    }
+    ```
 
 ----
 
@@ -139,130 +144,133 @@ Follow the steps below to obtain configuration details of the OpenID Provider.
 
 2.  Send a request to the endpoint as shown below.
 
-    ```tab="Request"
-    curl -v -k https://localhost:9443/oauth2/token/.well-known/openid-configuration
-    ```
-    
-    ```tab="Response"
+    !!! abstract ""
+        **Request**
+        ```
+        curl -v -k https://localhost:9443/oauth2/token/.well-known/openid-configuration
+        ```
+        ---
+        **Response**
+        ```
         {
-           "request_parameter_supported":true,
-           "claims_parameter_supported":true,
-           "introspection_endpoint":"https://localhost:9443/oauth2/introspect",
-           "Response_modes_supported":[
-              "query",
-              "fragment",
-              "form_post"
-           ],
-           "scopes_supported":[
-              "address",
-              "phone",
-              "openid",
-              "profile",
-              "email"
-           ],
-           "check_session_iframe":"https://localhost:9443/oidc/checksession",
-           "backchannel_logout_supported":true,
-           "issuer":"https://localhost:9443/oauth2/token",
-           "authorization_endpoint":"https://localhost:9443/oauth2/authorize",
-           "introspection_endpoint_auth_methods_supported":[
-              "client_secret_basic",
-              "client_secret_post"
-           ],
-           "claims_supported":[
-              "zoneinfo",
-              "profile",
-              "phone_number_verified",
-              "picture",
-              "postal_code",
-              "name",
-              "groups",
-              "locale",
-              "address",
-              "preferred_username",
-              "middle_name",
-              "street_address",
-              "country",
-              "website",
-              "phone_number",
-              "formatted",
-              "gender",
-              "sub",
-              "nickname",
-              "email",
-              "upn",
-              "birthdate",
-              "given_name",
-              "updated_at",
-              "locality",
-              "region",
-              "email_verified",
-              "family_name",
-              "iss",
-              "acr"
-           ],
-           "userinfo_signing_alg_values_supported":[
-              "RS256"
-           ],
-           "token_endpoint_auth_methods_supported":[
-              "client_secret_basic",
-              "client_secret_post"
-           ],
-           "response_modes_supported":[
-              "query",
-              "fragment",
-              "form_post"
-           ],
-           "backchannel_logout_session_supported":true,
-           "token_endpoint":"https://localhost:9443/oauth2/token",
-           "response_types_supported":[
-              "id_token token",
-              "code",
-              "code id_token token",
-              "code id_token",
-              "id_token",
-              "code token",
-              "none",
-              "token"
-           ],
-           "revocation_endpoint_auth_methods_supported":[
-              "client_secret_basic",
-              "client_secret_post"
-           ],
-           "grant_types_supported":[
-              "refresh_token",
-              "urn:ietf:params:oauth:grant-type:saml2-bearer",
-              "password",
-              "client_credentials",
-              "iwa:ntlm",
-              "authorization_code",
-              "urn:ietf:params:oauth:grant-type:uma-ticket",
-              "account_switch",
-              "urn:ietf:params:oauth:grant-type:jwt-bearer"
-           ],
-           "end_session_endpoint":"https://localhost:9443/oidc/logout",
-           "revocation_endpoint":"https://localhost:9443/oauth2/revoke",
-           "userinfo_endpoint":"https://localhost:9443/oauth2/userinfo",
-           "code_challenge_methods_supported":[
-              "S256",
-              "plain"
-           ],
-           "jwks_uri":"https://localhost:9443/oauth2/jwks",
-           "subject_types_supported":[
-              "public"
-           ],
-           "id_token_signing_alg_values_supported":[
-              "RS256"
-           ],
-           "registration_endpoint":"https://localhost:9443/api/identity/oauth2/dcr/v1.1/register",
-           "request_object_signing_alg_values_supported":[
-              "RS256",
-              "RS384",
-              "RS512",
-              "PS256",
-              "none"
-           ]
+            "request_parameter_supported":true,
+            "claims_parameter_supported":true,
+            "introspection_endpoint":"https://localhost:9443/oauth2/introspect",
+            "Response_modes_supported":[
+                "query",
+                "fragment",
+                "form_post"
+            ],
+            "scopes_supported":[
+                "address",
+                "phone",
+                "openid",
+                "profile",
+                "email"
+            ],
+            "check_session_iframe":"https://localhost:9443/oidc/checksession",
+            "backchannel_logout_supported":true,
+            "issuer":"https://localhost:9443/oauth2/token",
+            "authorization_endpoint":"https://localhost:9443/oauth2/authorize",
+            "introspection_endpoint_auth_methods_supported":[
+                "client_secret_basic",
+                "client_secret_post"
+            ],
+            "claims_supported":[
+                "zoneinfo",
+                "profile",
+                "phone_number_verified",
+                "picture",
+                "postal_code",
+                "name",
+                "groups",
+                "locale",
+                "address",
+                "preferred_username",
+                "middle_name",
+                "street_address",
+                "country",
+                "website",
+                "phone_number",
+                "formatted",
+                "gender",
+                "sub",
+                "nickname",
+                "email",
+                "upn",
+                "birthdate",
+                "given_name",
+                "updated_at",
+                "locality",
+                "region",
+                "email_verified",
+                "family_name",
+                "iss",
+                "acr"
+            ],
+            "userinfo_signing_alg_values_supported":[
+                "RS256"
+            ],
+            "token_endpoint_auth_methods_supported":[
+                "client_secret_basic",
+                "client_secret_post"
+            ],
+            "response_modes_supported":[
+                "query",
+                "fragment",
+                "form_post"
+            ],
+            "backchannel_logout_session_supported":true,
+            "token_endpoint":"https://localhost:9443/oauth2/token",
+            "response_types_supported":[
+                "id_token token",
+                "code",
+                "code id_token token",
+                "code id_token",
+                "id_token",
+                "code token",
+                "none",
+                "token"
+            ],
+            "revocation_endpoint_auth_methods_supported":[
+                "client_secret_basic",
+                "client_secret_post"
+            ],
+            "grant_types_supported":[
+                "refresh_token",
+                "urn:ietf:params:oauth:grant-type:saml2-bearer",
+                "password",
+                "client_credentials",
+                "iwa:ntlm",
+                "authorization_code",
+                "urn:ietf:params:oauth:grant-type:uma-ticket",
+                "account_switch",
+                "urn:ietf:params:oauth:grant-type:jwt-bearer"
+            ],
+            "end_session_endpoint":"https://localhost:9443/oidc/logout",
+            "revocation_endpoint":"https://localhost:9443/oauth2/revoke",
+            "userinfo_endpoint":"https://localhost:9443/oauth2/userinfo",
+            "code_challenge_methods_supported":[
+                "S256",
+                "plain"
+            ],
+            "jwks_uri":"https://localhost:9443/oauth2/jwks",
+            "subject_types_supported":[
+                "public"
+            ],
+            "id_token_signing_alg_values_supported":[
+                "RS256"
+            ],
+            "registration_endpoint":"https://localhost:9443/api/identity/oauth2/dcr/v1.1/register",
+            "request_object_signing_alg_values_supported":[
+                "RS256",
+                "RS384",
+                "RS512",
+                "PS256",
+                "none"
+            ]
         }
-    ```
+        ```
 
 
 !!! info "Related topics"

--- a/en/docs/guides/login/oidc-logout-url-redirection.md
+++ b/en/docs/guides/login/oidc-logout-url-redirection.md
@@ -31,12 +31,11 @@ Make the following changes to the created service provider.
 
     You can specify multiple callback URLs using a regex pattern as shown below.
 
-    !!! abstract ""
-        **Sample**
-        ```
-        regexp=(http://localhost:8080/playground2/oauth2client|http://localhost:8080/playground2/logout)
-        ```
-    
+    **Sample**
+    ```
+    regexp=(http://localhost:8080/playground2/oauth2client|http://localhost:8080/playground2/logout)
+    ```
+
 4. Click **Add** to save the changes.
 
 ## Configure to sign the ID token

--- a/en/docs/guides/login/oidc-logout-url-redirection.md
+++ b/en/docs/guides/login/oidc-logout-url-redirection.md
@@ -31,9 +31,11 @@ Make the following changes to the created service provider.
 
     You can specify multiple callback URLs using a regex pattern as shown below.
 
-    ```tab="Sample"
-    regexp=(http://localhost:8080/playground2/oauth2client|http://localhost:8080/playground2/logout)
-    ```
+    !!! abstract ""
+        **Sample**
+        ```
+        regexp=(http://localhost:8080/playground2/oauth2client|http://localhost:8080/playground2/logout)
+        ```
     
 4. Click **Add** to save the changes.
 
@@ -59,23 +61,29 @@ Make the following changes to the created service provider.
 
 8. Use the following cURL command to retrieve the `id_token` using the client ID, client secret, and authorization code.
 
-    ```tab="Request Format"
-    curl -k -v --user <client_id>:<client_secret> -d "grant_type=authorization_code&code=<authorization_code>&redirect_uri=<redirect_uri>" https://<IS_HOST>:<IS_PORT>/oauth2/token
-    ```
-
-    ``` tab="Sample Request"
-    curl -k -v --user IaWVc3g4eemSnbWwekBg79xudZMa:PL9PxKPqGZxkpJ8X8u7g8pA_ruoa -d "grant_type=authorization_code&code=ac1b2e9e-d8d0-3f42-bdd4-dc7aab45b5dc&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -k -v --user <client_id>:<client_secret> -d "grant_type=authorization_code&code=<authorization_code>&redirect_uri=<redirect_uri>" https://<IS_HOST>:<IS_PORT>/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```
+        curl -k -v --user IaWVc3g4eemSnbWwekBg79xudZMa:PL9PxKPqGZxkpJ8X8u7g8pA_ruoa -d "grant_type=authorization_code&code=ac1b2e9e-d8d0-3f42-bdd4-dc7aab45b5dc&redirect_uri=http://localhost:8080/playground2/oauth2client" https://localhost:9443/oauth2/token
+        ```
 
 9. Use the retrieved `id_token` in the following URL to logout from the identity provider and redirect to a URL in the relying party (RP).
 
-    ```tab="Format"
-    https://localhost:9443/oidc/logout?id_token_hint=<id_token>&post_logout_redirect_uri=<redirect URI>&state=<state>
-    ```
-
-    ```tab="Sample"
-    https://localhost:9443/oidc/logout?id_token_hint=eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoid3l2dExOU3VMbUpubV9FYVhWM183QSIsImF1ZCI6IllteEQwakRPSWZpQmtEOFRQTFlPZnhOU0lnNGEiLCJzdWIiOiJhZG1pbiIsInVwbiI6ImFkbWluIiwibmJmIjoxNTg3NTQyNDE5LCJhenAiOiJZbXhEMGpET0lmaUJrRDhUUExZT2Z4TlNJZzRhIiwiYW1yIjpbInBhc3N3b3JkIl0sImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImdyb3VwcyI6WyJBcHBsaWNhdGlvblwvVXNlciBQb3J0YWwiLCJBcHBsaWNhdGlvblwvcGlja3VwLWRpc3BhdGNoIiwiSW50ZXJuYWxcL2V2ZXJ5b25lIiwiQXBwbGljYXRpb25cL3BpY2t1cC1tYW5hZ2VyIiwiYWRtaW4iLCJBcHBsaWNhdGlvblwvbXAtand0Il0sImV4cCI6MTU4NzU0NjAxOSwiaWF0IjoxNTg3NTQyNDE5fQ.Ibguye1XxPbRgdmpMCAbHn3aNl00NWWpMubg8dKuYrO-7rP7Uh76_5LQqWdzp1dsBuPSqKATnGn95vZ4uz3yn1aB-TlsBqD6gCRc2GWO5Qk-jYfgCRZHLOrFn82f5Eaoc5p99b4lYIat6DAogS2xj3NYu_rbeo1jHDfI-CzY35X9u_w15uSLpwIxa6DPrU-0WhgSTBk_n9UGJKXdYYQipiXheVQZGAGU86IpHfMyOgd6KQrq2HTBsnFjPUSTBE0ifq2ZBGPfYKA9ESCJX2lC6h4wveqEQRkPWEsry4uYECNPyJXqbE2Kt3sLXo537W2rZpkNHL4_mWMGWv_EIdp0BQ&post_logout_redirect_uri=http://localhost:8080/playground2/logout&state=state_1
-    ```
+    !!! abstract ""
+        **Format**
+        ```
+        https://localhost:9443/oidc/logout?id_token_hint=<id_token>&post_logout_redirect_uri=<redirect URI>&state=<state>
+        ```
+        ---
+        **Sample**
+        ```
+        https://localhost:9443/oidc/logout?id_token_hint=eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoid3l2dExOU3VMbUpubV9FYVhWM183QSIsImF1ZCI6IllteEQwakRPSWZpQmtEOFRQTFlPZnhOU0lnNGEiLCJzdWIiOiJhZG1pbiIsInVwbiI6ImFkbWluIiwibmJmIjoxNTg3NTQyNDE5LCJhenAiOiJZbXhEMGpET0lmaUJrRDhUUExZT2Z4TlNJZzRhIiwiYW1yIjpbInBhc3N3b3JkIl0sImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImdyb3VwcyI6WyJBcHBsaWNhdGlvblwvVXNlciBQb3J0YWwiLCJBcHBsaWNhdGlvblwvcGlja3VwLWRpc3BhdGNoIiwiSW50ZXJuYWxcL2V2ZXJ5b25lIiwiQXBwbGljYXRpb25cL3BpY2t1cC1tYW5hZ2VyIiwiYWRtaW4iLCJBcHBsaWNhdGlvblwvbXAtand0Il0sImV4cCI6MTU4NzU0NjAxOSwiaWF0IjoxNTg3NTQyNDE5fQ.Ibguye1XxPbRgdmpMCAbHn3aNl00NWWpMubg8dKuYrO-7rP7Uh76_5LQqWdzp1dsBuPSqKATnGn95vZ4uz3yn1aB-TlsBqD6gCRc2GWO5Qk-jYfgCRZHLOrFn82f5Eaoc5p99b4lYIat6DAogS2xj3NYu_rbeo1jHDfI-CzY35X9u_w15uSLpwIxa6DPrU-0WhgSTBk_n9UGJKXdYYQipiXheVQZGAGU86IpHfMyOgd6KQrq2HTBsnFjPUSTBE0ifq2ZBGPfYKA9ESCJX2lC6h4wveqEQRkPWEsry4uYECNPyJXqbE2Kt3sLXo537W2rZpkNHL4_mWMGWv_EIdp0BQ&post_logout_redirect_uri=http://localhost:8080/playground2/logout&state=state_1
+        ```
       
     For a description of the parameters included in the URL, see [logout request parameters](#logout-request-parameters).
 
@@ -87,41 +95,44 @@ Sending an OIDC logout request as a POST request is useful in certain scenarios.
 
 The following sample HTML form shows the parameters you need to specify when sending an OIDC logout request as a POST request. 
 
-```html tab="Format"
-<html>
-    <body>
-            <p>OIDC_LOGOUT_POST</p>
-            <form method='post' action='$idp_url'>
-                    <input type='hidden' name='id_token_hint' value='$id_token'/>
-                    <input type='hidden' name='post_logout_redirect_uri' value='$callback'/>
-                    <input type='hidden' name='state' value='$state'/>
-                <button type='submit'>POST</button>
-            </form>
-            <script type='text/javascript'>
-                document.forms[0].submit();
-            </script>
-        </body>
-</html>
-```
-
-```html tab="Sample"
-<html>
-    <body>
-            <p>OIDC_LOGOUT_POST</p>
-            <form method='post' action='https://localhost:9443/oidc/logout'>
-                <p>
-                       <input type='hidden' name='id_token_hint' value='eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJraWQiOiJkMGVjNTE0YTMyYjZmODhjMGFiZDEyYTI4NDA2OTliZGQzZGViYTlkIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJhZG1pbiIsImF1ZCI6WyJuNUFndEFqRmhUZXVybjE4MzhqaTMwbWhUbUFhIl0sImF6cCI6Im41QWd0QWpGaFRldXJuMTgzOGppMzBtaFRtQWEiLCJhdXRoX3RpbWUiOjE1MjIwNTI4NDYsImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImV4cCI6MTUyMjA1NjQ0Nywibm9uY2UiOiIxMjMzNDIzNCIsImlhdCI6MTUyMjA1Mjg0N30.g2oSoC_D88XBjN81Lgx0DmOFELO_lXVXTu2YwbZOQGiCJyJLCjwW_Q0UJimBG-ZZIJo5sPj5yrHi5wB9r-Dkr_9QOsgQc7YpiZ0hGw3x53tttxaA655kHuZCsFSJDY7nIsfH-d9Yhi-p4arfdwrrMpcvkwVoLwca1M3-1j9v3LU'/>
-                    <input type='hidden' name='post_logout_redirect_uri' value='https://localhost/callback'/>
-                    <input type='hidden' name='state' value='zzdfdsfdfdfd'/>
+!!! abstract ""
+    **Format**
+    ```html
+    <html>
+        <body>
+                <p>OIDC_LOGOUT_POST</p>
+                <form method='post' action='$idp_url'>
+                        <input type='hidden' name='id_token_hint' value='$id_token'/>
+                        <input type='hidden' name='post_logout_redirect_uri' value='$callback'/>
+                        <input type='hidden' name='state' value='$state'/>
                     <button type='submit'>POST</button>
-                 </p>
-            </form>
-            <script type='text/javascript'>
-                document.forms[0].submit();
-            </script>
-        </body>
-</html>
-```
+                </form>
+                <script type='text/javascript'>
+                    document.forms[0].submit();
+                </script>
+            </body>
+    </html>
+    ```
+    ---
+    **Sample**
+    ```html
+    <html>
+        <body>
+                <p>OIDC_LOGOUT_POST</p>
+                <form method='post' action='https://localhost:9443/oidc/logout'>
+                    <p>
+                        <input type='hidden' name='id_token_hint' value='eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJraWQiOiJkMGVjNTE0YTMyYjZmODhjMGFiZDEyYTI4NDA2OTliZGQzZGViYTlkIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJhZG1pbiIsImF1ZCI6WyJuNUFndEFqRmhUZXVybjE4MzhqaTMwbWhUbUFhIl0sImF6cCI6Im41QWd0QWpGaFRldXJuMTgzOGppMzBtaFRtQWEiLCJhdXRoX3RpbWUiOjE1MjIwNTI4NDYsImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImV4cCI6MTUyMjA1NjQ0Nywibm9uY2UiOiIxMjMzNDIzNCIsImlhdCI6MTUyMjA1Mjg0N30.g2oSoC_D88XBjN81Lgx0DmOFELO_lXVXTu2YwbZOQGiCJyJLCjwW_Q0UJimBG-ZZIJo5sPj5yrHi5wB9r-Dkr_9QOsgQc7YpiZ0hGw3x53tttxaA655kHuZCsFSJDY7nIsfH-d9Yhi-p4arfdwrrMpcvkwVoLwca1M3-1j9v3LU'/>
+                        <input type='hidden' name='post_logout_redirect_uri' value='https://localhost/callback'/>
+                        <input type='hidden' name='state' value='zzdfdsfdfdfd'/>
+                        <button type='submit'>POST</button>
+                    </p>
+                </form>
+                <script type='text/javascript'>
+                    document.forms[0].submit();
+                </script>
+            </body>
+    </html>
+    ```
 
 For a description of the parameters included in the HTML form, see [logout request parameters](#logout-request-parameters).
 

--- a/en/docs/guides/login/oidc-parameters-in-auth-request.md
+++ b/en/docs/guides/login/oidc-parameters-in-auth-request.md
@@ -8,39 +8,45 @@ This page guides you through some special request parameters used with [OpenID C
 
 Use the [state parameter](../../../references/concepts/authentication/traditional-authentication-request#state-parameter) to maintain a correlation between the request and the response.
 
-```tab="Request Format"
-https://<IS_HOST>:<IS_PORT>/oauth2/authorize?
-response_type=<response_type>
-&client_id=<client_id>
-&state=<state_value>
-&redirect_uri=<callback_url>
-```
-
-```tab="Sample Request"
-https://localhost:9443/oauth2/authorize?
-response_type=token
-&client_id=s6BhdRkqt3
-&state=xyz
-&redirect_uri=https://localhost.com:8080/callback
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    https://<IS_HOST>:<IS_PORT>/oauth2/authorize?
+    response_type=<response_type>
+    &client_id=<client_id>
+    &state=<state_value>
+    &redirect_uri=<callback_url>
+    ```
+    ---
+    **Sample Request**
+    ```
+    https://localhost:9443/oauth2/authorize?
+    response_type=token
+    &client_id=s6BhdRkqt3
+    &state=xyz
+    &redirect_uri=https://localhost.com:8080/callback
+    ```
 
 You will receive a response similar to the one shown below.
 
-```tab="Response Format"
-HTTP/1.1 302 Found
-Location: <callback_url>#access_token=<access_token>
-&state=<state_value>
-&token_type=<token_type>
-&expires_in=<token_expiry_time>
-```
-
-```tab="Sample Response"
-HTTP/1.1 302 Found
-Location: https://localhost.com:8080/callback#access_token=2YotnFZFEjr1zCsicMWpAA
-&state=xyz
-&token_type=bearer
-&expires_in=3600
-```
+!!! abstract ""
+    **Response Format**
+    ```
+    HTTP/1.1 302 Found
+    Location: <callback_url>#access_token=<access_token>
+    &state=<state_value>
+    &token_type=<token_type>
+    &expires_in=<token_expiry_time>
+    ```
+    ---
+    **Sample Response**
+    ```
+    HTTP/1.1 302 Found
+    Location: https://localhost.com:8080/callback#access_token=2YotnFZFEjr1zCsicMWpAA
+    &state=xyz
+    &token_type=bearer
+    &expires_in=3600
+    ```
 
  ----
  
@@ -51,36 +57,52 @@ Use the [nonce parameter](../../../references/concepts/authentication/traditiona
 The `nonce` claim embedded in the ID token must contain the exact value that was sent in the request. 
 If not, authentication should be rejected by the application.
 
-```tab="Request Format"
-https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=<response_type>&client_id=<client_id>&redirect_uri=<callback_url>&nonce=<nonce_value>&scope=openid
-```
-
-```tab="Sample Request"
-https://localhost:9443/oauth2/authorize?response_type=id_token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=https://localhost.com:8080/callback&nonce=abc&scope=openid
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=<response_type>&client_id=<client_id>&redirect_uri=<callback_url>&nonce=<nonce_value>&scope=openid
+    ```
+    ---
+    **Sample Request**
+    ```
+    https://localhost:9443/oauth2/authorize?response_type=id_token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=https://localhost.com:8080/callback&nonce=abc&scope=openid
+    ```
 
 You will receive a response similar to shown below.
 
-```tab="Response Format"
-HTTP/1.1 302 Found
-Location: <callback_url>#access_token=<access_token>
-&state=<state_value>
-&token_type=<token_type>
-&expires_in=<token_expiry_time>
-```
-
-```tab="Sample Response"
-HTTP/1.1 302 Found
-Location: https://localhost.com:8080/callback#access_token=2YotnFZFEjr1zCsicMWpAA
-&state=xyz
-&token_type=bearer
-&expires_in=3600
-```
+!!! abstract ""
+    **Response Format**
+    ```
+    HTTP/1.1 302 Found
+    Location: <callback_url>#access_token=<access_token>
+    &state=<state_value>
+    &token_type=<token_type>
+    &expires_in=<token_expiry_time>
+    ```
+    ---
+    **Sample Response**
+    ```
+    HTTP/1.1 302 Found
+    Location: https://localhost.com:8080/callback#access_token=2YotnFZFEjr1zCsicMWpAA
+    &state=xyz
+    &token_type=bearer
+    &expires_in=3600
+    ```
 
 The decoded ID token is as follows.
 
 ```
-{"auth_time":1453184484,"exp":1453188084,"sub":"admin@carbon.super","azp":"W2OoSxQDCVrBk1lnffo1NGCKZbQa","at_hash":"DoxjyXzmrL6Z_kWRzmBdCA","nonce":"abc","aud":["W2OoSxQDCVrBk1lnffo1NGCKZbQa"],"iss":"https://playground.local:9443/oauth2/token","iat":1453184484}
+{
+    "auth_time":1453184484,
+    "exp":1453188084,
+    "sub":"admin@carbon.super",
+    "azp":"W2OoSxQDCVrBk1lnffo1NGCKZbQa",
+    "at_hash":"DoxjyXzmrL6Z_kWRzmBdCA",
+    "nonce":"abc",
+    "aud":["W2OoSxQDCVrBk1lnffo1NGCKZbQa"],
+    "iss":"https://playground.local:9443/oauth2/token",
+    "iat":1453184484
+}
 ```
 
  ----
@@ -97,23 +119,29 @@ The [prompt parameter](../../../references/concepts/authentication/traditional-a
 
 The silent authentication can be initiated by using the `prompt=none` parameter with the authentication request.
 
-```tab="Request Format"
-https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=token&client_id=<client_id>&redirect_uri=<callback_url>&prompt=none&scope=openid
-```
-
-```tab="Sample Request"
-https://localhost:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=https://localhost.com:8080/callback&prompt=none&scope=openid
-```
+!!! abstract ""
+    **Request Format**
+    ```
+    https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=token&client_id=<client_id>&redirect_uri=<callback_url>&prompt=none&scope=openid
+    ```
+    ---
+    **Sample Request**
+    ```
+    https://localhost:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=https://localhost.com:8080/callback&prompt=none&scope=openid
+    ```
 
 If the user has an already authenticated session and a pre-configured consent with the WSO2 Identity Server, you will receive a successful response as follows.
 
-```tab="Response Format"
-<callback_url>#token_type=<token_type>&expires_in=<expiry_time>&access_token=<access_token>
-```
-
-```tab="Sample Response"
-https://localhost.com:8080/callback#token_type=Bearer&expires_in=60&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
-```
+!!! abstract ""
+    **Response Format**
+    ```
+    <callback_url>#token_type=<token_type>&expires_in=<expiry_time>&access_token=<access_token>
+    ```
+    ---
+    **Sample Response**
+    ```
+    https://localhost.com:8080/callback#token_type=Bearer&expires_in=60&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
+    ```
 
 **Error Response**
 
@@ -136,15 +164,19 @@ session_state==...
 
 Use the `prompt=login` parameter with the authentication request to force authenticating the user even if the user has been authenticated already.
 
-```tab="Sample Request"
-https://<host>:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&prompt=none&scope=openid
-```
+!!! abstract ""
+    **Sample Request**
+    ```
+    https://<host>:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&prompt=none&scope=openid
+    ```
 
 If the user is successfully re-authenticated with WSO2 Identity Server, you will receive a successful response as follows.
 
-```tab="Successful Response"
-https://<callback_url>#token_type=Bearer&expires_in=60&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
-```
+!!! abstract ""
+    **Successful Response**
+    ```
+    https://<callback_url>#token_type=Bearer&expires_in=60&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
+    ```
 
 **Error Response**
 
@@ -164,24 +196,30 @@ session_state==...
 ### prompt=consent
 
 Use the `prompt=consent` parameter with the authentication request to force prompting user consent.
- 
- ```tab="Request Format"
- https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=<response_type>&client_id=<client_id>&redirect_uri=<callback_url>&prompt=consent&scope=openid&access_token=<access_token>
- ```
 
- ```tab="Sample Request"
- https://localhost:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&prompt=consent&scope=openid&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
- ```
+!!! abstract ""
+    **Request Format**
+    ```
+    https://<IS_HOST>:<IS_PORT>/oauth2/authorize?response_type=<response_type>&client_id=<client_id>&redirect_uri=<callback_url>&prompt=consent&scope=openid&access_token=<access_token>
+    ```
+    ---
+    **Sample Request**
+    ```
+    https://localhost:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&prompt=consent&scope=openid&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
+    ```
  
  If the user has successfully provided the consent again, even if the consent is already given, WSO2 Identity Server will return a successful response as follows.
 
- ```tab="Response Format"
- <callback_url>#token_type=<token_type>&expires_in=<expiry_time>&access_token=<access_token>
- ```
-
- ```tab="Sample Response"
- http://localhost:8080/playground2/oauth2client#token_type=Bearer&expires_in=60&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
- ```
+!!! abstract ""
+    **Response Format**
+    ```
+    <callback_url>#token_type=<token_type>&expires_in=<expiry_time>&access_token=<access_token>
+    ```
+    ---
+    **Sample Response**
+    ```
+    http://localhost:8080/playground2/oauth2client#token_type=Bearer&expires_in=60&access_token=10a361a99aa4bd6e0aa79c6ea7bcdb66
+    ```
  
 **Error Response**
 

--- a/en/docs/guides/login/using-jwks.md
+++ b/en/docs/guides/login/using-jwks.md
@@ -10,13 +10,16 @@ You can follow this guide when your relying party (RP) application needs to vali
 
 Copy and paste the following endpoint URL on your browser window.
 
-```tab="URL Format"
-https://<IS_HOST>:<IS_HTTPS_PORT>/oauth2/jwks
-```
-
-```tab="Sample URL"
-https://localhost:9443/oauth2/jwks
-```
+!!! abstract ""
+    **URL Format**
+    ```
+    https://<IS_HOST>:<IS_HTTPS_PORT>/oauth2/jwks
+    ```
+    ---
+    **Sample URL**
+    ```
+    https://localhost:9443/oauth2/jwks
+    ```
 
 - By default, `<IS_HOST>` is localhost. However, if you are using a public IP, the respective IP address or domain needs to be specified.
 
@@ -24,20 +27,22 @@ https://localhost:9443/oauth2/jwks
 
 You will see the following response. 
 
-```tab="Response"
-{
-  "keys": [
+!!! abstract ""
+    **Response**
+    ```
     {
-      "kty": "RSA",
-      "e": "AQAB",
-      "use": "sig",
-      "kid": "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",
-      "alg": "RS256",
-      "n": "luZFdW1ynitztkWLC6xKegbRWxky-5P0p4ShYEOkHs30QI2VCuR6Qo4Bz5rTgLBrky03W1GAVrZxuvKRGj9V9-PmjdGtau4CTXu9pLLcqnruaczoSdvBYA3lS9a7zgFU0-s6kMl2EhB-rk7gXluEep7lIOenzfl2f6IoTKa2fVgVd3YKiSGsyL4tztS70vmmX121qm0sTJdKWP4HxXyqK9neolXI9fYyHOYILVNZ69z_73OOVhkh_mvTmWZLM7GM6sApmyLX6OXUp8z0pkY-vT_9-zRxxQs7GurC4_C1nK3rI_0ySUgGEafO1atNjYmlFN-M3tZX6nEcA6g94IavyQ"
+        "keys": [
+            {
+            "kty": "RSA",
+            "e": "AQAB",
+            "use": "sig",
+            "kid": "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",
+            "alg": "RS256",
+            "n": "luZFdW1ynitztkWLC6xKegbRWxky-5P0p4ShYEOkHs30QI2VCuR6Qo4Bz5rTgLBrky03W1GAVrZxuvKRGj9V9-PmjdGtau4CTXu9pLLcqnruaczoSdvBYA3lS9a7zgFU0-s6kMl2EhB-rk7gXluEep7lIOenzfl2f6IoTKa2fVgVd3YKiSGsyL4tztS70vmmX121qm0sTJdKWP4HxXyqK9neolXI9fYyHOYILVNZ69z_73OOVhkh_mvTmWZLM7GM6sApmyLX6OXUp8z0pkY-vT_9-zRxxQs7GurC4_C1nK3rI_0ySUgGEafO1atNjYmlFN-M3tZX6nEcA6g94IavyQ"
+            }
+        ]
     }
-  ]
-}
-```
+    ```
 
 For information about the elements in the response, see [Response parameters](#response-parameters).
 
@@ -47,13 +52,16 @@ For information about the elements in the response, see [Response parameters](#r
 
 Copy and paste the following endpoint URL on your browser window.
 
-```tab="URL Format"
-https://<IS_HOST>:<IS_PORT>/t/<TENANT_DOMAIN>/oauth2/jwks
-```
-
-```tab="Sample URL"
-https://localhost:9443/t/foo.com/oauth2/jwks
-```
+!!! abstract ""
+    **URL Format**
+    ```
+    https://<IS_HOST>:<IS_PORT>/t/<TENANT_DOMAIN>/oauth2/jwks
+    ```
+    ---
+    **Sample URL**
+    ```
+    https://localhost:9443/t/foo.com/oauth2/jwks
+    ```
 
 - By default, `<IS_HOST>` is localhost. However, if you are using a public IP, the respective IP address or domain needs to be specified.
 
@@ -61,20 +69,22 @@ https://localhost:9443/t/foo.com/oauth2/jwks
 
 You will see the following response. 
 
-```tab="Response"
-{
-  "keys": [
+!!! abstract ""
+    **Response**
+    ```
     {
-      "kty": "RSA",
-      "e": "AQAB",
-      "use": "sig",
-      "kid": "MTk5NjA3YjRkNGRmZmI4NTYyMzEzZWFhZGM1YzAyZWMyZTg0ZGQ4Yw",
-      "alg": "RS256",
-      "n": "0OA-yiyn_pCKnldZBq2KPnGplLuTEtGU7IZP66Wf7ElhFJ-kQ87BMKvZqVNDV84MSY3XQg0t0yL6gITg-W8op61PWO2UrEcxhhMHN_rra22Ae2OCaUfOr43cW1YFc54cYj5p7v-HSVvjTuNLGMMrNfTGAOCPzuLxbSHfq62uydU"
+        "keys": [
+            {
+            "kty": "RSA",
+            "e": "AQAB",
+            "use": "sig",
+            "kid": "MTk5NjA3YjRkNGRmZmI4NTYyMzEzZWFhZGM1YzAyZWMyZTg0ZGQ4Yw",
+            "alg": "RS256",
+            "n": "0OA-yiyn_pCKnldZBq2KPnGplLuTEtGU7IZP66Wf7ElhFJ-kQ87BMKvZqVNDV84MSY3XQg0t0yL6gITg-W8op61PWO2UrEcxhhMHN_rra22Ae2OCaUfOr43cW1YFc54cYj5p7v-HSVvjTuNLGMMrNfTGAOCPzuLxbSHfq62uydU"
+            }
+        ]
     }
-  ]
-}
-```
+    ```
 
 For information about the elements in the response, see [Response parameters](#response-parameters).
 

--- a/en/docs/guides/login/webapp-oidc.md
+++ b/en/docs/guides/login/webapp-oidc.md
@@ -26,47 +26,62 @@ This guide assumes you have your own application. If you wish to try out this fl
 
 1. Obtain the `authorization_code` by sending an authorization request to the authorization endpoint.
 
-    ```tab="Request Format"
-    https://<host>:<port>/oauth2/authorize?scope=openid&response_type=code
-    &redirect_uri=<callback_url>
-    &client_id=<oauth_client_key>
-    ```
-
-    ```tab="Sample Request"
-    https://localhost:9443/oauth2/authorize?scope=openid&response_type=code
-    &redirect_uri=https://localhost/callback
-    &client_id=YYVdAL3lLcmrubZ2IkflCAuLwk0a
-    ```
+    !!! abstract  ""
+        **Request Format**
+        ```
+        https://<host>:<port>/oauth2/authorize?scope=openid&response_type=code
+        &redirect_uri=<callback_url>
+        &client_id=<oauth_client_key>
+        ```
+        ---
+        **Sample Request**
+        ```
+        https://localhost:9443/oauth2/authorize?scope=openid&response_type=code
+        &redirect_uri=https://localhost/callback
+        &client_id=YYVdAL3lLcmrubZ2IkflCAuLwk0a
+        ```
 
     You will receive the authorization code upon successful authorization.
     
-    ```tab="Response Format"
-    <callback_url>?code=<code>
-    ```
-        
-    ```tab="Sample Response"
-    https://localhost/callback?code=9142d4cad58c66d0a5edfad8952192
-    ```
+    !!! abstract ""
+        **Response Format**
+        ```
+        <callback_url>?code=<code>
+        ```
+        ---
+        **Sample Response**
+        ```
+        https://localhost/callback?code=9142d4cad58c66d0a5edfad8952192
+        ```
 
 2. Obtain the access token by sending a token request to the token endpoint using the `code` received in step 1, and the `oauth_client_key` and `oauth_client_secret` obtained when configuring the service provider.
 
-    ```tab="Request Format"
-    curl -i -X POST -u <oauth_client_key>:<oauth_client_secret> -k -d 
-    'grant_type=authorization_code&redirect_uri=<redirect_uri>
-    &code=<code>' https://<host>:<port>/oauth2/token
-    ```
-
-    ```tab="Sample Request"
-    curl -i -X POST -u YYVdAL3lLcmrubZ2IkflCAuLwk0a:azd39swy3Krt59fLjewYuD_EylIa -k -d 
-    'grant_type=authorization_code
-    &redirect_uri=https://localhost/callback&code=d827ec7e-1b8e-3d81-a4c0-2f7ff67ce844'
-    https://localhost:9443/oauth2/token
-    ```
+    !!! abstract ""
+        **Request Format**
+        ```
+        curl -i -X POST -u <oauth_client_key>:<oauth_client_secret> -k -d 
+        'grant_type=authorization_code&redirect_uri=<redirect_uri>
+        &code=<code>' https://<host>:<port>/oauth2/token
+        ```
+        ---
+        **Sample Request**
+        ```
+        curl -i -X POST -u YYVdAL3lLcmrubZ2IkflCAuLwk0a:azd39swy3Krt59fLjewYuD_EylIa -k -d 
+        'grant_type=authorization_code
+        &redirect_uri=https://localhost/callback&code=d827ec7e-1b8e-3d81-a4c0-2f7ff67ce844'
+        https://localhost:9443/oauth2/token
+        ```
 
 3. For the token request, you will receive a response containing the access token, scope, and ID token similar to the sample response provided below.
    
-    ```
-    {"access_token":"80c7c0d7-070a-38ff-a1f4-d21a444cdb67","refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d","scope":"openid","id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjZTA5YTM1NjBhYzI4ZDc3YWNlZjJjYzQxZGUyNjEzZDMxY2NmOGQwYTgxYjRhNzY2ZTlhYTFmZDRlNjhhMzA5IiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibzhIX0Fqc3FOSWkyd3g5LWVzcFo0dyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODc0NTM5LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzgxMzksImlhdCI6MTYxNTg3NDUzOSwibm9uY2UiOiJhc2QifQ.LIoD9ltfqsxysMaC1b0kX-Ot4qL5GycpF5R-GIB_wBkQvN5BVEQZ4XV2t0t9GaQv1gSApsd6CtUAvV0haAqaNDElVcDQrmsyyHNzN0051biTQWQkoC4wwtO6_w1MSmgbH_aNVjQkBWt2vnaWtn6bt9sdZVxGRSb3_Amxdty_rDmiOzhJPwxZbkdPp1US0jmAn2XOoQQyH7e__qoXSjjoBAKXQtncJWAKtteDUBQTqVLj13TdS8dYqnEQByKNvhpz8rZjGaBV9pxtOWoqnbc3IMA4lX47Mpxl22ZqhIn0J6WCQ7nJtEkfx6XNHdatWZyG2x20pxbZkgya6sKAEoy3zw","token_type":"Bearer","expires_in":2286}
+    ``` java
+    {
+        "access_token":"80c7c0d7-070a-38ff-a1f4-d21a444cdb67","refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d",
+        "scope":"openid"
+        "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjZTA5YTM1NjBhYzI4ZDc3YWNlZjJjYzQxZGUyNjEzZDMxY2NmOGQwYTgxYjRhNzY2ZTlhYTFmZDRlNjhhMzA5IiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibzhIX0Fqc3FOSWkyd3g5LWVzcFo0dyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODc0NTM5LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzgxMzksImlhdCI6MTYxNTg3NDUzOSwibm9uY2UiOiJhc2QifQ.LIoD9ltfqsxysMaC1b0kX-Ot4qL5GycpF5R-GIB_wBkQvN5BVEQZ4XV2t0t9GaQv1gSApsd6CtUAvV0haAqaNDElVcDQrmsyyHNzN0051biTQWQkoC4wwtO6_w1MSmgbH_aNVjQkBWt2vnaWtn6bt9sdZVxGRSb3_Amxdty_rDmiOzhJPwxZbkdPp1US0jmAn2XOoQQyH7e__qoXSjjoBAKXQtncJWAKtteDUBQTqVLj13TdS8dYqnEQByKNvhpz8rZjGaBV9pxtOWoqnbc3IMA4lX47Mpxl22ZqhIn0J6WCQ7nJtEkfx6XNHdatWZyG2x20pxbZkgya6sKAEoy3zw",
+        "token_type":"Bearer",
+        "expires_in":2286
+    }
     ```
 
     The ID token contains basic user information. To check what is encoded within the ID token, you can use a tool such as <https://devtoolzone.com/decoder/jwt>.

--- a/en/docs/guides/login/webapp-oidc.md
+++ b/en/docs/guides/login/webapp-oidc.md
@@ -76,7 +76,8 @@ This guide assumes you have your own application. If you wish to try out this fl
    
     ``` java
     {
-        "access_token":"80c7c0d7-070a-38ff-a1f4-d21a444cdb67","refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d",
+        "access_token":"80c7c0d7-070a-38ff-a1f4-d21a444cdb67",
+        "refresh_token":"18917dd6-4566-3294-92a9-01ec89cccf4d",
         "scope":"openid"
         "id_token":"eyJ4NXQiOiJNell4TW1Ga09HWXdNV0kwWldObU5EY3hOR1l3WW1NNFpUQTNNV0kyTkRBelpHUXpOR00wWkdSbE5qSmtPREZrWkRSaU9URmtNV0ZoTXpVMlpHVmxOZyIsImtpZCI6Ik16WXhNbUZrT0dZd01XSTBaV05tTkRjeE5HWXdZbU00WlRBM01XSTJOREF6WkdRek5HTTBaR1JsTmpKa09ERmtaRFJpT1RGa01XRmhNelUyWkdWbE5nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiJjZTA5YTM1NjBhYzI4ZDc3YWNlZjJjYzQxZGUyNjEzZDMxY2NmOGQwYTgxYjRhNzY2ZTlhYTFmZDRlNjhhMzA5IiwiYXRfaGFzaCI6IncwUG1fVFp4TlFfQTBRUU91RjJESUEiLCJhdWQiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiY19oYXNoIjoibzhIX0Fqc3FOSWkyd3g5LWVzcFo0dyIsInN1YiI6ImFkbWluIiwibmJmIjoxNjE1ODc0NTM5LCJhenAiOiJDVnlRZU01UDMzZ2ZOODB2dXIzTmN4elBnSHdhIiwiYW1yIjpbIkJhc2ljQXV0aGVudGljYXRvciJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE2MTU4NzgxMzksImlhdCI6MTYxNTg3NDUzOSwibm9uY2UiOiJhc2QifQ.LIoD9ltfqsxysMaC1b0kX-Ot4qL5GycpF5R-GIB_wBkQvN5BVEQZ4XV2t0t9GaQv1gSApsd6CtUAvV0haAqaNDElVcDQrmsyyHNzN0051biTQWQkoC4wwtO6_w1MSmgbH_aNVjQkBWt2vnaWtn6bt9sdZVxGRSb3_Amxdty_rDmiOzhJPwxZbkdPp1US0jmAn2XOoQQyH7e__qoXSjjoBAKXQtncJWAKtteDUBQTqVLj13TdS8dYqnEQByKNvhpz8rZjGaBV9pxtOWoqnbc3IMA4lX47Mpxl22ZqhIn0J6WCQ7nJtEkfx6XNHdatWZyG2x20pxbZkgya6sKAEoy3zw",
         "token_type":"Bearer",

--- a/en/docs/guides/oauth-request-path.md
+++ b/en/docs/guides/oauth-request-path.md
@@ -33,33 +33,53 @@ Send the following requests via your application to connect your application to 
 
 1. Use the following cURL command to get a valid token using password grant type. Replace the `<CLIENT_ID>`, `<CLIENT_SECRET>`, `<USERNAME>`, `<PASSWORD>`, `<IS_HOST>`, and `<IS_PORT>` tags with the relevant values.
 
-    ```tab="Request Format"
-    curl -v -X POST --basic -u <CLIENT_ID>:<CLIENT_SECRET> -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=password&username=<USERNAME>&password=<PASSWORD>" https://<IS_HOST>:<IS_PORT>/oauth2/token
-    ```
-
-    ```tab="Response Format"
-    {"token_type":"Bearer","expires_in":2655,"refresh_token":"2f03de95b8e196f78c94d07c23c9ef0a","access_token":"7ee57bc28a3336ccb7818b499941e4e4"}
-    ```
+    !!! abstract ""
+        **Request Format**    
+        ```
+        curl -v -X POST --basic -u <CLIENT_ID>:<CLIENT_SECRET> -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=password&username=<USERNAME>&password=<PASSWORD>" https://<IS_HOST>:<IS_PORT>/oauth2/token
+        ```
+        ---
+        **Response Format**
+        ```
+        {
+            "token_type":"Bearer","expires_in":2655,
+            "refresh_token":"2f03de95b8e196f78c94d07c23c9ef0a",
+            "access_token":"7ee57bc28a3336ccb7818b499941e4e4"
+        }
+        ```
 
 2. Send a cURL request using the access token you received as a response for step 1 in the authorization header, to the token endpoint. Replace the `<CLIENT_ID>`, `<REDIRECT_URI>`, `<IS_HOST>` and `<IS_PORT>` tags with the relevant values.
 
-    ```tab="Request Format"
-    curl -v -X POST -H "Authorization: Bearer 7ee57bc28a3336ccb7818b499941e4e4" -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "response_type=code&client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&scope=openid"  https://<IS_HOST>:<IS_PORT>/oauth2/authorize
-    ```
-
-    ```tab="Response Format"
-    Location: <REDIRECT_URI>?code=37c79c505960e90d5b25f62ce760c98c&session_state=6d1a72e0f3f6392d6648ec5e6ed0
-    ```
+    !!! abstract ""
+        **Request Format**    
+        ```
+        curl -v -X POST -H "Authorization: Bearer 7ee57bc28a3336ccb7818b499941e4e4" -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "response_type=code&client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&scope=openid"  https://<IS_HOST>:<IS_PORT>/oauth2/authorize
+        ```
+        ---
+        **Response Format**
+        ```
+        Location: <REDIRECT_URI>?code=37c79c505960e90d5b25f62ce760c98c&session_state=6d1a72e0f3f6392d6648ec5e6ed0
+        ```
     
 3. Use the following cURL command to get an access token using the authorization code received in step2. Replace the `<CLIENT_ID>`, `<CLIENT_SECRET>`, `<REDIRECT_URI>`, `<IS_HOST>` and `<IS_PORT>` tags with the relevant values.
 
-    ```tab="Request Format"
-    curl -v -X POST --basic -u <CLIENT_ID>:<CLIENT_SECRET>  -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=authorization_code&client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&code=37c79c505960e90d5b25f62ce760c98c&scope=openid" https://<IS_HOST>:<IS_PORT>/oauth2/token
-    ```
- 
-    ```tab="Response Format"
-    { "scope":"openid", "token_type":"Bearer", "expires_in":3600, "refresh_token":"70f202ca2e4ecf571d0b6d2e49af8f3a", "id_token":"eyJhbGciOiJSUzI1NiJ9.eyJhdXRoX3RpbWUiOjE0NjA0NTkzMTYsImV4cCI6MTQ2MDQ2MjkxNiwic3ViIjoiYWRtaW4iLCJhenAiOiJlN2VrQldVTVBITnFTNU5WQmhxNGhmNWZqMkVhIiwiYXRfaGFzaCI6IkhCWFVKQW50LWFMV3JxQlZJcTFoV2ciLCJhdWQiOlsiZTdla0JXVU1QSE5xUzVOVkJocTRoZjVmajJFYSJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJpYXQiOjE0NjA0NTkzMTZ9.PiqVn7B2vuICHmodnn9udjQrvGqRR-PZr-M8x8Xijg0bnAvzXY4hxqZ5luaLitBH2IgQ5p0Rh_gjPI7TWcQA7AK3iBCp7c29QY78hSSqt38_iG5bC0MYWoluH-jg5f3iyJ3aQ-DPAZexCXxEv65RPF5EDNfhA0fUFcsu79cb89k", "access_token":"7d6c01fb6bfaca22f01d9a24219cce45" }
-    ```
+    !!! abstract ""
+        **Request Format**    
+        ```
+        curl -v -X POST --basic -u <CLIENT_ID>:<CLIENT_SECRET>  -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -k -d "grant_type=authorization_code&client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&code=37c79c505960e90d5b25f62ce760c98c&scope=openid" https://<IS_HOST>:<IS_PORT>/oauth2/token
+        ```
+         ---
+        **Response Format**
+        ```
+        { 
+            "scope":"openid",
+            "token_type":"Bearer",
+            "expires_in":3600,
+            "refresh_token":"70f202ca2e4ecf571d0b6d2e49af8f3a",
+            "id_token":"eyJhbGciOiJSUzI1NiJ9.eyJhdXRoX3RpbWUiOjE0NjA0NTkzMTYsImV4cCI6MTQ2MDQ2MjkxNiwic3ViIjoiYWRtaW4iLCJhenAiOiJlN2VrQldVTVBITnFTNU5WQmhxNGhmNWZqMkVhIiwiYXRfaGFzaCI6IkhCWFVKQW50LWFMV3JxQlZJcTFoV2ciLCJhdWQiOlsiZTdla0JXVU1QSE5xUzVOVkJocTRoZjVmajJFYSJdLCJpc3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJpYXQiOjE0NjA0NTkzMTZ9.PiqVn7B2vuICHmodnn9udjQrvGqRR-PZr-M8x8Xijg0bnAvzXY4hxqZ5luaLitBH2IgQ5p0Rh_gjPI7TWcQA7AK3iBCp7c29QY78hSSqt38_iG5bC0MYWoluH-jg5f3iyJ3aQ-DPAZexCXxEv65RPF5EDNfhA0fUFcsu79cb89k",
+            "access_token":"7d6c01fb6bfaca22f01d9a24219cce45"
+        }
+        ```
  
     !!! Troubleshooting Tip 
             If you have not disabled consent, the response will be as follows.

--- a/en/docs/guides/password-mgt/challenge-question.md
+++ b/en/docs/guides/password-mgt/challenge-question.md
@@ -109,71 +109,96 @@ You can use the following CURL command to recover a password using REST API.
 
 This API is used to initiate password recovery using user challenge questions, one at a time. Response will be a random challenge question with a confirmation key.
 
-**Request**
-
-```curl
-curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-question?username=[USERNAME]"
-```
-
-```curl tab="Sample Request"
-curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-question?username=kim"
-```
-
-```curl tab="Sample Response"
-{"key":"7ced9ef0-7f3f-4f65-a115-ddbcce3a6b49","question":{"question":"Place of birth ?","question-set-id":"http://wso2.org/claims/challengeQuestion1"}
-```
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-question?username=[USERNAME]"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-question?username=kim"
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "key":"7ced9ef0-7f3f-4f65-a115-ddbcce3a6b49",
+        "question":{
+            "question":"Place of birth ?",
+            "question-set-id":"http://wso2.org/claims/challengeQuestion1"
+        }
+    }
+    ```
 
 ### Validate user challenge answer/answers
 
-**Request**
-
-```curl
-curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "[VALIDATION KEY]","answers": [{ "question-set-id": "http://wso2.org/claims/challengeQuestion1","answer": "[ANSWER]"},{"question-set-id": "http://wso2.org/claims/challengeQuestion2","[ANSWER2]": "car"}],"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/validate-answer"
-```
-
-```curl tab="Sample Request"
-curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "0b20bd4d-cd82-4e8f-8ca4-4d265360b56b","answers": [{ "question-set-id": "http://wso2.org/claims/challengeQuestion1","answer": "Sri Lanka"},{"question-set-id": "http://wso2.org/claims/challengeQuestion2","answer": "BMW"}],"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/validate-answer"
-```
-
-```curl tab="Sample Response"
-{"key":"c45d7251-59f1-468d-9844-8a6d7c5fe9d9","question":null,"link":{"rel":"set-password","uri":"/api/identity/recovery/v0.9"}}              
-```
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "[VALIDATION KEY]","answers": [{ "question-set-id": "http://wso2.org/claims/challengeQuestion1","answer": "[ANSWER]"},{"question-set-id": "http://wso2.org/claims/challengeQuestion2","[ANSWER2]": "car"}],"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/validate-answer"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -k -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "0b20bd4d-cd82-4e8f-8ca4-4d265360b56b","answers": [{ "question-set-id": "http://wso2.org/claims/challengeQuestion1","answer": "Sri Lanka"},{"question-set-id": "http://wso2.org/claims/challengeQuestion2","answer": "BMW"}],"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/validate-answer"
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "key":"c45d7251-59f1-468d-9844-8a6d7c5fe9d9",
+        "question":null,
+        "link":{"rel":"set-password","uri":"/api/identity/recovery/v0.9"}
+    }              
+    ```
 
 ### Get challenge questions of user
 
 This API is used to initiate password recovery by answering all the challenge questions at once. The response will have random challenge questions from the ones configured and a confirmation key.
 
-**Request**
-
-```curl 
-curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-questions?username=[USERNAME]"
-```
-
-```curl tab="Sample Request"
-curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-questions?username=kim"
-```
-
-```curl tab="Sample Response" 
-{"key":"f9f04fd7-3666-4bc6-bc99-9190b04b0ccc","questions":[{"question":"Place of birth?","question-set-id":"http://wso2.org/claims/challengeQuestion1"},{"question":"Model of your first car?","question-set-id":"http://wso2.org/claims/challengeQuestion2"}],"link":{"rel":"validate-answer","uri":"/api/identity/recovery/v0.9"}}
-```
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-questions?username=[USERNAME]"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/api/identity/recovery/v0.9/security-questions?username=kim"
+    ```
+    ---
+    **Sample Response**
+    ```
+    {
+        "key":"f9f04fd7-3666-4bc6-bc99-9190b04b0ccc",
+        "questions":[
+            {"question":"Place of birth?","question-set-id":"http://wso2.org/claims/challengeQuestion1"},
+            {"question":"Model of your first car?","question-set-id":"http://wso2.org/claims/challengeQuestion2"}
+        ],
+        "link":{"rel":"validate-answer","uri":"/api/identity/recovery/v0.9"}
+    }
+    ```
 
 ### Update password
 
 This API is used to reset user password using the confirmation key received through the recovery process. Input the key and the new password.
 
-**Request**
-
-```curl 
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "[CONFIRMATION KEY]", "password": "[NEW PASSWORD]","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
-```
-
-```curl tab="Sample Request" 
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "5c765a47-6764-4048-b5cf-55864cb654c0", "password": "Password1!","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
-```
-
-```curl tab="Sample Response"
-"HTTP/1.1 200 OK"        
-```
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "[CONFIRMATION KEY]", "password": "[NEW PASSWORD]","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "5c765a47-6764-4048-b5cf-55864cb654c0", "password": "Password1!","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
+    ```
+    ---
+    **Sample Response**
+    ```curl
+    "HTTP/1.1 200 OK"        
+    ```
 
 ---
 

--- a/en/docs/guides/password-mgt/recover-password.md
+++ b/en/docs/guides/password-mgt/recover-password.md
@@ -88,37 +88,41 @@ You can use the following CURL command to recover a password using REST API.
 
 This API is used to send password recovery confirmation over defined channels such as email or SMS.
 
-**Request**
-
-```curl
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user": {"username": "[USERNAME]","realm": "[USER STORE NAME]","tenant-domain":"[TENANT DOMAIN NAME]"},"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/recover-password?type=email&notify=true"
-```
-
-```curl tab="Sample Request"
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user": {"username": "kim","realm": "PRIMARY","tenant-domain":"carbon.super"},"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/recover-password?type=email&notify=true"
-```
-
-```curl tab="Sample Response" 
-"HTTP/1.1 202 Accepted"
-```
+!!! abstract ""
+    **Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user": {"username": "[USERNAME]","realm": "[USER STORE NAME]","tenant-domain":"[TENANT DOMAIN NAME]"},"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/recover-password?type=email&notify=true"
+    ```
+    ---
+    **Sample Request**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user": {"username": "kim","realm": "PRIMARY","tenant-domain":"carbon.super"},"properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/recover-password?type=email&notify=true"
+    ```
+    ---
+    **Sample Response**
+    ```curl
+    "HTTP/1.1 202 Accepted"
+    ```
 
 ### Update password
 
 This API is used to reset user password using the confirmation key received through the recovery process. Input the key and the new password.
 
-**Request**
-
-```curl 
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "[CONFIRMATION KEY]", "password": "[NEW PASSWORD]","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
-```
-
-```curl tab="Sample Request" 
-curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "5c765a47-6764-4048-b5cf-55864cb654c0", "password": "Password1!","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
-```
-
-```curl tab="Sample Response"
-"HTTP/1.1 200 OK"        
-```
+!!! abstract ""
+    **Request**
+    ```curl 
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "[CONFIRMATION KEY]", "password": "[NEW PASSWORD]","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
+    ```
+    ---
+    **Sample Request**
+    ```curl 
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"key": "5c765a47-6764-4048-b5cf-55864cb654c0", "password": "Password1!","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/set-password"
+    ```
+    ---
+    **Sample Response**
+    ```curl
+    "HTTP/1.1 200 OK"        
+    ```
 
 ---
 
@@ -126,21 +130,21 @@ curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: applic
  
  Run the following curl command to resend email notification for password reset. 
  
- **Request** 
- 
- ```curl
- curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user":{"username": <USERNAME>,"realm": <REALM>"},"properties": [{"key":"RecoveryScenario","value":"NOTIFICATION_BASED_PW_RECOVERY"}]}' "https://<IS_HOST>:<IS_PORT>/api/identity/user/v1.0/resend-code" -k -v
- ```
- 
- **Sample**
- 
- ```curl tab="Request"
- curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user":{"username": "admin","realm": "PRIMARY"},"properties": [{"key":"RecoveryScenario","value":"NOTIFICATION_BASED_PW_RECOVERY"}]}' "https://localhost:9443/api/identity/user/v1.0/resend-code" -k -v
- ```
- 
- ```curl tab="Response"
- HTTP/1.1 201 Created
- ```
+!!! abstract ""
+    **Request**  
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user":{"username": <USERNAME>,"realm": <REALM>"},"properties": [{"key":"RecoveryScenario","value":"NOTIFICATION_BASED_PW_RECOVERY"}]}' "https://<IS_HOST>:<IS_PORT>/api/identity/user/v1.0/resend-code" -k -v
+    ```
+    ---
+    **Sample**
+    ```curl
+    curl -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{"user":{"username": "admin","realm": "PRIMARY"},"properties": [{"key":"RecoveryScenario","value":"NOTIFICATION_BASED_PW_RECOVERY"}]}' "https://localhost:9443/api/identity/user/v1.0/resend-code" -k -v
+    ```
+    ---
+    **Response**
+    ```curl
+    HTTP/1.1 201 Created
+    ```
 
 !!! info "Related topics"
     - [Guide: Recover password via Challenge Questions](../../../guides/password-mgt/challenge-question)

--- a/en/docs/quick-starts/auth-code-playground.md
+++ b/en/docs/quick-starts/auth-code-playground.md
@@ -43,23 +43,26 @@ This page guides you through using a **sample Playground application** to try ou
 	to the **authorize** endpoint of the WSO2 Identity Server using the
 	following format.
 
-	```java tab="Request Format"
-	https://<host>:<port>/oauth2/authorize?response_type=code
-	&client_id=<client-ID>
-	&redirect_uri=<callback-url>
-	&scope=<scope>
-	```
+	!!! abstract ""
+		**Request Format**
+		```java
+		https://<host>:<port>/oauth2/authorize?response_type=code
+		&client_id=<client-ID>
+		&redirect_uri=<callback-url>
+		&scope=<scope>
+		```
+		---
+		**Sample Request**
+		```java
+		https://localhost:9443/oauth2/authorize?response_type=code
+		&client_id=Cx4LKFNObeuXocx7xgOpz5vfzFoa
+		&redirect_uri=http://wso2is.local:8080/playground2/oauth2client
+		&scope=openid
+		``` 
 
-	```java tab="Sample Request"
-	https://localhost:9443/oauth2/authorize?response_type=code
-	&client_id=Cx4LKFNObeuXocx7xgOpz5vfzFoa
-	&redirect_uri=http://wso2is.local:8080/playground2/oauth2client
-	&scope=openid
-	``` 
+4. Log in with user credentials (e.g., admin/admin).  
 
-3. Log in with user credentials (e.g., admin/admin).  
-
-4. Provide the requested consent and enter the following details on the screen that appears. 
+5. Provide the requested consent and enter the following details on the screen that appears. 
 
     - **Callback URL:** `http://<IS_HOST>:<IS_PORT>/playground2/oauth2client`
 

--- a/en/docs/quick-starts/client-credentials-playground.md
+++ b/en/docs/quick-starts/client-credentials-playground.md
@@ -29,23 +29,26 @@ This page guides you through using a **sample Playground application** to try ou
 	to the **authorize** endpoint of the WSO2 Identity Server using the
 	following format.
 	
-	```java tab="Request Format"
-	POST
-	https://<host>:<port>/oauth2/token
-	Authorization: Basic [Base64encode(Client-ID>:<ClientSecret>)]
-	Content-Type: application/x-www-form-urlencoded
+	!!! abstract ""
+        **Request Format**
+		```java
+		POST
+		https://<host>:<port>/oauth2/token
+		Authorization: Basic [Base64encode(Client-ID>:<ClientSecret>)]
+		Content-Type: application/x-www-form-urlencoded
 
-	grant_type=client_credentials
-	```
-	
-	```java tab="Sample Request"
-	POST
-	https://localhost:9443/oauth2/token
-	Authorization: Basic Q3g0TEtGTk9iZXVYb2N4N3hnT3B6NXZmekZvYTogVWRUNm5XbnFXWkdnNDFHWnI5TXBTWGs5eU04YQ==
-	Content-Type: application/x-www-form-urlencoded
+		grant_type=client_credentials
+		```
+		---
+        **Sample Request**
+		```java
+		POST
+		https://localhost:9443/oauth2/token
+		Authorization: Basic Q3g0TEtGTk9iZXVYb2N4N3hnT3B6NXZmekZvYTogVWRUNm5XbnFXWkdnNDFHWnI5TXBTWGs5eU04YQ==
+		Content-Type: application/x-www-form-urlencoded
 
-	grant_type=client_credentials
-	``` 
+		grant_type=client_credentials
+		```
 
 3. Log in with user credentials (e.g., `admin`/`admin`). At this point, the application receives the access token. 
 

--- a/en/docs/quick-starts/implicit-playground.md
+++ b/en/docs/quick-starts/implicit-playground.md
@@ -29,19 +29,22 @@ This page guides you through using a **sample Playground application** to try ou
 	to the **authorize** endpoint of the WSO2 Identity Server using the
 	following format.
 	
-	```java tab="Request Format"
-	https://<host>:<port>/oauth2/authorize?response_type=token
-	&client_id=<client-ID>
-	&redirect_uri=<callback-url>
-	&scope=<scope>
-	```
-	
-	```java tab="Sample Request"
-	https://localhost:9443/oauth2/authorize?response_type=id_token+token
-	&client_id=Cx4LKFNObeuXocx7xgOpz5vfzFoa
-	&redirect_uri=http://wso2is.local:8080/playground2/oauth2client
-	&scope=openid
-	``` 
+	!!! abstract ""
+        **Request Format**
+		```java
+		https://<host>:<port>/oauth2/authorize?response_type=token
+		&client_id=<client-ID>
+		&redirect_uri=<callback-url>
+		&scope=<scope>
+		```
+		---
+		**Sample Request**
+		```java
+		https://localhost:9443/oauth2/authorize?response_type=id_token+token
+		&client_id=Cx4LKFNObeuXocx7xgOpz5vfzFoa
+		&redirect_uri=http://wso2is.local:8080/playground2/oauth2client
+		&scope=openid
+		``` 
 
 3. Log in with user credentials (e.g., admin/admin). At this point, the application receives the ID token. 
 

--- a/en/docs/quick-starts/implicit-playground.md
+++ b/en/docs/quick-starts/implicit-playground.md
@@ -30,7 +30,7 @@ This page guides you through using a **sample Playground application** to try ou
 	following format.
 	
 	!!! abstract ""
-        **Request Format**
+		**Request Format**
 		```java
 		https://<host>:<port>/oauth2/authorize?response_type=token
 		&client_id=<client-ID>

--- a/en/docs/quick-starts/password-playground.md
+++ b/en/docs/quick-starts/password-playground.md
@@ -35,23 +35,26 @@ This page guides you through using a **sample Playground application** to try ou
 	to the **authorize** endpoint of the WSO2 Identity Server using the
 	following format.
 	
-	```java tab="Request Format"
-	POST
-	https://<host>:<port>/oauth2/token
-	Authorization: Basic [Base64encode(Client-ID>:<ClientSecret>)]
-	Content-Type: application/x-www-form-urlencoded
+	!!! abstract ""
+        **Request Format**
+		```java
+		POST
+		https://<host>:<port>/oauth2/token
+		Authorization: Basic [Base64encode(Client-ID>:<ClientSecret>)]
+		Content-Type: application/x-www-form-urlencoded
 
-	grant_type=password&username=<Resource Owner User Name>&password=<Resource Owner Password>
-	```
-	
-	```java tab="Sample Request"
-	POST
-	https://localhost:9443/oauth2/token
-	Authorization: Basic Q3g0TEtGTk9iZXVYb2N4N3hnT3B6NXZmekZvYTogVWRUNm5XbnFXWkdnNDFHWnI5TXBTWGs5eU04YQ==
-	Content-Type: application/x-www-form-urlencoded
+		grant_type=password&username=<Resource Owner User Name>&password=<Resource Owner Password>
+		```
+		---
+        **Sample Request**
+		```java
+		POST
+		https://localhost:9443/oauth2/token
+		Authorization: Basic Q3g0TEtGTk9iZXVYb2N4N3hnT3B6NXZmekZvYTogVWRUNm5XbnFXWkdnNDFHWnI5TXBTWGs5eU04YQ==
+		Content-Type: application/x-www-form-urlencoded
 
-	grant_type=password&username=admin&password=admin
-	``` 
+		grant_type=password&username=admin&password=admin
+		``` 
 
 3. Log in with user credentials (e.g., admin/admin). At this point, the application receives the access token. 
 

--- a/en/docs/quick-starts/query-saml-assertions-sample.md
+++ b/en/docs/quick-starts/query-saml-assertions-sample.md
@@ -64,81 +64,57 @@ Optionally, you can use a custom assertion builder that enables persisting asser
 
 7. Run the `main()` method of the class. Note that a request and response get generated similar to the following.
 
-    ``` xml tab="Request"
-    <?xml version="1.0" encoding="UTF-8" ?>
-    <saml2p:AssertionIDRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="_1c785f98-4e41-4a4d-a496-5e7432e700fa" IssueInstant="2016-09-12T03:18:24.762Z" Version="2.0">
-        <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">travelocity.com</saml2:Issuer>
-        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-            <ds:SignedInfo>
-                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
-                <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
-                <ds:Reference URI="#_1c785f98-4e41-4a4d-a496-5e7432e700fa">
-                    <ds:Transforms>
-                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
-                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
-                    </ds:Transforms>
-                    <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-                    <ds:DigestValue>TFH3NQVv2N41PnPh3G2dKDgg0mw=</ds:DigestValue>
-                </ds:Reference>
-            </ds:SignedInfo>
-            <ds:SignatureValue>a1wabcJTMDUv0KYTU3ftukKDR7e2zgd9Q6OFMDJmee7HcKb896spUprQIjMuvoMie9fxnm2+7346 q/zi5fe5Vdjid9MMAN7ls4iNbrIYnlHTdJzYX7ulQpNQ76GJevZw4N65qf/oaamc4HOOFw3TZYtv jYX0osmGqW5MjR9b748lQJ4kKgtgxzvT92s8Yn9OndJ+970pRuPdgZO57/LueSvUjHLfA7AuGGbH 5WDYuK4BJ6WnrhqzJ2Zc/OpilOO3uoP/RW4kJEtbMFpH6xWnb552uRYdS121qJasZM9aqzfKa0NH sWrZpmqwz0inXmZliqFShuhRKkIOF+2CmdZgXg==
-            </ds:SignatureValue>
-            <ds:KeyInfo>
-                <ds:X509Data>
-                    <ds:X509Certificate>MIIDezCCAmOgAwIBAgIEa4wPCDANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJMSzEQMA4GA1UE CBMHd2VzdGVybjEQMA4GA1UEBxMHY29sb21ibzEUMBIGA1UEChMLc29hc2VjdXJpdHkxETAPBgNV BAsTCHNlY3VyaXR5MRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTYwNzEzMTczMDQ5WhcNMTYxMDEx MTczMDQ5WjBuMQswCQYDVQQGEwJMSzEQMA4GA1UECBMHd2VzdGVybjEQMA4GA1UEBxMHY29sb21i bzEUMBIGA1UEChMLc29hc2VjdXJpdHkxETAPBgNVBAsTCHNlY3VyaXR5MRIwEAYDVQQDEwlsb2Nh bGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCRo50ubPqW09rzptxmKIaeSjFP UbkmsMUn1jQvrH5vyumRjBKDY//uXQwcCAcmTw4Bb5RVdZVOiJPxQixQghBGgaVv3UobuilYtNuS /qEVZvnX4RBNkADOXXp+inf5a8OQYjVV7aac1bcSFx/4DgvcWT6mPLpm4dMVMhBWYye0gfPHKMIR 1W1BR/+dJuZePJVa0xFzJ33CBA38vrqg6OuEsZY0fMMfFasyxepUlIECTkKq7ie5PP+31gqw9cAu bIfeO9HtXcQBC7GPgcCgRV7+azJS1MgxbpvlDHJnVxcTcX3IdMCrclCC87DJIMVpbDeK6oGSqbhu Kn69sqnq6e9PAgMBAAGjITAfMB0GA1UdDgQWBBRRWwyTdsm/QxyObtcHBKtH0EMQ2zANBgkqhkiG 9w0BAQsFAAOCAQEANy3xYK8wD9EuKyXbAeEJs5jvoL/2cI4EOZfP1VKAa3SHv+AYPzxqmuyMpD2f 6Tx9yyOP+0QNNynHMC6RPjz8Ib5GzSbvUfbJKXAU7GPc/7riKMJzv52NI8KqFdQ1Y7YiKAMs5dpJ QAhiLlRU9yuhljWqXQ5h8eVJ+vO+9+VPSctDuNpHrhbIZbwAd5Cf+Avp7VDdaU2UIG3Xg7AJkXRF Oa0pEVPW+brkq9uLYTA4bMcr+ROH9REUA0f1AuWfi4aVDFptfVwULCqT9PPliqoZxJEzqccGjWgf Q0NktrBaTVRQo5BPpfRja5l7ajYAPKL7vS3OGCF1Ycocq6Wa6WMj7g==
-                    </ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </ds:Signature>
-        <saml2:AssertionIDRef xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">_f013b1db55d7bdea33102b4d72159011</saml2:AssertionIDRef>
-    </saml2p:AssertionIDRequest>
-    ```
-
-    ``` xml tab="Response"
-    <?xml version="1.0" encoding="UTF-8" ?>
-    <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="_714cddb7f1c42d64376f0e6bd9d2f310" IssueInstant="2016-09-12T03:18:31.233Z" Version="2.0">
-        <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">localhost</saml2:Issuer>
-        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-            <ds:SignedInfo>
-                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
-                <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
-                <ds:Reference URI="#_714cddb7f1c42d64376f0e6bd9d2f310">
-                    <ds:Transforms>
-                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
-                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
-                    </ds:Transforms>
-                    <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-                    <ds:DigestValue>+ghoomfq6hsNvVqr3+SKcGowIu0=</ds:DigestValue>
-                </ds:Reference>
-            </ds:SignedInfo>
-            <ds:SignatureValue>YofQrnFqtF2bDrq7w1CsKQKI/E3GdimZ4INryN27hX4bSXa3EP4gHsGr0MH+Hhk6g9xYHbVBuCQR ht+/j8EBBmBnqHIxPrg43Xn+zNg9FmKtwqa8rXJeu5pELq0dhx/X6tSVzXAuDmLoOlyO/YwEYmuJ wnUZce4MfIlNt7UdyqM=
-            </ds:SignatureValue>
-            <ds:KeyInfo>
-                <ds:X509Data>
-                    <ds:X509Certificate>MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJVUzELMAkGA1UE CAwCQ0ExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxDTALBgNVBAoMBFdTTzIxEjAQBgNVBAMMCWxv Y2FsaG9zdDAeFw0xMDAyMTkwNzAyMjZaFw0zNTAyMTMwNzAyMjZaMFUxCzAJBgNVBAYTAlVTMQsw CQYDVQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzENMAsGA1UECgwEV1NPMjESMBAGA1UE AwwJbG9jYWxob3N0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCUp/oV1vWc8/TkQSiAvTou sMzOM4asB2iltr2QKozni5aVFu818MpOLZIr8LMnTzWllJvvaA5RAAdpbECb+48FjbBe0hseUdN5 HpwvnH/DW8ZccGvk53I6Orq7hLCv1ZHtuOCokghz/ATrhyPq+QktMfXnRS4HrKGJTzxaCcU7OQID AQABoxIwEDAOBgNVHQ8BAf8EBAMCBPAwDQYJKoZIhvcNAQEFBQADgYEAW5wPR7cr1LAdq+IrR44i QlRG5ITCZXY9hI0PygLP2rHANh+PYfTmxbuOnykNGyhM6FjFLbW2uZHQTY1jMrPprjOrmyK5sjJR O4d1DeGHT/YnIjs9JogRKv4XHECwLtIVdAbIdWHEtVZJyMSktcyysFcvuhPQK8Qc/E/Wq8uHSCo=
-                    </ds:X509Certificate>
-                </ds:X509Data>
-            </ds:KeyInfo>
-        </ds:Signature>
-        <saml2p:Status>
-            <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
-        </saml2p:Status>
-        <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_f013b1db55d7bdea33102b4d72159011" IssueInstant="2016-09-11T10:51:06.563Z" Version="2.0">
-            <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">localhost</saml2:Issuer>
+    !!! abstract ""
+        **Request**
+        ``` xml
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <saml2p:AssertionIDRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="_1c785f98-4e41-4a4d-a496-5e7432e700fa" IssueInstant="2016-09-12T03:18:24.762Z" Version="2.0">
+            <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">travelocity.com</saml2:Issuer>
             <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
                 <ds:SignedInfo>
                     <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
                     <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
-                    <ds:Reference URI="#_f013b1db55d7bdea33102b4d72159011">
+                    <ds:Reference URI="#_1c785f98-4e41-4a4d-a496-5e7432e700fa">
                         <ds:Transforms>
                             <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
                             <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
                         </ds:Transforms>
                         <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-                        <ds:DigestValue>4Ga5N4FTMUTAdkxiiuj9OeGTf3c=</ds:DigestValue>
+                        <ds:DigestValue>TFH3NQVv2N41PnPh3G2dKDgg0mw=</ds:DigestValue>
                     </ds:Reference>
                 </ds:SignedInfo>
-                <ds:SignatureValue>LRh6u1wTb7h7NgY+UoWtlgxhXRFyceYGxI7Q+ava2r+MhXl/N/uL5PgW6Bad5UwhqivINGuSrYJd L++taWxyaOVFQPNp2nEMRn+BhMgR2lWpyU/aaXgDIPyZGG5MrF0VI3r1s1NNBc1n0tREOeqxTSFZ eDLW/J2xCRYIZm8HKSU=
+                <ds:SignatureValue>a1wabcJTMDUv0KYTU3ftukKDR7e2zgd9Q6OFMDJmee7HcKb896spUprQIjMuvoMie9fxnm2+7346 q/zi5fe5Vdjid9MMAN7ls4iNbrIYnlHTdJzYX7ulQpNQ76GJevZw4N65qf/oaamc4HOOFw3TZYtv jYX0osmGqW5MjR9b748lQJ4kKgtgxzvT92s8Yn9OndJ+970pRuPdgZO57/LueSvUjHLfA7AuGGbH 5WDYuK4BJ6WnrhqzJ2Zc/OpilOO3uoP/RW4kJEtbMFpH6xWnb552uRYdS121qJasZM9aqzfKa0NH sWrZpmqwz0inXmZliqFShuhRKkIOF+2CmdZgXg==
+                </ds:SignatureValue>
+                <ds:KeyInfo>
+                    <ds:X509Data>
+                        <ds:X509Certificate>MIIDezCCAmOgAwIBAgIEa4wPCDANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJMSzEQMA4GA1UE CBMHd2VzdGVybjEQMA4GA1UEBxMHY29sb21ibzEUMBIGA1UEChMLc29hc2VjdXJpdHkxETAPBgNV BAsTCHNlY3VyaXR5MRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTYwNzEzMTczMDQ5WhcNMTYxMDEx MTczMDQ5WjBuMQswCQYDVQQGEwJMSzEQMA4GA1UECBMHd2VzdGVybjEQMA4GA1UEBxMHY29sb21i bzEUMBIGA1UEChMLc29hc2VjdXJpdHkxETAPBgNVBAsTCHNlY3VyaXR5MRIwEAYDVQQDEwlsb2Nh bGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCRo50ubPqW09rzptxmKIaeSjFP UbkmsMUn1jQvrH5vyumRjBKDY//uXQwcCAcmTw4Bb5RVdZVOiJPxQixQghBGgaVv3UobuilYtNuS /qEVZvnX4RBNkADOXXp+inf5a8OQYjVV7aac1bcSFx/4DgvcWT6mPLpm4dMVMhBWYye0gfPHKMIR 1W1BR/+dJuZePJVa0xFzJ33CBA38vrqg6OuEsZY0fMMfFasyxepUlIECTkKq7ie5PP+31gqw9cAu bIfeO9HtXcQBC7GPgcCgRV7+azJS1MgxbpvlDHJnVxcTcX3IdMCrclCC87DJIMVpbDeK6oGSqbhu Kn69sqnq6e9PAgMBAAGjITAfMB0GA1UdDgQWBBRRWwyTdsm/QxyObtcHBKtH0EMQ2zANBgkqhkiG 9w0BAQsFAAOCAQEANy3xYK8wD9EuKyXbAeEJs5jvoL/2cI4EOZfP1VKAa3SHv+AYPzxqmuyMpD2f 6Tx9yyOP+0QNNynHMC6RPjz8Ib5GzSbvUfbJKXAU7GPc/7riKMJzv52NI8KqFdQ1Y7YiKAMs5dpJ QAhiLlRU9yuhljWqXQ5h8eVJ+vO+9+VPSctDuNpHrhbIZbwAd5Cf+Avp7VDdaU2UIG3Xg7AJkXRF Oa0pEVPW+brkq9uLYTA4bMcr+ROH9REUA0f1AuWfi4aVDFptfVwULCqT9PPliqoZxJEzqccGjWgf Q0NktrBaTVRQo5BPpfRja5l7ajYAPKL7vS3OGCF1Ycocq6Wa6WMj7g==
+                        </ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </ds:Signature>
+            <saml2:AssertionIDRef xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">_f013b1db55d7bdea33102b4d72159011</saml2:AssertionIDRef>
+        </saml2p:AssertionIDRequest>
+        ```
+        ---
+        **Response**
+        ``` xml
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="_714cddb7f1c42d64376f0e6bd9d2f310" IssueInstant="2016-09-12T03:18:31.233Z" Version="2.0">
+            <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">localhost</saml2:Issuer>
+            <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:SignedInfo>
+                    <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                    <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
+                    <ds:Reference URI="#_714cddb7f1c42d64376f0e6bd9d2f310">
+                        <ds:Transforms>
+                            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                        </ds:Transforms>
+                        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+                        <ds:DigestValue>+ghoomfq6hsNvVqr3+SKcGowIu0=</ds:DigestValue>
+                    </ds:Reference>
+                </ds:SignedInfo>
+                <ds:SignatureValue>YofQrnFqtF2bDrq7w1CsKQKI/E3GdimZ4INryN27hX4bSXa3EP4gHsGr0MH+Hhk6g9xYHbVBuCQR ht+/j8EBBmBnqHIxPrg43Xn+zNg9FmKtwqa8rXJeu5pELq0dhx/X6tSVzXAuDmLoOlyO/YwEYmuJ wnUZce4MfIlNt7UdyqM=
                 </ds:SignatureValue>
                 <ds:KeyInfo>
                     <ds:X509Data>
@@ -147,25 +123,52 @@ Optionally, you can use a custom assertion builder that enables persisting asser
                     </ds:X509Data>
                 </ds:KeyInfo>
             </ds:Signature>
-            <saml2:Subject>
-                <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">admin</saml2:NameID>
-                <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-                    <saml2:SubjectConfirmationData NotOnOrAfter="2016-09-11T10:56:06.467Z" Recipient="http://travelocity.com" />
-                </saml2:SubjectConfirmation>
-            </saml2:Subject>
-            <saml2:Conditions NotBefore="2016-09-11T10:51:06.563Z" NotOnOrAfter="2016-09-11T10:56:06.467Z">
-                <saml2:AudienceRestriction>
-                    <saml2:Audience>travelocity.com</saml2:Audience>
-                </saml2:AudienceRestriction>
-            </saml2:Conditions>
-            <saml2:AuthnStatement AuthnInstant="2016-09-11T10:51:06.580Z" SessionIndex="d1e12225-6c86-49f7-9d13-b07793caecc4">
-                <saml2:AuthnContext>
-                    <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml2:AuthnContextClassRef>
-                </saml2:AuthnContext>
-            </saml2:AuthnStatement>
-        </saml2:Assertion>
-    </saml2p:Response>
-    ```
+            <saml2p:Status>
+                <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+            </saml2p:Status>
+            <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_f013b1db55d7bdea33102b4d72159011" IssueInstant="2016-09-11T10:51:06.563Z" Version="2.0">
+                <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">localhost</saml2:Issuer>
+                <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                    <ds:SignedInfo>
+                        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                        <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
+                        <ds:Reference URI="#_f013b1db55d7bdea33102b4d72159011">
+                            <ds:Transforms>
+                                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                                <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                            </ds:Transforms>
+                            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+                            <ds:DigestValue>4Ga5N4FTMUTAdkxiiuj9OeGTf3c=</ds:DigestValue>
+                        </ds:Reference>
+                    </ds:SignedInfo>
+                    <ds:SignatureValue>LRh6u1wTb7h7NgY+UoWtlgxhXRFyceYGxI7Q+ava2r+MhXl/N/uL5PgW6Bad5UwhqivINGuSrYJd L++taWxyaOVFQPNp2nEMRn+BhMgR2lWpyU/aaXgDIPyZGG5MrF0VI3r1s1NNBc1n0tREOeqxTSFZ eDLW/J2xCRYIZm8HKSU=
+                    </ds:SignatureValue>
+                    <ds:KeyInfo>
+                        <ds:X509Data>
+                            <ds:X509Certificate>MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJVUzELMAkGA1UE CAwCQ0ExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxDTALBgNVBAoMBFdTTzIxEjAQBgNVBAMMCWxv Y2FsaG9zdDAeFw0xMDAyMTkwNzAyMjZaFw0zNTAyMTMwNzAyMjZaMFUxCzAJBgNVBAYTAlVTMQsw CQYDVQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzENMAsGA1UECgwEV1NPMjESMBAGA1UE AwwJbG9jYWxob3N0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCUp/oV1vWc8/TkQSiAvTou sMzOM4asB2iltr2QKozni5aVFu818MpOLZIr8LMnTzWllJvvaA5RAAdpbECb+48FjbBe0hseUdN5 HpwvnH/DW8ZccGvk53I6Orq7hLCv1ZHtuOCokghz/ATrhyPq+QktMfXnRS4HrKGJTzxaCcU7OQID AQABoxIwEDAOBgNVHQ8BAf8EBAMCBPAwDQYJKoZIhvcNAQEFBQADgYEAW5wPR7cr1LAdq+IrR44i QlRG5ITCZXY9hI0PygLP2rHANh+PYfTmxbuOnykNGyhM6FjFLbW2uZHQTY1jMrPprjOrmyK5sjJR O4d1DeGHT/YnIjs9JogRKv4XHECwLtIVdAbIdWHEtVZJyMSktcyysFcvuhPQK8Qc/E/Wq8uHSCo=
+                            </ds:X509Certificate>
+                        </ds:X509Data>
+                    </ds:KeyInfo>
+                </ds:Signature>
+                <saml2:Subject>
+                    <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">admin</saml2:NameID>
+                    <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                        <saml2:SubjectConfirmationData NotOnOrAfter="2016-09-11T10:56:06.467Z" Recipient="http://travelocity.com" />
+                    </saml2:SubjectConfirmation>
+                </saml2:Subject>
+                <saml2:Conditions NotBefore="2016-09-11T10:51:06.563Z" NotOnOrAfter="2016-09-11T10:56:06.467Z">
+                    <saml2:AudienceRestriction>
+                        <saml2:Audience>travelocity.com</saml2:Audience>
+                    </saml2:AudienceRestriction>
+                </saml2:Conditions>
+                <saml2:AuthnStatement AuthnInstant="2016-09-11T10:51:06.580Z" SessionIndex="d1e12225-6c86-49f7-9d13-b07793caecc4">
+                    <saml2:AuthnContext>
+                        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml2:AuthnContextClassRef>
+                    </saml2:AuthnContext>
+                </saml2:AuthnStatement>
+            </saml2:Assertion>
+        </saml2p:Response>
+        ```
 
 You have successfully queried an assertion with an `AssertionIDRequest` using the sample application. 
 

--- a/en/docs/quick-starts/saml2-bearer-assertion-profile.md
+++ b/en/docs/quick-starts/saml2-bearer-assertion-profile.md
@@ -205,38 +205,63 @@ For example,
 
     **Request**
 
-    ``` java tab="Request Format"
-    curl -k -u <username>:<password> -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=<access token>' https://<IS_HOST>:<IS_PORT>/oauth2/introspect
-    ```
-
-    ``` java tab="Sample Request"
-    curl -k -u admin:admin -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=f3116b04-924f-3f1a-b323-4f0988b94f9f' https://localhost:9443/oauth2/introspect
-    ```
+    !!! abstract ""
+        **Request Format**
+        ``` java
+        curl -k -u <username>:<password> -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=<access token>' https://<IS_HOST>:<IS_PORT>/oauth2/introspect
+        ```
+        ---
+        **Sample Request**
+        ``` java
+        curl -k -u admin:admin -H 'Content-Type: application/x-www-form-urlencoded' -X POST --data 'token=f3116b04-924f-3f1a-b323-4f0988b94f9f' https://localhost:9443/oauth2/introspect
+        ```
 
     **Response**
 
     ``` java
-    {"active":true,"token_type":"Bearer","exp":1508927700,"iat":1508924100,"client_id":"EiqKsYfVH6dffF0b6LmrFBJW95Aa","username":"admin@carbon.super"}
+    {
+        "active":true,
+        "token_type":"Bearer",
+        "exp":1508927700,
+        "iat":1508924100,
+        "client_id":"EiqKsYfVH6dffF0b6LmrFBJW95Aa"
+        "username":"admin@carbon.super"
+    }
     ```
 
-6.  Since the Travelocity application has now exchanged the SAML assertion for a valid OAuth access token, you can use the received access token to access a protected resource in WSO2 Identity Server. 
+7.  Since the Travelocity application has now exchanged the SAML assertion for a valid OAuth access token, you can use the received access token to access a protected resource in WSO2 Identity Server. 
 
     Use the [SCIM User Endpoint](insertlink) which is secured with OAuth to retrieve users. 
 
     **Request**
 
-    ``` java tab="Request Format"
-    curl -v -k --header "Authorization: Bearer <access token>" https://<IS_HOST>:<IS_PORT>/wso2/scim/Users
-    ```
-
-    ``` java tab="Sample Request"
-    curl -v -k --header "Authorization: Bearer 865c60a5-969b-36b4-95e2-721a1fb5c867" https://localhost:9443/wso2/scim/Users
-    ```
+    !!! abstract ""
+        **Request Format**
+        ``` java
+        curl -v -k --header "Authorization: Bearer <access token>" https://<IS_HOST>:<IS_PORT>/wso2/scim/Users
+        ```
+        ---
+        **Sample Request**
+        ``` java
+        curl -v -k --header "Authorization: Bearer 865c60a5-969b-36b4-95e2-721a1fb5c867" https://localhost:9443/wso2/scim/Users
+        ```
     
     **Response**
 
     ``` java
-    {"totalResults":1,"schemas":["urn:scim:schemas:core:1.0"],"Resources":[{"meta":{"created":"2017-11-15T11:23:25","location":"https://localhost:9443/wso2/scim/Users/admin","lastModified":"2017-11-15T11:23:25"},"id":"0fb2af3f-03f2-4d6b-8340-957012df23f4","userName":"admin"}]}
+    {
+        "totalResults":1,
+        "schemas":["urn:scim:schemas:core:1.0"],
+        "Resources":[{
+            "meta":{
+                "created":"2017-11-15T11:23:25",
+                "location":"https://localhost:9443/wso2/scim/Users/admin"
+                "lastModified":"2017-11-15T11:23:25"
+            },
+            "id":"0fb2af3f-03f2-4d6b-8340-957012df23f4",
+            "userName":"admin"
+        }]
+    }
     ```
 
 !!! info "Related topics"

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -830,6 +830,7 @@ markdown_extensions:
   - pymdownx.tilde
   - markdown_include.include:
       base_path: docs/
+  - attr_list
            
 # Extra
 extra_css:

--- a/en/theme/material/partials/nav-item.html
+++ b/en/theme/material/partials/nav-item.html
@@ -13,7 +13,7 @@
       <div class="nav__link-text">
         {{ nav_item.title }}
       </div>
-      <img class="nav__link-icon" src="assets/img/icons/landing-page/arrow_down.svg">
+      <img class="nav__link-icon" src="../../../assets/img/icons/landing-page/arrow_down.svg">
     </label>
     <nav class="md-nav" data-md-component="collapsible" data-md-level="{{ level }}">
       <label class="md-nav__title" for="{{ path }}">

--- a/en/theme/material/templates/landing-page.html
+++ b/en/theme/material/templates/landing-page.html
@@ -124,6 +124,11 @@
     margin-top: 0;
   }
 
+  .md-typeset img {
+    border: none !important;
+    padding: 0 !important;
+  }
+
   @media (max-width: 1220px) {
     .md-header-nav {
       margin-right: auto;


### PR DESCRIPTION
## Purpose
Implements a new UI in place of the tabs UI that is currently being used to represent the response/request format and their samples in on-prem docs site.

## Goals
This PR replaces the existing tab-based UI with a more intuitive block-based UI and fixes the issue mentioned below.

Resolves https://github.com/wso2/product-is/issues/11847

## Approach

1.  For this purpose, MkDocs Material Admonition UI component were used.

2. `Tabs` UI components in above-mentioned places were replaced by `Admonition` UI as the parent and each section of **Request/Response Format** and **Request/Response Sample** were included as the contents inside the Admonition as child elements separated with a horizontal rule.

3. `theme.css` file was used to override the default properties of `Admonitions` to make it look in line with the design of on-prem docs site.

![Concept #4](https://user-images.githubusercontent.com/42619922/121296373-299fdd80-c90e-11eb-9fcc-32dda4582aad.png)


## Test environment
Tested with the following Mkdocs dependencies on Ubuntu 20.04.1

- mkdocs - 1.1.2
- mkdocs-material - 4.1.1
- mkdocs-material-extensions - 1.0.1
- pymdown-extensions - 5.0