### PR TITLE
user-portal broken link

### DIFF
--- a/en/docs/learn/configuring-totp.md
+++ b/en/docs/learn/configuring-totp.md
@@ -92,7 +92,7 @@ and security during the authentication for this application.
 ## Configuring the user profile
 
 1.  Login to the
-    [user portal](../../learn/user-portal) and go to **Personal info**.  
+    [My Account user portal](../../learn/my-account) and go to **Personal info**.  
 2.  Update your email address in **Profile**(this email address is used to send the
     token).
     ![my-profile-gadget](../assets/img/tutorials/update-email-in-profile.png)


### PR DESCRIPTION
Update link from user-portal to my-account.

## Purpose
Fix broken link.

## Goals
Have user portal link go to the my-account page.

## Approach
Changing the markdown to use the correct URL.

## Certification
N/A, this documentation working can only improve the certification process.