### PR TITLE
Fixing issues in Token Hashing in deployment.toml configs[5:11:0]

### DIFF
--- a/en/docs/learn/configuring-oauth2-openid-connect.md
+++ b/en/docs/learn/configuring-oauth2-openid-connect.md
@@ -31,7 +31,7 @@ the users with an authorization server-based authentication.
     ![oauth2-openid-connect-configuration](../assets/img/tutorials/oauth2-openid-connect-configuration.png)
         
     !!! note
-        WSO2 Identity Server supports RP-initiated logout requests to OpenID Connect identity providers.
+        WSO2 Identity Server supports RP-initiated logout requests to OpenID Connect identity providers..
     
 5.  Fill in the following fields where relevant.
 

--- a/en/docs/learn/configuring-oauth2-openid-connect.md
+++ b/en/docs/learn/configuring-oauth2-openid-connect.md
@@ -52,7 +52,9 @@ the users with an authorization server-based authentication.
 
         ```toml
         [oauth]
-		hash_tokens_and_secrets = true 
+		hash_tokens_and_secrets = true
+        hash_token_algorithm = "SHA-256"
+        token_storage_method = "hashed"
 		```
         For information on
         possible values that you can specify based on your

--- a/en/docs/learn/configuring-oauth2-openid-connect.md
+++ b/en/docs/learn/configuring-oauth2-openid-connect.md
@@ -31,7 +31,7 @@ the users with an authorization server-based authentication.
     ![oauth2-openid-connect-configuration](../assets/img/tutorials/oauth2-openid-connect-configuration.png)
         
     !!! note
-        WSO2 Identity Server supports RP-initiated logout requests to OpenID Connect identity providers..
+        WSO2 Identity Server supports RP-initiated logout requests to OpenID Connect identity providers.
     
 5.  Fill in the following fields where relevant.
 


### PR DESCRIPTION
## Purpose
> Resolving the issues in Configuring OAuth2-OpenID Connect documentation for 5:11:0 when configuring deployment .toml file to hash secret tokens.
## Goals
>This pr ensures proper toml configurations when hashing secret tokens.

## Approach
> in the following document https://is.docs.wso2.com/en/latest/learn/configuring-oauth2-openid-connect/
when hashing secret token , additional configurations should be added than the existing configurations as below.


```
`[oauth]
hash_tokens_and_secrets = true `
```

**Describe the improvement**
```
`[oauth]
hash_tokens_and_secrets = true
hash_token_algorithm = "SHA-256"
token_storage_method = "hashed"
`
```
inorder to hash the tokens sucessfully hash-token-alorithm and the token-storage-method should be specify additionally.

## User stories
> User will be able to successfully hash the secret tokens

## Release note
> Few bugs were fixed related to Configuring OAuth2-OpenID Connect in Identity Server Documentation 5:11;0
## Documentation
> https://is.docs.wso2.com/en/latest/learn/configuring-oauth2-openid-connect/
## Training
> N/A

## Certification
> N/A
## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
>N/A

## Related PRs
> N/A
## Migrations
>N/A
## Test environment
>N/A
 
## Learning
> N/A