### PR TITLE
Fix JMX Server Configurations[Master]

### DIFF
--- a/en/docs/setup/jmx-based-monitoring.md
+++ b/en/docs/setup/jmx-based-monitoring.md
@@ -30,7 +30,7 @@ rmi_server_por = "11111"
 #### Enabling JMX for the server
 
 You can enable the JMX server by setting the following
-property to ` true ` in the `deployment.toml` file.
+property to ` true ` in the `deployment.toml` file:
 
 ```toml
 [monitoring.jmx]

--- a/en/docs/setup/jmx-based-monitoring.md
+++ b/en/docs/setup/jmx-based-monitoring.md
@@ -8,9 +8,7 @@
   
 
 ### Configuring JMX in WSO2 Identity Server
-
-JMX is enabled in WSO2 Identity Server by default ensuring that the JMX
-server starts automatically. Additionally, you can enable JMX separately for the various datasources
+JMX  can be enabled separately for the various datasources
 that are used by WSO2 IS. Once JMX is enabled, you can log in to the
 JConsole tool and monitor your WSO2 IS instance as explained in the [Monitoring WSO2 Identity Server with JConsole](#monitoring-wso2-identity-server-with-jconsole) section.
 
@@ -29,14 +27,14 @@ rmi_registry_port = "9999"
 rmi_server_por = "11111"
 ```
 
-#### Disabling JMX for the server
+#### Enabling JMX for the server
 
-You can disable the JMX server by setting the following
-property to ` false ` in the `deployment.toml` file.
+You can enable the JMX server by setting the following
+property to ` true ` in the `deployment.toml` file.
 
 ```toml
 [monitoring.jmx]
-rmi_server_start = false
+rmi_server_start = true
 ```
 
 #### Enabling JMX for a datasource


### PR DESCRIPTION
## Purpose
> Resolve the issues in setting up the JMX server

## Goals
>This Pr solves the issues in enabling the JMX server

## Approach
> In the documentation it was mentioned that the JMX server is enabled by default in the identity server. But its disabled by default in identity server 5.11.0 . Therefore JMX server should be enabled through toml configurations as below.

```
[monitoring.jmx]
rmi_server_start = true
```

## Release note
> Fix issues in enabling the JMX server in documentation of 5.11.0 - JMX-Based Monitoring
## Documentation
> https://is.docs.wso2.com/en/latest/setup/jmx-based-monitoring/
## Training
> N/A

## Certification
>N/A
## Marketing
> N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A


## Migrations (if applicable)
> N/A
## Test environment
> OS-Linux
 
## Learning
> N/A