### PR TITLE
Fix-Configuring Account Locking due to Failed Login Attempts issues -[Master]

### DIFF
--- a/en/docs/learn/configuring-account-locking-due-to-failed-login-attempts.md
+++ b/en/docs/learn/configuring-account-locking-due-to-failed-login-attempts.md
@@ -14,16 +14,57 @@ Let's learn how Sam implements this!
 
 Follow the steps below to configure account locking due to failed login attempts.
 
-1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory and check whether the following listener configs are in place.
+1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
 
-	```
-	[event.default_listener.identity_mgt]
-	priority= "50"
-	enable = false
-	[event.default_listener.governance_identity_mgt]
-	priority= "95"
-	enable = true
-	```
+	1.	To request password entry from the users who are registered via Management Console, add the following configurations. 
+
+
+	 	```
+	  	[event.default_listener.identity_mgt]
+	  	priority= "50"
+	  	enable = false
+	  	event.default_listener.governance_identity_mgt]
+	    priority= "95"
+	    enable = true
+	    ```
+
+	2.	To configure the email server to send emails requesting password entry, add the following configurations.
+
+		-	**from_address**: This is the email address from which the confirmation email will be sent.
+		-	**username**: This is the user name of the given email address.
+		-	**password**: This is the password of the given email address. 
+
+		```toml tab="Format"
+		[output_adapter.email]
+		from_address= ""
+		username= ""
+		password= ""
+		hostname= "smtp.gmail.com"
+		port= 587
+		enable_start_tls= true
+		enable_authentication= true
+		```
+
+		```toml tab="Sample"
+		[output_adapter.email]
+		from_address= "wso2iamtest@gmail.com"
+		username= "wso2iamtest"
+		password= "Wso2@iam70"
+		hostname= "smtp.gmail.com"
+		port= 587
+		enable_start_tls= true
+		enable_authentication= true
+		```
+
+		!!! warning "If you are using a Google email account"
+
+			Google has restricted third-party applications and less secure applications from sending emails by default. As WSO2 Identity Server acts as a third-party application when sending emails for password entry, follow the steps below to enable your Google email account to provide access to third-party applications.
+
+			1.	Access [https://myaccount.google.com/security](https://myaccount.google.com/security).
+
+			2.	Under **Signing in to Google** section, turn off the **2-step Verification** option.
+
+			3.  Enable **Less secure app access** in Google Account security section.
 
 2.	[Restart WSO2 Identity Server](../../setup/running-the-product/).
 

--- a/en/docs/learn/configuring-account-locking-due-to-failed-login-attempts.md
+++ b/en/docs/learn/configuring-account-locking-due-to-failed-login-attempts.md
@@ -16,7 +16,7 @@ Follow the steps below to configure account locking due to failed login attempts
 
 1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
 
-	1.	To request password entry from the users who are registered via Management Console, add the following configurations. 
+	1.	To request password entry from the users who are registered via the management console, add the following configurations. 
 
 
 	 	```
@@ -28,10 +28,10 @@ Follow the steps below to configure account locking due to failed login attempts
 	    enable = true
 	    ```
 
-	2.	To configure the email server to send emails requesting password entry, add the following configurations.
+	2.	To configure the email server to send emails requesting password entry, add the following configurations:
 
 		-	**from_address**: This is the email address from which the confirmation email will be sent.
-		-	**username**: This is the user name of the given email address.
+		-	**username**: This is the username of the given email address.
 		-	**password**: This is the password of the given email address. 
 
 		```toml tab="Format"
@@ -58,13 +58,13 @@ Follow the steps below to configure account locking due to failed login attempts
 
 		!!! warning "If you are using a Google email account"
 
-			Google has restricted third-party applications and less secure applications from sending emails by default. As WSO2 Identity Server acts as a third-party application when sending emails for password entry, follow the steps below to enable your Google email account to provide access to third-party applications.
+			Google has restricted third-party applications and less-secure applications from sending emails by default. As WSO2 Identity Server acts as a third-party application when sending emails for password entry, follow the steps below to enable your Google email account to provide access to third-party applications.
 
 			1.	Access [https://myaccount.google.com/security](https://myaccount.google.com/security).
 
-			2.	Under **Signing in to Google** section, turn off the **2-step Verification** option.
+			2.	In the  **Signing in to Google** section, turn off the **2-step Verification** option.
 
-			3.  Enable **Less secure app access** in Google Account security section.
+			3.  Enable **Less secure app access** in the Google Account's security section.
 
 2.	[Restart WSO2 Identity Server](../../setup/running-the-product/).
 

--- a/en/docs/learn/configuring-account-locking-due-to-failed-login-attempts.md
+++ b/en/docs/learn/configuring-account-locking-due-to-failed-login-attempts.md
@@ -16,7 +16,7 @@ Follow the steps below to configure account locking due to failed login attempts
 
 1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
 
-	1.	To request password entry from the users who are registered via the management console, add the following configurations. 
+	1.	To request password entry from the users who are registered via the management console, add the following configurations:
 
 
 	 	```


### PR DESCRIPTION
## Purpose
> Resolved the issues in Configuring Account Locking due to Failed Login Attempts in 5.11.0 Identity Server Documentation.
## Goals
> This PR enables the proper guidelines in Configuring Account Locking due to Failed Login Attempts in 5.11.0 Identity Server Documentation.

## Approach
> Added toml configurations to configure the email server
Added extra step for Google Account configuration for the email sending [Less secure app access]

## User stories
> his pr enables privileged users to define the maximum number of failed login attempts the system accepts. When a user exceeds the maximum number of failed login attempts defined in the system, the user account will be automatically locked


## Release note
>Few bugs were fixed in the documentation of 5.11.0 -Configuring Account Locking due to Failed Login Attempts

## Documentation
> https://is.docs.wso2.com/en/latest/learn/configuring-account-locking-due-to-failed-login-attempts/

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A