### PR TITLE
Configuring Admin-Initiated Account Locking

### DIFF
--- a/en/docs/learn/configuring-admin-initiated-account-locking.md
+++ b/en/docs/learn/configuring-admin-initiated-account-locking.md
@@ -12,7 +12,7 @@ Let's learn how Sam can lock Alex's user account!
 
 Follow the steps below to configure admin-initiated account locking in WSO2 Identity Server.
 
-1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory 
+1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
     1.	Check whether the following listener configs are in place.
 
 		```

--- a/en/docs/learn/configuring-admin-initiated-account-locking.md
+++ b/en/docs/learn/configuring-admin-initiated-account-locking.md
@@ -24,7 +24,7 @@ Follow the steps below to configure admin-initiated account locking in WSO2 Iden
 		enable = true
 		```
 
-	2.	To configure the email server to send emails requesting passwor reset, add the following configurations.
+	2.	To configure the email server to send emails requesting password reset, add the following configurations:
 
 		-	**from_address**: This is the email address from which the confirmation email will be sent.
 		-	**username**: This is the user name of the given email address.

--- a/en/docs/learn/configuring-admin-initiated-account-locking.md
+++ b/en/docs/learn/configuring-admin-initiated-account-locking.md
@@ -27,7 +27,7 @@ Follow the steps below to configure admin-initiated account locking in WSO2 Iden
 	2.	To configure the email server to send emails requesting password reset, add the following configurations:
 
 		-	**from_address**: This is the email address from which the confirmation email will be sent.
-		-	**username**: This is the user name of the given email address.
+		-	**username**: This is the username of the given email address.
 		-	**password**: This is the password of the given email address. 
 
 		```toml tab="Format"

--- a/en/docs/learn/configuring-admin-initiated-account-locking.md
+++ b/en/docs/learn/configuring-admin-initiated-account-locking.md
@@ -60,7 +60,7 @@ Follow the steps below to configure admin-initiated account locking in WSO2 Iden
 
 			2.	Under **Signing in to Google** section, turn off the **2-step Verification** option.
 
-			3.  Enable **Less secure app access** in Google account security section.
+			3.  Enable **Less secure app access** in the Google account's security section.
 
 2.	[Restart WSO2 Identity Server](../../setup/running-the-product/).
 

--- a/en/docs/learn/configuring-admin-initiated-account-locking.md
+++ b/en/docs/learn/configuring-admin-initiated-account-locking.md
@@ -1,6 +1,6 @@
 # Configuring Admin-Initiated Account Locking
 
-WSO2 Identity Server enables the privileged users to temporarily lock suspicious user accounts and prevent the users from logging in. These locked user accounts can only be unlocked by privileged users. 
+WS02 Identity Server enables the privileged users to temporarily lock suspicious user accounts and prevent the users from logging in. These locked user accounts can only be unlocked by privileged users. 
 
 ## Scenario
 
@@ -12,16 +12,55 @@ Let's learn how Sam can lock Alex's user account!
 
 Follow the steps below to configure admin-initiated account locking in WSO2 Identity Server.
 
-1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory and check whether the following listener configs are in place.
+1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory 
+    1.	Check whether the following listener configs are in place.
 
-	```toml
-	[event.default_listener.identity_mgt]
-	priority= "50"
-	enable = false
-	[event.default_listener.governance_identity_mgt]
-	priority= "95"
-	enable = true
-	```
+		```
+		[event.default_listener.identity_mgt]
+		priority= "50"
+		enable = false
+		[event.default_listener.governance_identity_mgt]
+		priority= "95"
+		enable = true
+		```
+
+	2.	To configure the email server to send emails requesting passwor reset, add the following configurations.
+
+		-	**from_address**: This is the email address from which the confirmation email will be sent.
+		-	**username**: This is the user name of the given email address.
+		-	**password**: This is the password of the given email address. 
+
+		```toml tab="Format"
+		[output_adapter.email]
+		from_address= ""
+		username= ""
+		password= ""
+		hostname= "smtp.gmail.com"
+		port= 587
+		enable_start_tls= true
+		enable_authentication= true
+		```
+
+		```toml tab="Sample"
+		[output_adapter.email]
+		from_address= "wso2iamtest@gmail.com"
+		username= "wso2iamtest"
+		password= "Wso2@iam70"
+		hostname= "smtp.gmail.com"
+		port= 587
+		enable_start_tls= true
+		enable_authentication= true
+		```
+
+		!!! warning "If you are using a Google email account"
+
+			Google has restricted third-party applications and less secure applications from sending emails by default. As WSO2 Identity Server acts as a third-party application when sending emails for password entry, follow the steps below to enable your Google email account to provide access to third-party applications.
+
+			1.	Access [https://myaccount.google.com/security](https://myaccount.google.com/security).
+
+			2.	Under **Signing in to Google** section, turn off the **2-step Verification** option.
+
+			3.  Enable **Less secure app access** in Google account security section.
 
 2.	[Restart WSO2 Identity Server](../../setup/running-the-product/).
 


### PR DESCRIPTION
## Purpose
> Resolved the issues in Configuring Admin-Initiated Account Locking of 5.11.0 Identity Server Documentation.


## Goals
> This PR enables the proper guidelines in Configuring Admin-Initiated Account Locking in 5.11.0 Identity Server Documentation.

## Approach
> 
Added toml configurations to  configure the email server
Added extra step for Google Account configuration for the email sending [Less secure app access]


## User stories
> Enables the privileged users to temporarily lock suspicious user accounts and prevent the users from logging in

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring Admin-Initiated Account Locking
## Documentation
> https://is.docs.wso2.com/en/latest/learn/configuring-admin-initiated-account-locking/

## Training
> N/A

## Certification
> N/A
## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A