### PR TITLE
Fixing broken link

### DIFF
--- a/en/docs/learn/consent-management-with-single-sign-on.md
+++ b/en/docs/learn/consent-management-with-single-sign-on.md
@@ -140,7 +140,7 @@ authentication.
     !!! tip
     
         For more information on revoking/accepting user consent, see
-        [Consent management](../../learn/consent-management/)
+        [Consent management](../../learn/my-account/#consent-management)
         .
     
 

--- a/en/docs/learn/consent-management-with-single-sign-on.md
+++ b/en/docs/learn/consent-management-with-single-sign-on.md
@@ -140,7 +140,7 @@ authentication.
     !!! tip
     
         For more information on revoking/accepting user consent, see
-        [Consent management](../../learn/user-portal/#consent-management)
+        [Consent management](../../learn/consent-management/)
         .
     
 


### PR DESCRIPTION
Link "learn/user-portal/#consent-management" is broken.

Correct link is:
"learn/consent-management/"