### PR TITLE
Fix- Incorrect Terms in Configuring Email OTP

### DIFF
--- a/en/docs/guides/mfa/2fa-email-otp.md
+++ b/en/docs/guides/mfa/2fa-email-otp.md
@@ -109,9 +109,9 @@ Configure the multiple factor authentication steps for the service provider:
     - **Step 2**
         1. Click **Add Authentication Step**.
 
-        2. Select `emailotp` under **Federated Authenticators** and click **Add Authenticator** to add SMSOTP authentication as the second step.
+        2. Select `emailotp` under **Federated Authenticators** and click **Add Authenticator** to add EMAIL OTP authentication as the second step.
 
-            Adding SMSOTP as a second step adds another layer of authentication and security.
+            Adding EMAIL OTP as a second step adds another layer of authentication and security.
     
         <img name='sms-otp-authentication-steps' src='../../../assets/img/guides/sms-otp-authentication-steps.png' class='img-zoomable'/>
 


### PR DESCRIPTION
## Purpose
> This Pr fixes few  incorrect terms , used in the identity server documentation for 5.12(new_restructure) when  configuring Email OTP.

## Goals
>
## Approach
> Replaced the incorrect terms

## User stories
> 
## Release note
>

## Documentation
> 

## Training
>

## Certification
> 

## Marketing
> 
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
>
## Related PRs
> 
## Migrations (if applicable)
> 
## Test environment
> 
 
## Learning
>Product Version: [e.g., IS 5.12-beta2]
OS: [Mac]
Database: [MySQL]
Userstore: [JDBC]