### PR TITLE
[5.11.0] - Add further information to the documentation.

### DIFF
--- a/en/docs/learn/configuring-email-otp.md
+++ b/en/docs/learn/configuring-email-otp.md
@@ -64,6 +64,7 @@ as explained [here](../../setup/configuring-email-sending).
     showEmailAddressInUI = true
     useEventHandlerBasedEmailSender = true
     emailAddressRegex = '(?&lt;=.{1}).(?=.*@)'
+    tokenExpirationTime = 300000
     ``` 
 
 
@@ -83,9 +84,9 @@ as explained [here](../../setup/configuring-email-sending).
                         <ul>
                             <li><code>local</code>: This is the default value and is based on the federated username. You must set the federated username in the local userstore . The federated username must be the same as the local username.</li>
                             <li><code>assocication</code>: The federated username must be associated with the
-                                local account in advance in the user portal. The local username is retrieved
-                                from the association. To associate the user, log into the  [user portal](../../learn
-                                /user-portal)  and go to  **Associated Account**  by clicking  **View details**.</li>
+                                local account in advance in the **My Account**. The local username is retrieved
+                                from the association. To associate the user, log into the  [**My Account**](../../learn
+                                /my-account)  and go to  **Associated Account**  by clicking  **View details**.</li>
                             <li><code>subjectUri</code>: When configuring the federated authenticator, select the attribute in the subject identifier under the service provider section in UI, this is used as the username of the  <code>EmailOTP</code> authenticator.</li>
                             <li>
                                 <p><code>userAttribute </code>: The name of the  federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the  ```[authentication.authenticator.email_otp.parameters]```  section in the ```deployment.toml``` file and put the value, e.g., email and screen_name, id.</p>
@@ -244,6 +245,15 @@ as explained [here](../../setup/configuring-email-sending).
                         <ul>
                             <li><code>(?&lt;=.{1}).(?=.*@)</code>&nbsp;&nbsp;:&nbsp;&nbsp;`t***@mail.com`</li>
                             <li><code>(?&lt;=.)[^@](?=[^@]*?@)|(?:(?&lt;=@.)|(?!^)\\G(?=[^@]*$)).(?=.*\\.)</code>&nbsp;&nbsp;:&nbsp;&nbsp;`t***@m***.com`</li>
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>tokenExpirationTime</code></td>
+                    <td>This parameter helps to define a custom Email OTP expiry time. The default expiration time is 300000 milliseconds.</td>
+                    <td>
+                        <ul>
+                            <li>300000</li>
                         </ul>
                     </td>
                 </tr>

--- a/en/docs/learn/configuring-email-otp.md
+++ b/en/docs/learn/configuring-email-otp.md
@@ -253,7 +253,7 @@ as explained [here](../../setup/configuring-email-sending).
                     <td>This parameter helps to define a custom Email OTP expiry time. The default expiration time is 300000 milliseconds.</td>
                     <td>
                         <ul>
-                            <li>300000</li>
+                            <li><code>300000</code></li>
                         </ul>
                     </td>
                 </tr>

--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -465,6 +465,11 @@ the various values you can configure for the authenticator.
             <td>redirectToMultiOptionPageOnFailure</td>
             <td>During a failed attempt enable redirect to the Multi Option Page where the user 
             can select the authentication mechanism.</td>
+		</tr>
+		<tr>
+            <td>TokenExpiryTime</td>
+            <td>SMS OTP does not have a default validity period hence you will have to explicitly configure it by adding the <code>TokenExpiryTime</code> parameter. The value provided for the parameter is considered as seconds.</td>
+		</tr>
     </tbody>
 </table>
 
@@ -491,6 +496,7 @@ You can configure any of the above as following in the
     CaptureAndUpdateMobileNumber = true
     SendOTPDirectlyToMobile = false
     redirectToMultiOptionPageOnFailure = false
+	TokenExpiryTime = 12
     ```
      
 !!! note

--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -468,7 +468,7 @@ the various values you can configure for the authenticator.
 		</tr>
 		<tr>
             <td>TokenExpiryTime</td>
-            <td>SMS OTP does not have a default validity period hence you will have to explicitly configure it by adding the <code>TokenExpiryTime</code> parameter. The value provided for the parameter is considered as seconds.</td>
+            <td>SMS OTP does not have a default validity period hence you will have to explicitly configure it by adding the <code>TokenExpiryTime</code> parameter. The value provided for the parameter is considered in seconds.</td>
 		</tr>
     </tbody>
 </table>

--- a/en/docs/references/adaptive-authentication-js-api-reference.md
+++ b/en/docs/references/adaptive-authentication-js-api-reference.md
@@ -61,13 +61,13 @@ Supported results are “ <code>             onSuccess            </code> ” an
 
 The API can be called in either of the following ways:
 
--   With only the `           stepId          ` . Example:
+- With only the `           stepId          ` . Example:
 
     ``` java
     executeStep(1)
     ```
 
--   With only the `           stepId          ` and
+- With only the `           stepId          ` and
     `           eventCallbacks          ` . Example:
 
     ``` java
@@ -78,11 +78,11 @@ The API can be called in either of the following ways:
     });
     ```
 
--   With the `           stepId          `,
+- With the `           stepId          `,
     `           options          `, and an empty
     `           eventCallbacks          ` array.  Different properties can be defined in the `           options          ` 
-object such as `           authenticationOptions          `, `           authenticatorParams          `,
-`           stepOptions          `. See the following examples:
+  object such as `           authenticationOptions          `, `           authenticatorParams          `,
+  `           stepOptions          `. See the following examples:
 
     ``` java
     executeStep(1,{
@@ -97,7 +97,10 @@ object such as `           authenticationOptions          `, `           authent
             local: {
                 SessionExecutor: {
                     MaxSessionCount: '1'
-                                    }
+                },
+                totp: {
+                    enableRetryFromAuthenticator: 'true'
+                }
             }
         }
     }, {} );

--- a/en/docs/references/adaptive-authentication-js-api-reference.md
+++ b/en/docs/references/adaptive-authentication-js-api-reference.md
@@ -61,13 +61,13 @@ Supported results are “ <code>             onSuccess            </code> ” an
 
 The API can be called in either of the following ways:
 
-- With only the `           stepId          ` . Example:
+-   With only the `           stepId          ` . Example:
 
     ``` java
     executeStep(1)
     ```
 
-- With only the `           stepId          ` and
+-   With only the `           stepId          ` and
     `           eventCallbacks          ` . Example:
 
     ``` java
@@ -78,11 +78,11 @@ The API can be called in either of the following ways:
     });
     ```
 
-- With the `           stepId          `,
+-   With the `           stepId          `,
     `           options          `, and an empty
     `           eventCallbacks          ` array.  Different properties can be defined in the `           options          ` 
-  object such as `           authenticationOptions          `, `           authenticatorParams          `,
-  `           stepOptions          `. See the following examples:
+object such as `           authenticationOptions          `, `           authenticatorParams          `,
+`           stepOptions          `. See the following examples:
 
     ``` java
     executeStep(1,{


### PR DESCRIPTION
## Purpose
> Add information about how to set expiry time for Email OTP and SMS OTP.
> Add example for enableRetryFromAuthenticator in Adaptive Authentication JS references.

## Goals
> Increase awareness of certain configurations that are already existing.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8, Linux 20.04