### PR TITLE
Add WIP banner to 5.12 docs

### DIFF
--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -38,6 +38,7 @@
           {% else %}
             <span class="md-header-nav__topic">
               {{ config.site_name | replace('WSO2', '') }}
+              <span class="beta-badge"><b>This documentation version is Work in Progress!</br>Please see the <a href="https://is.docs.wso2.com/en/latest/"><u>latest released documentation</u></a>.</b></span>
             </span>
             <span class="md-header-nav__topic">
               {{ page.title }}


### PR DESCRIPTION
Added a WIP banner.

<img width="1417" alt="Screenshot 2022-03-07 at 22 29 11" src="https://user-images.githubusercontent.com/21237558/157081354-7e254833-3024-4856-a57c-910d7c9b6fe4.png">
