### PR TITLE
Add Description on H2 Console Removal to what-has-changed page

### DIFF
--- a/en/docs/setup/migrating-what-has-changed.md
+++ b/en/docs/setup/migrating-what-has-changed.md
@@ -303,7 +303,7 @@ proxy_context_path="abc"
 
 ## Removed H2 console
 
-The H2 console packed with the embedded H2 database bears the risk of having security vulnerabilities due to remote code execution. Since there is no valid usage of the H2 console feature in the production environments and is only useful during development tasks, it has been removed from the WSO2 IS 5.12.0. As an alternative, use standard database client software for development or testing purposes.  
+The H2 console, which is packed with the embedded H2 database can cause security vulnerabilities due to remote code execution. Since there is no valid usage of the H2 console in production environments and is only useful during development tasks, it has been removed from WSO2 IS 5.12.0. As an alternative, you can use standard database client software for development or testing purposes.  
 
 ## WS-Trust authenticator moved to the connector store
 

--- a/en/docs/setup/migrating-what-has-changed.md
+++ b/en/docs/setup/migrating-what-has-changed.md
@@ -301,6 +301,10 @@ From WSO2 Identity Server 5.11.0 onwards, we have deprecated the `WebContextRoot
 proxy_context_path="abc"
 ```
 
+## Removed H2 Console
+
+The H2 console packed with the embedded H2 database bears the risk of having security vulnerabilities due to remote code execution. Since there is no valid usage of the H2 console feature in the production environments and is only useful during development tasks, it has been removed from the WSO2 IS 5.12.0. As an alternative, use standard database client software for development or testing purposes.  
+
 ## WS-Trust authenticator moved to the connector store
 
 WS-Trust authentication is no longer supported by default in WSO2 IS 5.11.0 and has been introduced as a connector. To use WS-Trust authentication, [configure the connector](https://github.com/wso2-extensions/identity-inbound-auth-sts/tree/master/docs). 

--- a/en/docs/setup/migrating-what-has-changed.md
+++ b/en/docs/setup/migrating-what-has-changed.md
@@ -301,7 +301,7 @@ From WSO2 Identity Server 5.11.0 onwards, we have deprecated the `WebContextRoot
 proxy_context_path="abc"
 ```
 
-## Removed H2 Console
+## Removed H2 console
 
 The H2 console packed with the embedded H2 database bears the risk of having security vulnerabilities due to remote code execution. Since there is no valid usage of the H2 console feature in the production environments and is only useful during development tasks, it has been removed from the WSO2 IS 5.12.0. As an alternative, use standard database client software for development or testing purposes.  
 


### PR DESCRIPTION
This PR adds more details about removing the H2 console to the `What has changed` page.

Related to : https://github.com/wso2/docs-is/pull/2857