### PR TITLE
Update Outbound Provisioning with Salesforce with unique username note

### DIFF
--- a/en/docs/learn/outbound-provisioning-with-salesforce.md
+++ b/en/docs/learn/outbound-provisioning-with-salesforce.md
@@ -520,8 +520,6 @@ management console, this user should also appear in Salesforce.
         unique across all Salesforce organizations.
         Otherwise the user might not be provisioned to Salesforce if the username already exists 
         even in another Salesforce organization.
-        For example, if we consider test@gmail.com as the username, this will not get provisioned to Salesforce.
-        This is because this username is already in use in one of the organizations in Salesforce.
         For more information visit https://help.salesforce.com/s/articleView?id=000325728&type=1
         
         Later on, if you want to update the user details, you

--- a/en/docs/learn/outbound-provisioning-with-salesforce.md
+++ b/en/docs/learn/outbound-provisioning-with-salesforce.md
@@ -516,8 +516,13 @@ management console, this user should also appear in Salesforce.
 3.  Enter the username in the form of an email and enter the password.
     
     !!! note
-        When adding the username, make sure to add a unique email address as the username. 
-        Otherwise the user might not be provisioned to Salesforce if the username already exists in Salesforce.
+        When adding the username, make sure to add a unique email address as the username which must be 
+        unique across all Salesforce organizations.
+        Otherwise the user might not be provisioned to Salesforce if the username already exists 
+        even in another Salesforce organization.
+        For example, if we consider test@gmail.com as the username, this will not get provisioned to Salesforce.
+        This is because this username is already in use in one of the organizations in Salesforce.
+        For more information visit https://help.salesforce.com/s/articleView?id=000325728&type=1
         
         Later on, if you want to update the user details, you
         won't be able to update the email address.

--- a/en/docs/learn/outbound-provisioning-with-salesforce.md
+++ b/en/docs/learn/outbound-provisioning-with-salesforce.md
@@ -516,11 +516,9 @@ management console, this user should also appear in Salesforce.
 3.  Enter the username in the form of an email and enter the password.
     
     !!! note
-        When adding the username, make sure to add a unique email address as the username which must be 
-        unique across all Salesforce organizations.
-        Otherwise the user might not be provisioned to Salesforce if the username already exists 
-        even in another Salesforce organization.
-        For more information visit https://help.salesforce.com/s/articleView?id=000325728&type=1
+        When adding the username, make sure to add an email address that is unique across all Salesforce organizations.
+        The user might not be provisioned to Salesforce if the username already exists even in another Salesforce organization.
+        For more information see the [Salesforce documentation](https://help.salesforce.com/s/articleView?id=000325728&type=1).
         
         Later on, if you want to update the user details, you
         won't be able to update the email address.

--- a/en/docs/learn/outbound-provisioning-with-salesforce.md
+++ b/en/docs/learn/outbound-provisioning-with-salesforce.md
@@ -516,6 +516,9 @@ management console, this user should also appear in Salesforce.
 3.  Enter the username in the form of an email and enter the password.
     
     !!! note
+        When adding the username, make sure to add a unique email address as the username. 
+        Otherwise the user might not be provisioned to Salesforce if the username already exists in Salesforce.
+        
         Later on, if you want to update the user details, you
         won't be able to update the email address.
 


### PR DESCRIPTION
## Purpose
> If the username is already in the Salesforce, the user will not be provisioned.

## Related Issues
> https://github.com/wso2/product-is/issues/13619