### PR TITLE
Setting up an account for MFA in FIDO

### DIFF
--- a/en/docs/guides/mfa/2fa-fido.md
+++ b/en/docs/guides/mfa/2fa-fido.md
@@ -34,7 +34,7 @@ Follow the steps given below if you are using a reverse proxy enabled setup to c
     ```
 
 ----
-## Setting up an account for MFA
+### Setting up an account for MFA
 To associate a FIDO device with the user account, refer [Add security device](../my-account/my-account.md#add-security-device).
 ## Create a service provider
 

--- a/en/docs/guides/mfa/2fa-fido.md
+++ b/en/docs/guides/mfa/2fa-fido.md
@@ -34,7 +34,8 @@ Follow the steps given below if you are using a reverse proxy enabled setup to c
     ```
 
 ----
-
+## Setting up an account for MFA
+To associate a FIDO device with the user account, refer [Add security device](../my-account/my-account.md#add-security-device).
 ## Create a service provider
 
 {!fragments/register-a-service-provider.md!}


### PR DESCRIPTION
## Purpose
>This PR resolves the issue of missing steps, in setting up an account for MFA when configuring FIDO Authentication in the documentation for 5.12(new-restructure)

## Goals
>User will be able to successfully setup the user account to configure FIDO authentication .
## Approach
> Adding necessary steps and links to the Identity server  documentation(5.12) , in order to guide the user to set up an account for MFA when setting up FIDO Authentication

## User stories
> N/A

## Release note
> 

## Documentation
>[
](http://127.0.0.1:8000/guides/mfa/2fa-fido/)
## Training
>N/A

## Certification
>N/A


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
>  - Product Version: [e.g., IS 5.10.0, IS 5.9.0]
 - OS: [e.g., Windows, Linux, Mac] 
## Learning
> N/A