### PR TITLE
[5.11.0] - Fixed Configuring SAML 2.0 Artifact Binding Doc Issues

### DIFF
--- a/en/docs/learn/configuring-saml-2.0-artifact-binding.md
+++ b/en/docs/learn/configuring-saml-2.0-artifact-binding.md
@@ -58,7 +58,7 @@ or with an existing service provider.
     sample application.
 
 2.  Access the PickUp application URL at
-        <http://localhost:8080/saml2-web-app-pickup-dispatch.com.>
+        <http://localhost:8080/saml2-web-app-pickup-dispatch.com>
 
 3.  Once you deploy the sample application and start the tomcat server,
     a folder named **saml2-web-app-pickup-dispatch.com** is created inside the


### PR DESCRIPTION
## Purpose
> Resolved the issues in the Configuring SAML 2.0 Artifact Binding Documentation for 5.11.0.

## Goals
> This PR will ensure the proper Configuring SAML 2.0 Artifact Binding documentation guidelines using wso2 identity server.

## Approach
> Corrected the mistakes in the documentation

## User stories
> Can properly go through a Configuring SAML 2.0 Artifact Binding steps for Identity Server.

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring SAML 2.0 Artifact Binding page

## Documentation
> Updated the Configuring SAML 2.0 Artifact Binding page in 5.11.0 doc

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A