### PR TITLE
Configure email notification for account locking - In reCAPTCHA for Single Sign-On

### DIFF
--- a/en/docs/guides/login/configure-recaptcha-for-single-sign-on.md
+++ b/en/docs/guides/login/configure-recaptcha-for-single-sign-on.md
@@ -19,7 +19,7 @@ attacks.
 {! fragments/configure-recaptcha-for-sso.md !}
 
 !!! Info
-    - If the user exceeds the Maximum failed login attempts as well, the  email notification for account locking scenario can be configured by [Configure Email Notifications for Account Locking](../../../guides/tenants/email-account-locking)
+     If the user exceeds the maximum allowed failed login attempts as well, be sure to [configure email notifications for account locking](../../../guides/tenants/email-account-locking).
     
 
 !!! info "Related topics"

--- a/en/docs/guides/login/configure-recaptcha-for-single-sign-on.md
+++ b/en/docs/guides/login/configure-recaptcha-for-single-sign-on.md
@@ -18,5 +18,9 @@ attacks.
 
 {! fragments/configure-recaptcha-for-sso.md !}
 
+!!! Info
+    - If the user exceeds the Maximum failed login attempts as well, the  email notification for account locking scenario can be configured by [Configure Email Notifications for Account Locking](../../../guides/tenants/email-account-locking)
+    
+
 !!! info "Related topics"
     - [Concept: Single Sign-On](../../../references/concepts/single-sign-on)


### PR DESCRIPTION
## Purpose
> Adding missing configurations for sending email notifications  for account locking in reCAPTCHA for Single Sign-On
## Goals
> This pr resolve the issue of missing configurations when sending email notifications account locking in reCAPTCHA for Single Sign-On in IS 5.12.0 Documentation[new-restructure]

## Approach
> Adding hyperlinks

## User stories
> N/A
## Release note
>N/A

## Documentation
>http://127.0.0.1:8000/guides/login/configure-recaptcha-for-single-sign-on/

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A
## Test environment
>OS - Linux
 
## Learning
>N/A