### PR TITLE
[5.11.0] - Fix deploying the sample applications Doc Issues

### DIFF
--- a/en/docs/learn/deploying-the-sample-app.md
+++ b/en/docs/learn/deploying-the-sample-app.md
@@ -124,7 +124,7 @@ For example,
     allow_generic_http_requests = true
     allow_any_origin = false
     allowed_origins = [
-        "http://localhost:8080"
+        "http://localhost:8080", "http://localhost.com:8080"
     ]
     allow_subdomains = false
     supported_methods = [
@@ -369,7 +369,7 @@ For example,
     allow_generic_http_requests = true
     allow_any_origin = false
     allowed_origins = [
-        "http://localhost:8080"
+        "http://localhost:8080", "http://localhost.com:8080"
     ]
     allow_subdomains = false
     supported_methods = [
@@ -474,7 +474,7 @@ For example,
     allow_generic_http_requests = true
     allow_any_origin = false
     allowed_origins = [
-        "http://localhost:8080"
+        "http://localhost:8080", "http://localhost.com:8080"
     ]
     allow_subdomains = false
     supported_methods = [


### PR DESCRIPTION
## Purpose
> Resolved the issues in the deploying the sample applications Documentation CORS origin denied issue for 5.11.0.

## Goals
> This PR will ensure the proper deploying the sample applications documentation guidelines using wso2 identity server.

## Approach
> Added .com origin also to the toml allowed_origins as follows
```
allow_any_origin = false
allowed_origins = [
    "http://localhost:8080", "http://localhost.com:8080"
]
```

## User stories
> Can properly go through a deploying the sample applications steps for Identity Server.

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Deploying the sample applications page

## Documentation
> Updated the deploying the sample applications page in 5.11.0 doc

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A