### PR TITLE
[5.11.0] - Fixed Configuring SMS OTP Doc Issues

### DIFF
--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -253,13 +253,16 @@ The next step is to configure the service provider.
 
 3. Configure Inbound Authentication for the service provider. For instructions, see [Configuring Inbound Authentication for a Service Provider](../../learn/configuring-inbound-authentication-for-a-service-provider)
 
-6.  Go to **Claim configuration** and select the
+    !!! info 
+        Try out the the sample application. To deploy the pickup-dispatch sample application, follow the steps in [Deploying the SAML2 Pickup-Dispatch Sample App](../../learn/deploying-the-sample-app/#deploying-the-saml2-web-app-pickup-dispatch-webapp).
+
+4.  Go to **Claim configuration** and select the
     **`            http://wso2.org/claims/mobile           `** claim for
     the **Subject Claim URI**.
 
     ![subject-claim-uri](../assets/img/tutorials/subject-claim-uri.png)
 
-7.  Go to **Local and Outbound Authentication Configuration** section.
+5.  Go to **Local and Outbound Authentication Configuration** section.
 
     1.  Select the **Advanced configuration** radio button option.
 
@@ -287,7 +290,7 @@ The next step is to configure the service provider.
 
         ![creating-the-second-authentication](../assets/img/tutorials/creating-the-second-authentication.jpeg)
 
-8.  Click **Update** to save the changes.
+6.  Click **Update** to save the changes.
 
 You have now added and configured the service provider.
 


### PR DESCRIPTION
## Purpose
> Resolved the issues in the Configuring SMS OTP Documentation for 5.11.0.

## Goals
> This PR will ensure the proper Configuring SMS OTP documentation guidelines using wso2 identity server.

## Approach
> Added a try out sample for the Configuring SMS OTP.

## User stories
> Can properly go through a Configuring SMS OTP steps for Identity Server.

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring SMS OTP page

## Documentation
> Updated the Configuring SMS OTP page in 5.11.0 doc

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A