### PR TITLE
Add persisting scroll position to left navigation after page refresh

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -38,7 +38,7 @@
 }
 
 .md-sidebar[data-md-state=lock] {
-    top: 4rem !important;
+    top: unset !important;
 }
 
 .md-main.hide-toc .md-content {
@@ -51,7 +51,6 @@
 
 .md-sidebar {
     padding: 1.45rem 0;
-    top: 4rem !important;
 }
 
 .md-header {
@@ -1740,5 +1739,10 @@ h5 {
 
 .border-img {
     border: #dadada solid 1px !important;
+}
+
+.md-main__inner {
+    margin-top: 2.5rem;
+    padding-top: 0 !important;
 }
 

--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -1720,11 +1720,6 @@ h5 {
     border-bottom: 3px solid #ff7300;
 }
 
-/* custom CSS for code snippets inside admonitions */
-/* .admonition > .codehilite {
-    background-color: #fff !important;
-} */
-
 .admonition > .codehilite > .md-clipboard:before {
     color: #adadad;
 }

--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -322,7 +322,7 @@ window.onbeforeunload = function () {
     sessionStorage.clear("navScrollPos");
     sessionStorage.setItem("navScrollPos", leftSidebarScrollPos);
 }
-// Retriving the scroll position on reload.
+// Retrieving the scroll position on reload.
 window.onload = function () {
     var prevScrollPos = parseInt(sessionStorage.getItem("navScrollPos"));
     if(prevScrollPos) {

--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -306,7 +306,7 @@ window.addEventListener("hashchange", function () {
     window.scrollTo(window.scrollX, window.scrollY - 40, 'smooth');
 });
 
-// Preserving scroll position of the left nav on reload or switching pages
+// Preserving scroll position of the left nav on reload or switching pages.
 let timer = null;
 var leftSidebarScrollPos = 0;
 var leftSidebar = document.querySelector(".md-sidebar--primary > .md-sidebar__scrollwrap");
@@ -317,12 +317,12 @@ leftSidebar.addEventListener('scroll', (function (e) {
     },100)
 }));
 
-// Saving the scroll position in session storage
+// Saving the scroll position in session storage.
 window.onbeforeunload = function () {
     sessionStorage.clear("navScrollPos");
     sessionStorage.setItem("navScrollPos", leftSidebarScrollPos);
 }
-// Retriving the scroll position on reload
+// Retriving the scroll position on reload.
 window.onload = function () {
     var prevScrollPos = parseInt(sessionStorage.getItem("navScrollPos"));
     if(prevScrollPos) {

--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -305,3 +305,28 @@ window.addEventListener('scroll', function() {
 window.addEventListener("hashchange", function () {
     window.scrollTo(window.scrollX, window.scrollY - 40, 'smooth');
 });
+
+// Preserving scroll position of the left nav on reload or switching pages
+let timer = null;
+var leftSidebarScrollPos = 0;
+var leftSidebar = document.querySelector(".md-sidebar--primary > .md-sidebar__scrollwrap");
+leftSidebar.addEventListener('scroll', (function (e) {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+        leftSidebarScrollPos = leftSidebar.scrollTop;
+        console.log(leftSidebarScrollPos);
+    },100)
+}));
+
+// saving the scroll position in session storage
+window.onbeforeunload = function () {
+    sessionStorage.clear("navScrollPos");
+    sessionStorage.setItem("navScrollPos", leftSidebarScrollPos);
+}
+// retriving the scroll position on reload
+window.onload = function () {
+    var prevScrollPos = parseInt(sessionStorage.getItem("navScrollPos"));
+    if(prevScrollPos) {
+        leftSidebar.scrollTop = prevScrollPos;
+    }
+}

--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -314,16 +314,15 @@ leftSidebar.addEventListener('scroll', (function (e) {
     clearTimeout(timer);
     timer = setTimeout(() => {
         leftSidebarScrollPos = leftSidebar.scrollTop;
-        console.log(leftSidebarScrollPos);
     },100)
 }));
 
-// saving the scroll position in session storage
+// Saving the scroll position in session storage
 window.onbeforeunload = function () {
     sessionStorage.clear("navScrollPos");
     sessionStorage.setItem("navScrollPos", leftSidebarScrollPos);
 }
-// retriving the scroll position on reload
+// Retriving the scroll position on reload
 window.onload = function () {
     var prevScrollPos = parseInt(sessionStorage.getItem("navScrollPos"));
     if(prevScrollPos) {

--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -342,3 +342,4 @@ window.onload = function () {
         window.scroll({top: (targetElement.offsetTop - offset), left: 0, behavior: "smooth"});
     }
 }
+

--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -329,3 +329,15 @@ window.onload = function () {
         leftSidebar.scrollTop = prevScrollPos;
     }
 }
+
+// Offsetting the scroll in anchors to compensate for the secondary header (tabs).
+window.onload = function () {
+    var targetHash = window.location.hash;
+    var offset = 50;
+    // If coming from an external link, the hash value will be there in the URL.
+    if (targetHash) {
+        var targetElement = document.querySelector(targetHash);
+        // Scroll to the target element with the offset value set above.
+        window.scroll({top: (targetElement.offsetTop - offset), left: 0, behavior: "smooth"});
+    }
+}


### PR DESCRIPTION
## Purpose
Makes the scrollbar in the left navigation remember its last scroll position and then scroll back to that position whenever page refresh occurs (such as switching to another page) and thereby improving the UX. 
This also improves the UX by offsetting the scroll bar by few pixels when coming from to accommodate the space taken by the header. This will allow the users to see target the heading they clicked on without being obstructed by the top header.

## Goals

1. Preserve the scroll position of the left navigation when the page is reloaded so that the user will not have to scroll back to the same position if he/she visits a different link or refreshes the page.

2. Offsetting the scroll position by few pixels to prevent the target headers being obstructed by the header when a user is coming from a target link.

Resolves https://github.com/wso2/product-is/issues/11908
Resolves https://github.com/wso2/product-is/issues/11909

## Approach

1.  This was achieved using a Javascript code added to `en/docs/assets/js/theme.js`

2.  The current scroll position of the left navigation was extracted and stored in `session storage` just before the reload occurs.

3.  After the reload, the stored variable was taken from session storage and reassigned as the new scroll position of the left navigation, persisting the scroll position after reload.

4. Scroll offset was handled by adding an offset value of  `50` to the scroll when a user is coming from another page via target links.

## Test environment

- mkdocs - 1.1.2
- mkdocs-material - 4.1.1
- mkdocs-material-extensions - 1.0.1
- pymdown-extensions - 5.0
 