### PR TITLE
fixing  default Response Signing Algorithm

### DIFF
--- a/en/docs/learn/configuring-saml2-web-single-sign-on.md
+++ b/en/docs/learn/configuring-saml2-web-single-sign-on.md
@@ -138,7 +138,7 @@ To configure SAML2 Web SSO:
     [saml]
     signing_alg="signing algorithm"
     ```
-    If it is not provided the default algorithm is RSA­SHA 1, at URI ‘ http://www.w3.org/2000/09/xmldsig#rsa­sha1 ' .</p></td>
+    If it is not provided the default algorithm is RSA­SHA 1, at URI ‘ http://www.w3.org/2000/09/xmldsig#rsa­-sha1 ' .</p></td>
     <td>http://www.w3.org/2000/09/xmldsig#rsa­sha1</td>
     </tr>
     <tr class="even">

--- a/en/docs/learn/configuring-saml2-web-single-sign-on.md
+++ b/en/docs/learn/configuring-saml2-web-single-sign-on.md
@@ -16,7 +16,7 @@ Let's start configuring SAML2 Web SSO.
 	 
 To configure SAML2 Web SSO:
 
-1.  Expand the **SAML2 Web SSO Configuration** in the Inbound Authentication Configuration and click **Configure**.
+1.  Expand **SAML2 Web SSO Configuration** under **Inbound Authentication Configuration** and click **Configure**.
 2.  Select one of the following modes:  
 
 !!! info "Metadata and URL configuration"

--- a/en/docs/learn/configuring-saml2-web-single-sign-on.md
+++ b/en/docs/learn/configuring-saml2-web-single-sign-on.md
@@ -16,7 +16,7 @@ Let's start configuring SAML2 Web SSO.
 	 
 To configure SAML2 Web SSO:
 
-1.  Expand the **SAML2 Web SSO Configuration** and click **Configure**.
+1.  Expand the **SAML2 Web SSO Configuration** in the Inbound Authentication Configuration and click **Configure**.
 2.  Select one of the following modes:  
 
 !!! info "Metadata and URL configuration"


### PR DESCRIPTION
## Purpose
> Resolved the issues in  Configuring SAML2 Web Single-Sign-On in the Documentation for 5.11.0.

## Goals
> This PR ensures the proper guidelines for user registration with password entry in the the wso2 identity server Documentation

## Approach
> fixing  default Response Signing Algorithm url
   Adding  Path  changes

## User stories
> user can go through the wso2 identity server Documentation and successfully Configure SAML2 Web Single-Sign-On

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring SAML2 Web Single-Sign-On

## Documentation
> 
https://is.docs.wso2.com/en/latest/learn/configuring-saml2-web-single-sign-on/

## Training
> N/A
## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A
## Related PRs
> N/A
## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A