### PR TITLE
Fix property name issues [Master]

### DIFF
--- a/en/docs/learn/x509certificate-authenticator.md
+++ b/en/docs/learn/x509certificate-authenticator.md
@@ -395,9 +395,9 @@ The next step is to configure the service provider.
             ![browser-certificate](../assets/img/learn/browser-certificate.png)
 
             !!! note
-                For more information on creating users and assigning roles
-                using management console, refer
-                [here](../../learn/configuring-users-roles-and-permissions).
+                For more information on creating users from the Email address as the username 
+                in management console, refer
+                [here](../../learn/using-email-address-as-the-username).
             
 10. Finally, click on **Update** to finish the service provider
     configurations.

--- a/en/docs/learn/x509certificate-authenticator.md
+++ b/en/docs/learn/x509certificate-authenticator.md
@@ -97,7 +97,7 @@ To create a sample certificate and create your own Certificate Authority to sign
             -  `validation.cnf`
             -  `/usr/lib/ssl/openssl.cnf`
 
-        2.  Set the following properties under `x509_extensions`.
+        2.  Set the following properties under `x509_extensions`:
 
             ``` java
             crlDistributionPoints = URI:http://pki.google.com/GIAG2.crl

--- a/en/docs/learn/x509certificate-authenticator.md
+++ b/en/docs/learn/x509certificate-authenticator.md
@@ -97,7 +97,7 @@ To create a sample certificate and create your own Certificate Authority to sign
             -  `validation.cnf`
             -  `/usr/lib/ssl/openssl.cnf`
 
-        2.  Set the following properties under `x509\_extensions`.
+        2.  Set the following properties under `x509_extensions`.
 
             ``` java
             crlDistributionPoints = URI:http://pki.google.com/GIAG2.crl


### PR DESCRIPTION
## Purpose
> Fix incorrect property names used in -Identity Server Documentation(5:11:0)- Configuring X509 Certificate Authenticator

## Goals
> This pr resolves incorrect property names used in Identity Server Documentation(5:11:0)- Configuring X509 Certificate Authenticator

## Approach
>

## User stories
>

## Release note
>
Fix bugs in Configuring X509 Certificate Authenticator- dentity Server Documentation(5:11:0)
## Documentation
> https://is.docs.wso2.com/en/latest/learn/x509certificate-authenticator/#configuring-crl-caching
## Training
>N/A
## Certification
> N/A
## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
>N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A
## Test environment
> N/A
 
## Learning
>N/A