### PR TITLE
[5.11.0] - Add stepOptions configurations details in the Adaptive Authentication JS API Reference page

### DIFF
--- a/en/docs/references/adaptive-authentication-js-api-reference.md
+++ b/en/docs/references/adaptive-authentication-js-api-reference.md
@@ -105,9 +105,7 @@ object such as `           authenticationOptions          `, `           authent
     ``` java
     executeStep(1, {
         stepOptions: {
-            forceAuth: 'true',
-            subjectIdentifier: 'true',
-            subjectAttributeStep: 'true'
+            forceAuth: 'true'
         }
     }, {} );
     ```
@@ -143,33 +141,8 @@ executeStep(1,{
 **Authentication step options**
 
 `         stepOptions        ` is an optional property that can be defined in the `         executeStep         `.
-This will add additional authentication options like `         forceAuth        `,
-`         subjectIdentifier        ` &
-`         subjectAttributeStep        ` . These attributes work as follows,
-
-<table>
-<thead>
-<tr class="header">
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>forceAuth</td>
-<td>Force the authenticators in the steps to prompt again even if it's already authenticated<br />
-**note: <b>onSuccess</b> callback should be provided for this to work.</td>
-</tr>
-<tr class="even">
-<td>subjectIdentifier</td>
-<td>Set the current authentication step as the subject identifier step. This will override the already configured subject identifier step.</td>
-</tr>
-<tr class="odd">
-<td>subjectAttributeStep</td>
-<td>Set the current authentication step as the subject attribute step.  This will override the already configured subject attribute step.</td>
-</tr>
-</tbody>
-</table>
+This will allow adding the additional `         forceAuth        ` authentication option. The `         forceAuth        ` option can
+force the authenticator in the steps to prompt again event if it was already authenticated.
 
 **Example code**
 
@@ -178,17 +151,9 @@ executeStep(1, {
     stepOptions: {
         forceAuth: 'true'
      }
-}, {} );
+}, {});
 ```
 
-``` java
-executeStep(1, {
-    stepOptions: {
-        subjectIdentifier: 'true',
-        subjectAttributeStep: 'true'
-     }
-}, {} );
-```
 
 ### Utility functions
 

--- a/en/docs/references/adaptive-authentication-js-api-reference.md
+++ b/en/docs/references/adaptive-authentication-js-api-reference.md
@@ -100,7 +100,16 @@ The API can be called in either of the following ways:
         }
     });
     ```
-      
+    ``` java
+    executeStep(1, {
+        stepOptions: {
+            forceAuth: 'true',
+            subjectIdentifier: 'true',
+            subjectAttributeStep: 'true'
+        }
+    });
+    ```
+
     !!! note
     
         The API cannot be called with only the `           stepId          `
@@ -125,6 +134,55 @@ executeStep(1,{
    },{
        onSuccess: function (context) {
            // Do something on success
+};
+```
+
+<a name = "step-options"></a>
+**Authentication step options**
+
+`         stepOptions        ` is an optional property that can be defined in the `         executeStep         `.
+This will add additional authentication options like `         forceAuth        `,
+`         subjectIdentifier        ` &
+`         subjectAttributeStep        ` . These attributes work as follows,
+
+<table>
+<thead>
+<tr class="header">
+<th>Attribute</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>forceAuth</td>
+<td>force a particular authentication step from adaptive authentication script.<br />
+**note: <b>onSuccess</b> callback should be provided for this to work.</td>
+</tr>
+<tr class="even">
+<td>subjectIdentifier</td>
+<td>Set the current authentication step as the subject identifier step.</td>
+</tr>
+<tr class="odd">
+<td>subjectAttributeStep</td>
+<td>Set the current authentication step as the subject attribute step.</td>
+</tr>
+</tbody>
+</table>
+
+**Example code**
+
+``` java
+executeStep(1, {
+    stepOptions: {
+        forceAuth: 'true'
+};
+```
+
+``` java
+executeStep(1, {
+    stepOptions: {
+        subjectIdentifier: 'true',
+        subjectAttributeStep: 'true'
 };
 ```
 

--- a/en/docs/references/adaptive-authentication-js-api-reference.md
+++ b/en/docs/references/adaptive-authentication-js-api-reference.md
@@ -80,7 +80,9 @@ The API can be called in either of the following ways:
 
 -   With the `           stepId          `,
     `           options          `, and an empty
-    `           eventCallbacks          ` array.  Different properties can be defined in the `           options          ` object such as `           authenticationOptions          `, `           authenticatorParams          `. See the following two examples:
+    `           eventCallbacks          ` array.  Different properties can be defined in the `           options          ` 
+object such as `           authenticationOptions          `, `           authenticatorParams          `,
+`           stepOptions          `. See the following examples:
 
     ``` java
     executeStep(1,{
@@ -98,7 +100,7 @@ The API can be called in either of the following ways:
                                     }
             }
         }
-    });
+    }, {} );
     ```
     ``` java
     executeStep(1, {
@@ -107,7 +109,7 @@ The API can be called in either of the following ways:
             subjectIdentifier: 'true',
             subjectAttributeStep: 'true'
         }
-    });
+    }, {} );
     ```
 
     !!! note
@@ -155,16 +157,16 @@ This will add additional authentication options like `         forceAuth        
 <tbody>
 <tr class="odd">
 <td>forceAuth</td>
-<td>force a particular authentication step from adaptive authentication script.<br />
+<td>Force the authenticators in the steps to prompt again even if it's already authenticated<br />
 **note: <b>onSuccess</b> callback should be provided for this to work.</td>
 </tr>
 <tr class="even">
 <td>subjectIdentifier</td>
-<td>Set the current authentication step as the subject identifier step.</td>
+<td>Set the current authentication step as the subject identifier step. This will override the already configured subject identifier step.</td>
 </tr>
 <tr class="odd">
 <td>subjectAttributeStep</td>
-<td>Set the current authentication step as the subject attribute step.</td>
+<td>Set the current authentication step as the subject attribute step.  This will override the already configured subject attribute step.</td>
 </tr>
 </tbody>
 </table>
@@ -175,7 +177,8 @@ This will add additional authentication options like `         forceAuth        
 executeStep(1, {
     stepOptions: {
         forceAuth: 'true'
-};
+     }
+}, {} );
 ```
 
 ``` java
@@ -183,7 +186,8 @@ executeStep(1, {
     stepOptions: {
         subjectIdentifier: 'true',
         subjectAttributeStep: 'true'
-};
+     }
+}, {} );
 ```
 
 ### Utility functions


### PR DESCRIPTION
## Purpose
* Add stepOptions config details with all the sub-attributes (`forceAuth`, `subjectIdentifier`,  `subejctAttributeStep`) in the Adaptive Authentication JS API Reference page
* Fixes https://github.com/wso2/product-is/issues/10973

Related PR(s):
* https://github.com/wso2/carbon-identity-framework/pull/3858
* https://github.com/wso2/carbon-identity-framework/pull/2961