### PR TITLE
[Master] - Fixed Configuring SAML 2.0 Web SSO Doc Issues

### DIFF
--- a/en/docs/learn/configuring-saml-2.0-web-sso.md
+++ b/en/docs/learn/configuring-saml-2.0-web-sso.md
@@ -476,8 +476,7 @@ To configure through file upload:
         ``` java
         [authentication.authenticator.saml] 
         enable=true
-
-		[authentication.authenticator.saml.parameters]
+	    [authentication.authenticator.saml.parameters]
         SAMLSSOAssertionConsumerUrl="https://localhost:9443/commonauth"
     	```
 

--- a/en/docs/learn/configuring-saml-2.0-web-sso.md
+++ b/en/docs/learn/configuring-saml-2.0-web-sso.md
@@ -112,7 +112,7 @@ To configure manually,
 				<div class="sourceCode" id="cb1" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: xml; gutter: false; theme: Confluence">
 				<pre class="sourceCode xml"><code class="sourceCode xml">
 				<a class="sourceLine" id="cb1-1" title="1">[authentication.authenticator.saml.parameters] </a>
-				<a class="sourceLine" id="cb1-2" title="2">VerifyAsserstionIssuer: true </a>
+				<a class="sourceLine" id="cb1-2" title="2">VerifyAssertionIssuer=true </a>
 				</div>
 				</div>
 				</div></td>
@@ -476,6 +476,8 @@ To configure through file upload:
         ``` java
         [authentication.authenticator.saml] 
         enable=true
+
+		[authentication.authenticator.saml.parameters]
         SAMLSSOAssertionConsumerUrl="https://localhost:9443/commonauth"
     	```
 
@@ -490,7 +492,7 @@ To configure through file upload:
 	 
 		``` xml
 		[saml.slo] 
-		host_name_verification: false
+		host_name_verification=false
 		```
 	
 	- If the certificate is self-signed, import the service


### PR DESCRIPTION
## Purpose
> Resolved the issues in the Configuring SAML 2.0 Web SSO Documentation issue for 5.11.0.

## Goals
> This PR will ensure the proper Configuring SAML 2.0 Web SSO documentation guidelines using wso2 identity server.

## Approach
> Fixed toml configuration for `SAMLSSOAssertionConsumerUrl` using following adjustment
``` java
[authentication.authenticator.saml] 
enable=true
[authentication.authenticator.saml.parameters]
SAMLSSOAssertionConsumerUrl="https://localhost:9443/commonauth"
```
> Fixed typo mistakes in toml configuration

## User stories
> Can properly go through a Configuring SAML 2.0 Web SSO steps for Identity Server.

## Release note
> Few bugs were fixed in the documentation of 5.11.0 - Configuring SAML 2.0 Web SSO page

## Documentation
> Updated the Configuring SAML 2.0 Web SSO page in 5.11.0 doc

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A