### PR TITLE
Fix Set passwords using System Properties-[5.11.0]

### DIFF
--- a/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
+++ b/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
@@ -25,7 +25,7 @@ password = "$env{ENV_VAR}"
 ``` 
 
 ### Set passwords using System Properties
- 1.  Open `<IS_HOME>/repository/deployment.toml` file and refer the required password value in the configuration using `$sys{system.property}` placeholder. 
+ 1.  Open the `<IS_HOME>/repository/deployment.toml` file and refer the required password value in the configuration using the `$sys{system.property}` placeholder. 
    
     ``` tab="Format"
     [super_admin]

--- a/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
+++ b/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
@@ -1,8 +1,11 @@
 # Set Passwords using Environment Variables/System Properties
 
-The instructions on this page explain how you can set the configuration passwords in the ei.toml file using values passed from environment variables and system properties. 
+The instructions on this page explain how you can set the configuration passwords in the `         deployment.toml        `  file using values passed from environment variables and system properties. 
 
 This is done using the $env{ENV_VAR} and the $sys{system.property} place holders as shown below
+
+### Set passwords using Environment Variables
+
 
 ```
 [database.shared_db]
@@ -20,3 +23,25 @@ key_password = "$env{ENV_VAR}"
 [truststore]                  
 password = "$env{ENV_VAR}" 
 ``` 
+
+### Set passwords using System Properties
+ 1.  Open `<IS_HOME>/repository/deployment.toml` file and refer the required password value in the configuration using `$sys{system.property}` placeholder. 
+   
+    ``` tab="Format"
+    [super_admin]
+    username="admin"
+    password="$sys{system.property}"
+    ```
+        
+    ``` tab="Example"
+    [super_admin]
+    username="admin"
+    password="$sys{admin.password}"
+    ```
+    
+2.  Pass the above configured system property to runtime by using one of following options (`admin.password` has been used as the sample system property)
+
+    -   During the server startup time
+
+        * On Linux: `./wso2server.sh -Dadmin.password=admin`
+        * On Windows: `./wso2server.bat -Dadmin.password=admin`

--- a/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
+++ b/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
@@ -1,13 +1,14 @@
 # Set Passwords using Environment Variables/System Properties
 
-The instructions on this page explain how you can set the configuration passwords in the `         deployment.toml        `  file using values passed from environment variables and system properties. 
+The instructions on this page explain how you can set the configuration passwords in the `deployment.toml`  file using values passed from environment variables and system properties. 
 
-This is done using the $env{ENV_VAR} and the $sys{system.property} place holders as shown below
+This is done using the `$env{ENV_VAR}` and the `$sys{system.property}` place holders as shown below
 
-### Set passwords using Environment Variables
+## Set passwords using Environment Variables
 
+Open the `<IS_HOME>/repository/deployment.toml` file and refer the required password value in the configuration using the `$env{ENV_VAR}` placeholder. 
 
-```
+```toml
 [database.shared_db]
 password = "$env{ENV_VAR}"
 
@@ -24,24 +25,26 @@ key_password = "$env{ENV_VAR}"
 password = "$env{ENV_VAR}" 
 ``` 
 
-### Set passwords using System Properties
- 1.  Open the `<IS_HOME>/repository/deployment.toml` file and refer the required password value in the configuration using the `$sys{system.property}` placeholder. 
+## Set passwords using System Properties
+
+1. Open the `<IS_HOME>/repository/deployment.toml` file and refer the required password value in the configuration using the `$sys{system.property}` placeholder. 
    
     ``` tab="Format"
     [super_admin]
     username="admin"
     password="$sys{system.property}"
     ```
-        
+
     ``` tab="Example"
     [super_admin]
     username="admin"
     password="$sys{admin.password}"
     ```
-    
-2. Pass the above configured system property to the runtime by using one of following options during server startup.
-!!! info
-       Note that `admin.password` has been used as the sample system property.
 
-       - On Linux: `./wso2server.sh -Dadmin.password=admin`
-       - On Windows: `./wso2server.bat -Dadmin.password=admin`
+2. Pass the above configured system property to the runtime by using one of following options during server startup.
+
+    !!! info
+        Note that `admin.password` has been used as the sample system property.
+
+    - On Linux: `./wso2server.sh -Dadmin.password=admin`
+    - On Windows: `./wso2server.bat -Dadmin.password=admin`

--- a/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
+++ b/en/docs/setup/set-passwords-using-environment-variables-or-system-properties.md
@@ -39,9 +39,9 @@ password = "$env{ENV_VAR}"
     password="$sys{admin.password}"
     ```
     
-2.  Pass the above configured system property to runtime by using one of following options (`admin.password` has been used as the sample system property)
+2. Pass the above configured system property to the runtime by using one of following options during server startup.
+!!! info
+       Note that `admin.password` has been used as the sample system property.
 
-    -   During the server startup time
-
-        * On Linux: `./wso2server.sh -Dadmin.password=admin`
-        * On Windows: `./wso2server.bat -Dadmin.password=admin`
+       - On Linux: `./wso2server.sh -Dadmin.password=admin`
+       - On Windows: `./wso2server.bat -Dadmin.password=admin`


### PR DESCRIPTION
## Purpose
> Adding the missing configurations , when setting passwords using System properties.

## Goals
>This PR solves the issue of missing configurations , when setting passwords using System properties.
## Approach
> 
Adding toml configurations of  setting System properties with example.
   ```
  [super_admin]
   username="admin"
   password="$sys{system.property}
```
## User stories
> 

## Release note
> Fix issues in Set passwords using System Properties in the  documentation of 5.11.0 - Set Passwords using Environment Variables/System Properties
## Documentation
> https://is.docs.wso2.com/en/latest/setup/set-passwords-using-environment-variables-or-system-properties/

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> OS - Linux
