### PR TITLE
file name changes

### DIFF
--- a/en/docs/setup/http-access-logging.md
+++ b/en/docs/setup/http-access-logging.md
@@ -6,7 +6,7 @@ it received, what the errors are, etc. This information is useful for
 troubleshooting errors. WSO2 Identity Server can enable access logs for the
 HTTP servlet transport. This servlet transport works on `9443`/`9763` ports,
 and it recieves admin/operation requests. Therefore, access logs for the
-servert transpot is useful for analysing operational/admin-level access
+servlet transport is useful for analysing operational/admin-level access
 details.
 
 
@@ -78,8 +78,8 @@ In the Identity Server 5.9.0 only the access log pattern is configurable.
 
 3.  Restart the server. According to the configurations, a log
     file named
-    `           localhost_access_log_sample.{DATE}.log          ` is
-    created inside the `<IS_HOME>/repository/logs          ` directory. The
+    `           http_access.{DATE}.log          ` is
+    created by default inside the `<IS_HOME>/repository/logs          ` directory. The
     log is rotated on a daily basis.
 
 ### Customizing access logs by pattern
@@ -106,7 +106,7 @@ GET http://<IP>:<PORT>/example/servlets/servlet/RequestInfoExample?abc=xyz
 ```
 
 The following log entry is recorded in the
-`         localhost_access_log_sample.{DATE}.log        ` file.
+`         http_access.{DATE}.log        ` file.
 
 ``` java
 text/plain; charset=utf-8        */*        gzip,deflate,sdch
@@ -145,7 +145,7 @@ exists), and a remote hostname (or IP) of every request coming to the
 server as follows:
 
 ``` java
-“GET /example/servlets/servlet/RequestInfoExample?abc=xyz HTTP/1.1”      ?abc=xyz     10.100.0.67
+“GET http://<IP>:<PORT>//example/servlets/servlet/RequestInfoExample?abc=xyz HTTP/1.1”      ?abc=xyz     10.100.0.67
 ```
 
 #### Example 4: Logging URL encoded parameters


### PR DESCRIPTION
## Purpose
>  Resolve the issues in HTTP Access Logging documentation for 5:11:0

## Goals
> This Pr resolves the issues in naming formats of the log whiles, When logging HTTP requests through the wso2 identity server.


## Approach
> -The name format of the log files created  are  shown as `localhost_access_log_sample.{DATE}.log` in the documentation.
     But the file format created by default is ` http_access.{DATE}.log ` unless  the file prefix is changes in the configurations.
- Fixed Incorrect URL formats in the documentation.



## Release note
Fix bugs were fixed n the documentation of 5.11.0 - Identity Server Documentation HTTP Access Logging
## Documentation
>https://is.docs.wso2.com/en/latest/setup/http-access-logging/

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A
## Related PRs
> N/A
## Migrations (if applicable)
>N/A
## Test environment
> OS - Linux
 
## Learning
>N/A