### PR TITLE
[5.10] Update callback URL examples

### DIFF
--- a/en/docs/develop/service-provider-configurations-used-with-apis.md
+++ b/en/docs/develop/service-provider-configurations-used-with-apis.md
@@ -349,7 +349,7 @@ This section guides you through the configurations you can include in a service 
                                 <li>https://testapp:8000/callback</li>
                             </ul>
                         <p>To configure the callback URL to work for both of these URLs, set it using a regex pattern as follows:<br>
-                            <code>regexp=(https://myapp.com/callback|https://testapp:8000/callback)</code><br>
+                            <code>regexp=(https://((myapp\.com)|(testapp:8000))(/callback))</code><br>
                         <p>Make sure to set the prefix 'regexp=' before your regex pattern. To define a normal URL, you can specify the callback URL without this prefix.</p>
                         </p>
                     </div> 

--- a/en/docs/learn/configuring-oauth2-openid-connect-single-sign-on.md
+++ b/en/docs/learn/configuring-oauth2-openid-connect-single-sign-on.md
@@ -106,7 +106,7 @@ Let's get started to configure the service provider you created!
                <div class="code panel pdl" style="border-width: 1px;">
                   <div class="codeContent panelContent pdl">
                      <div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence">
-                        <pre class="sourceCode java"><code class="sourceCode java"><a class="sourceLine" id="cb1-1" title="1">regexp=(https:<span class="co">//myapp.com/callback|https://testapp:8000/callback)</span></a></code></pre>
+                        <pre class="sourceCode java"><code class="sourceCode java"><a class="sourceLine" id="cb1-1" title="1">regexp=(https:<span class="co">//((myapp\.com)|(testapp:8000))(/callback))</span></a></code></pre>
                      </div>
                   </div>
                </div>

--- a/en/docs/learn/openid-connect-single-logout.md
+++ b/en/docs/learn/openid-connect-single-logout.md
@@ -278,7 +278,7 @@ WSO2 Identity Server Management Console:
         </p>
         <div class="code panel pdl" style="border-width: 1px;">
         <div class="codeContent panelContent pdl">
-        <div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><pre class="sourceCode java"><code class="sourceCode java"><a class="sourceLine" id="cb1-1" title="1">regexp=(https:<span class="co">//myapp.com/callback|https://testapp:8000/callback)</span></a></code></pre></div>
+        <div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><pre class="sourceCode java"><code class="sourceCode java"><a class="sourceLine" id="cb1-1" title="1">regexp=(https:<span class="co">//((myapp\.com)|(testapp:8000))(/callback))</span></a></code></pre></div>
         </div>
         </div>
         <div class="admonition note">


### PR DESCRIPTION
Change callback URL changes as follows
`regexp=(https://myapp.com/callback|https://testapp:8000/callback) ` ->  `regexp=(https://((myapp\.com)|(testapp:8000))(/callback))`

Backported PR:
https://github.com/wso2/docs-is/pull/2831