### PR TITLE
Fix issue in SMS-OTP disable option

### DIFF
--- a/en/docs/guides/mfa/2fa-sms-otp.md
+++ b/en/docs/guides/mfa/2fa-sms-otp.md
@@ -269,7 +269,7 @@ This page guides you through configuring [two-factor authentication](../../../re
     
     ![user-disable-smsotp](../../../assets/img/guides/user-disable-smsotp.png)
 
-6. Enter **True** for the Disable SMSOTP option and click **Update**, in the user profile to Disable the SMS OTP.	
+6. To disable SMS OTP in the user profile, enter **True** in the **Disable SMSOTP** field and click **Update**.	
    
 
 ----

--- a/en/docs/guides/mfa/2fa-sms-otp.md
+++ b/en/docs/guides/mfa/2fa-sms-otp.md
@@ -262,11 +262,16 @@ This page guides you through configuring [two-factor authentication](../../../re
 
     ![supported-by-default](../../../assets/img/guides/supported-by-default.png)
 
+
+
 5. To verify whether the option is available for the users, navigate to a user 
     profile of a user and check whether the **Disable SMSOTP** option is available.
     
     ![user-disable-smsotp](../../../assets/img/guides/user-disable-smsotp.png)
-	
+
+6. Enter **True** for the Disable SMSOTP option and click **Update**, in the user profile to Disable the SMS OTP.	
+   
+
 ----
 
 ## Configuring backup codes for SMS OTP


### PR DESCRIPTION
## Purpose
> Fix the issue of incomplete steps in disabling SMS-OTP option.


## Approach
> in the documentation for IS 5.12.0**[New-restructure]** when disabling the SMS-OTP in the user profile. User have to enter **
![Screenshot from 2022-04-26 09-38-48](https://user-images.githubusercontent.com/40081059/165273390-078b6c05-f482-42dd-bc75-66e3b588526c.png)
True** in the Disable SMSOTP option and update .


## User stories
> User will be able to successfully disable the SMS-OTP option

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
>http://127.0.0.1:8000/guides/mfa/2fa-sms-otp/

## Training
> N/A

## Certification
> N/A

## Marketing
> 
N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> OS-Linux
## Learning
> N/A