### PR TITLE
[5.11.0] - Fixed Configuring Identity Analytics Doc Issues

### DIFF
--- a/en/docs/learn/configuring-identity-analytics.md
+++ b/en/docs/learn/configuring-identity-analytics.md
@@ -44,7 +44,7 @@ Follow the steps below to configure WSO2 Identity Server Analytics.
         command. The default keystore password is `wso2carbon`.
 
         ``` java
-        keytool -export -alias wso2carbon -keystore wso2carbon.jks -file sp.pem
+        keytool -export -alias wso2carbon -keystore wso2carbon.jks -file sp.cer
         ```
 
     2.  Navigate to the
@@ -57,7 +57,7 @@ Follow the steps below to configure WSO2 Identity Server Analytics.
 			`              <ISANALYTICS_HOME>             ` folder.
 
         ``` java
-        keytool -import -alias certalias -file <ISANALYTICS_HOME>/resources/security/sp.pem -keystore client-truststore.jks -storepass wso2carbon
+        keytool -import -alias certalias -file <ISANALYTICS_HOME>/resources/security/sp.cer -keystore client-truststore.jks -storepass wso2carbon
         ```
 
 

--- a/en/docs/learn/configuring-identity-analytics.md
+++ b/en/docs/learn/configuring-identity-analytics.md
@@ -6,7 +6,7 @@ Using the WSO2 Identity Server Analytics distribution, you can view and analyze 
 
 A taxi company called "Pickup" has launched a new application to be used by their customers. The Pickup developers wish to measure the performance of the authentication mechanism used for users to log into the application so that they can improve the user login experience. 
 
-To do this, the developers need to view authentication statistics about the login attempts to the application. This tutorial demonstrates how the Pickup developers can setup WSO2 IS Analytics to view login attempts to the Pickup application. 
+To do this, the developers need to view authentication statistics about the login attempts to the application. This tutorial demonstrates how the Pickup developers can setup WSO2 IS Analytics to view login attempts to the Pickup application.
 
 ## Set up 
 
@@ -15,18 +15,51 @@ To do this, the developers need to view authentication statistics about the logi
 2. [Download WSO2 Identity Server Analytics distribution](https://github.com/wso2/analytics-is/releases/tag/v5.8.0-rc3).
 
 ## Enable analytics
+Follow the steps below to configure WSO2 Identity Server Analytics.
 
-Open the `deployment.toml` file found in the `<IS_HOME>/repository/conf` folder and enable the following event publishers to enable analytics in WSO2 Identity Server. 
+1.	Open the `deployment.toml` file found in the `<IS_HOME>/repository/conf` folder and enable the following event publishers to enable analytics in WSO2 Identity Server. 
  
-``` toml
-[identity_mgt.analytics_login_data_publisher]
-enable=true
-```
+    ``` toml
+    [identity_mgt.analytics_login_data_publisher]
+    enable=true
+    ```
 
-```toml
-[identity_mgt.analytics_session_data_publisher] 
-enable=true
-```
+    ```toml
+    [identity_mgt.analytics_session_data_publisher] 
+    enable=true
+    ```
+
+
+2.  An HTTP connection is used to communicate between WSO2 IS and WSO2
+    IS Analytics. Therefore, you must add the certificate of WSO2 IS Analytics to WSO2 IS.
+    Follow the steps given below to import the certificate from WSO2 IS Analytics
+    to WSO2 IS. Import the
+    `           public certificate          ` of each keystore to the
+    `           client­-truststore.jks          ` of the WSO2 IS. This example uses the default keystores and
+    certificates.
+
+    1.  Navigate to the
+        `             <ISANALYTICS_HOME>/resources/security            `
+        directory on a new terminal window and run the following
+        command. The default keystore password is `wso2carbon`.
+
+        ``` java
+        keytool -export -alias wso2carbon -keystore wso2carbon.jks -file sp.pem
+        ```
+
+    2.  Navigate to the
+        `             <IS_HOME>/repository/resources/security            `
+        directory and run the following command.
+
+        !!! info 
+			Replace the `              <ISANALTICS_HOME>             ` placeholder
+			in the command with the filepath location of your
+			`              <ISANALYTICS_HOME>             ` folder.
+
+        ``` java
+        keytool -import -alias certalias -file <ISANALYTICS_HOME>/resources/security/sp.pem -keystore client-truststore.jks -storepass wso2carbon
+        ```
+
 
 The rest of the configurations required to connect the analytics distribution with the WSO2 IS distribution have already been pre-configured for fresh distributions. To see more information about these pre-configurations, see [Prerequisites to Publish Statistics](../../learn/prerequisites-to-publish-statistics). 
 
@@ -69,11 +102,11 @@ If you do not need to change the default values, proceed to start the servers.
 
 Let's create some basic authentication statistics. To do this, log in to the WSO2 IS dashboard. This login attempt will be published to WSO2 IS Analytics and you will be able to view the login attempt using the WSO2 IS Analytics dashboard. 
 
-1. Log in to the [WSO2 Identity Server User Portal](https://localhost:9443/user-portal/) using admin/admin credentials. 
+1. Log in to the [WSO2 Identity Server My Account](https://localhost:9443/myaccount/) using admin/admin credentials. 
 
 2. Next, access the WSO2 Identity Server Analytics Dashboard at the following URL: 
 
-    `http://<HTTPS_IS_ANALYTICS_HOST>: 9643 /portal`
+    `https://<HTTPS_IS_ANALYTICS_HOST>:9643/portal`
 
 3. Log in using admin/admin credentials. 
 

--- a/en/docs/learn/configuring-identity-analytics.md
+++ b/en/docs/learn/configuring-identity-analytics.md
@@ -6,7 +6,7 @@ Using the WSO2 Identity Server Analytics distribution, you can view and analyze 
 
 A taxi company called "Pickup" has launched a new application to be used by their customers. The Pickup developers wish to measure the performance of the authentication mechanism used for users to log into the application so that they can improve the user login experience. 
 
-To do this, the developers need to view authentication statistics about the login attempts to the application. This tutorial demonstrates how the Pickup developers can setup WSO2 IS Analytics to view login attempts to the Pickup application.
+To do this, the developers need to view authentication statistics about the login attempts to the application. This tutorial demonstrates how the Pickup developers can set up WSO2 IS Analytics to view login attempts to the Pickup application.
 
 ## Set up 
 

--- a/en/docs/learn/configuring-identity-analytics.md
+++ b/en/docs/learn/configuring-identity-analytics.md
@@ -44,7 +44,7 @@ Follow the steps below to configure WSO2 Identity Server Analytics.
         command. The default keystore password is `wso2carbon`.
 
         ``` java
-        keytool -export -alias wso2carbon -keystore wso2carbon.jks -file sp.cer
+        keytool -export -alias wso2carbon -keystore wso2carbon.jks -file sp.pem
         ```
 
     2.  Navigate to the
@@ -57,7 +57,7 @@ Follow the steps below to configure WSO2 Identity Server Analytics.
 			`              <ISANALYTICS_HOME>             ` folder.
 
         ``` java
-        keytool -import -alias certalias -file <ISANALYTICS_HOME>/resources/security/sp.cer -keystore client-truststore.jks -storepass wso2carbon
+        keytool -import -alias certalias -file <ISANALYTICS_HOME>/resources/security/sp.pem -keystore client-truststore.jks -storepass wso2carbon
         ```
 
 


### PR DESCRIPTION
## Purpose
> Resolved the issues in the Configuring Identity Analytics Documentation for 5.11.0.

## Goals
> This PR will ensure the proper Configuring Identity Analytics documentation guidelines using wso2 identity server.

## Approach
> Added configurations for import the public certificate of each keystore to the client­-truststore.jks
> Corrected the provided old version links (user portal).
> Corrected the mistakes in the documentation

## User stories
> Can properly go through a Configuring Identity Analytics steps for Identity Server.

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring Identity Analytics page

## Documentation
> Updated the Configuring Identity Analytics page in 5.11.0 doc

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A