### PR TITLE
Fix a issue in X509Certificate Authenticator

### DIFF
--- a/en/docs/learn/x509certificate-authenticator.md
+++ b/en/docs/learn/x509certificate-authenticator.md
@@ -149,7 +149,7 @@ Once you have done the above steps, you have the keystore (`localcrt.jks`), trus
     `<IS_HOME>/repository/conf/deployment.toml` file.
 
     ``` toml 
-    [custom_trasport.x509.properties]
+    [custom_transport.x509.properties]
     protocols="HTTP/1.1"
     port="8443"
     maxThreads="200"


### PR DESCRIPTION
## Purpose
> Fix a spelling mistake in Configuring X509Certificate Authenticator.