### PR TITLE
[5.11.0] - Fixed Configuring Account Disabling Doc Issues

### DIFF
--- a/en/docs/learn/configuring-account-disabling.md
+++ b/en/docs/learn/configuring-account-disabling.md
@@ -25,7 +25,7 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 		enable = true
 		```
 
-	2.	To configure the email server to send emails that informs about the disabled account to the user, add the following configurations.
+	2.	To configure the email server to send emails that informs about the disabled account to the user, add the following configurations:
 
 		-	**from_address**: This is the email address from which the confirmation email will be sent.
 		-	**username**: This is the username of the given email address.

--- a/en/docs/learn/configuring-account-disabling.md
+++ b/en/docs/learn/configuring-account-disabling.md
@@ -14,7 +14,7 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 
 1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
 
-	1.	Check whether the following listener configs are in place.
+	1.	Check whether the following listener configs are in place:
 
 		```toml
 		[event.default_listener.identity_mgt]

--- a/en/docs/learn/configuring-account-disabling.md
+++ b/en/docs/learn/configuring-account-disabling.md
@@ -4,24 +4,64 @@ WSO2 Identity Server enables the privileged users to disable user accounts for l
 
 ## Scenario
 
-**Pickup** is a cab company that has many employees who use different credentials to sign in to different internal enterprise applications. **Sam** is an administrator at Pickup. **Alex** is an employee who had served Pickup for 7 years and is entitled for sabbatical leave. As Alex is going on sabbatical leave for 2 years, Sam wants to disable Alex's account.  
+**Pickup** is a cab company that has many employees who use different credentials to sign in to different internal enterprise applications. **Sam** is an administrator at Pickup. **Larry** is an employee who had served Pickup for 7 years and is entitled for sabbatical leave. As Larry is going on sabbatical leave for 2 years, Sam wants to disable Larry's account.  
 
-Let's learn how Sam can disable Alex's user account! 
+Let's learn how Sam can disable Larry's user account! 
 
 ## Set up
 
 Follow the steps below to configure account disabling in WSO2 Identity Server.
 
-1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory and check whether the following listener configs are in place.
+1.	Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
 
-	```toml
-	[event.default_listener.identity_mgt]
-	priority= "50"
-	enable = false
-	[event.default_listener.governance_identity_mgt]
-	priority= "95"
-	enable = true
-	```
+	1.	Check whether the following listener configs are in place.
+
+		```toml
+		[event.default_listener.identity_mgt]
+		priority= "50"
+		enable = false
+		[event.default_listener.governance_identity_mgt]
+		priority= "95"
+		enable = true
+		```
+
+	2.	To configure the email server to send emails that informs about the disabled account to the user, add the following configurations.
+
+		-	**from_address**: This is the email address from which the confirmation email will be sent.
+		-	**username**: This is the username of the given email address.
+		-	**password**: This is the password of the given email address. 
+
+		```toml tab="Format"
+		[output_adapter.email]
+		from_address= ""
+		username= ""
+		password= ""
+		hostname= "smtp.gmail.com"
+		port= 587
+		enable_start_tls= true
+		enable_authentication= true
+		```
+
+		```toml tab="Sample"
+		[output_adapter.email]
+		from_address= "wso2iamtest@gmail.com"
+		username= "wso2iamtest"
+		password= "Wso2@iam70"
+		hostname= "smtp.gmail.com"
+		port= 587
+		enable_start_tls= true
+		enable_authentication= true
+		```
+
+		!!! warning "If you are using a Google email account"
+
+			Google has restricted third-party applications and less secure applications from sending emails by default. As WSO2 Identity Server acts as a third-party application when sending emails for password entry, follow the steps below to enable your Google email account to provide access to third-party applications.
+
+			1.	Access [https://myaccount.google.com/security](https://myaccount.google.com/security).
+
+			2.	Under **Signing in to Google** section, turn off the **2-step Verification** option.
+
+			3.  Enable **Less secure app access** in Google Account **Security** section.
 
 2.	[Restart WSO2 Identity Server](../../setup/running-the-product/).
 
@@ -31,7 +71,7 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 
 		<img src="../../assets/img/learn/resident-menu-item.png" alt="Resident menu-item" width="200" style="border:1px solid grey">  
 
-	2.	Under the **Login Policies** section, click **Account Disabling**.
+	2.	Under the **Account Management** section, click **Account Disable**.
 
 		<img src="../../assets/img/learn/account-disabling-option.png" alt="Account Disabling Option" width="700" style="border:1px solid grey">  	
 
@@ -59,11 +99,11 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 
 		<img src="../../assets/img/learn/account-disabled-claim-supported-by-default.png" alt="Account Disabled claim's Suppported by Default option" width="700" style="border:1px solid grey">  
 
-	5. Click **Update**.
+	1. Click **Update**.
 
 ## Try out
 
-1.	To create the user account for Alex:
+1.	To create the user account for Larry:
 
 	1.	On the **Main** menu of the Management Console, click **Identity > Users and Roles > Add**.
 
@@ -78,13 +118,13 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 		<img src="../../assets/img/learn/add-new-user-screen.png" alt="Add New User screen" width="700" style="border:1px solid grey">   
 
 		-	**Domain**: `Primary`
-		-	**Username**: `Alex`
+		-	**Username**: `Larry`
 
 	4.	Click **Finish**. 
 
 2.	To assign login permissions to the user:
 	
-	1.	Click the **View Roles** option of Alex.
+	1.	Click the **View Roles** option of Larry.
 
 		<img src="../../assets/img/learn/view-roles-option.png" alt="View Roles option" width="700" style="border:1px solid grey"> 	 		 		
 
@@ -96,13 +136,13 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 
 		<img src="../../assets/img/learn/login-permission.png" alt="Login permission" width="700" style="border:1px solid grey">  
 
-3.	To disable Alex's user account:
+3.	To disable Larry's user account:
 	
-	1.	Click **User Profile** option of Alex.
+	1.	Click **User Profile** option of Larry.
 
 		<img src="../../assets/img/learn/user-profile-option.png" alt="User Profile option" width="700" style="border:1px solid grey">   
 
-	2.	Enter an email address to which Alex's account disabling emails will be sent and select the **User Locked** check box.
+	2.	Enter an email address to which Larry's account disabling emails will be sent and select the **Account Disabled** check box.
 
 		<img src="../../assets/img/learn/user-disabled.png" alt="User Disabled option" width="700" style="border:1px solid grey">    		
 
@@ -112,18 +152,18 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 
 		<img src="../../assets/img/learn/account-disabled-email.png" alt="Account Disabled email" width="500" style="border:1px solid grey"> 
 
-	5.	Access the WSO2 Identity Server User Portal at `https://localhost:9443/user-portal/`.
+	5.	Access the WSO2 Identity Server My Account at `https://localhost:9443/myaccount`.
 
 		<img src="../../assets/img/learn/userportal-login-screen.png" alt="Sign In form" width="400" style="border:1px
 		 solid grey"> 	
 
-	6.	Try logging in with Alex's credentials. Note that an error message appears.
+	6.	Try logging in with Larry's credentials. Note that an error message appears.
 
 4. To revoke the account disabling:
 
-	1.	Click **User Profile** option of Alex.
+	1.	Click **User Profile** option of Larry.
 
-	2.	Unselect the **User Disabled** check box.
+	2.	Unselect the **Account Disabled** check box.
 
 	3.	Click **Update**.
 
@@ -131,5 +171,5 @@ Follow the steps below to configure account disabling in WSO2 Identity Server.
 
 		<img src="../../assets/img/learn/account-enabled-email.png" alt="Account Enabled email" width="500" style="border:1px solid grey"> 		
 
-	5.	Trying logging in to the WSO2 Identity Server User Portal with Alex's credentials. The WSO2 Identity Server
+	5.	Trying logging in to the WSO2 Identity Server User Portal with Larry's credentials. The WSO2 Identity Server
 	 User Portal home screen appears.


### PR DESCRIPTION
## Purpose
> Resolved the issues in the Configuring Account Disabling Documentation for 5.11.0.

## Goals
> This PR will ensure the proper configuring account disabling documentation guidelines using wso2 identity server.

## Approach
> Added toml configuration to configure the email server to send emails.
> Corrected the provided old version links (user portal).
> Corrected the mistakes in the documentation
> Added extra step for Google Account configuration for the email sending [Less secure app access]

## User stories
> Can properly go through a Configuring Account Disabling steps for Identity Server.

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring Account Disabling page

## Documentation
> Updated the Configuring Account Disabling page in 5.11.0 doc

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A