### PR TITLE
Modify the Description of `base_dn` Property

### DIFF
--- a/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
+++ b/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
@@ -32,11 +32,11 @@ should be active_directory_unique_id.
 <tr class="odd">
 <td>base_dn</td>
 <td>User Search Base</td>
-<td>DN of the base directory where Users container with user entries is stored in the user store.
-When the userstore searches for users, it will start from this location of the directory and search inside the Users container for users.<br />
+<td>DN of the base directory where the <b>Users</b> container (which holds user entries) is stored in the user store.
+When the user store searches for users, it will start from this location of the directory and search inside the <b>Users</b> container for users.<br />
 Sample values: dc=wso2,dc=org
 
-Note: By default, cn=Users is appended to this base_dn value for the UserSearchBase. If the users are stored inside a different context or object, add the DN of it as an additional property through the UserSearchBase property.</td>
+<b>Note:</b> By default, <code>cn=Users</code> is appended to this <code>base_dn</code> value for the <code>UserSearchBase</code>. If the users are stored inside a different context or object, add the DN of it as an additional property through the <code>UserSearchBase</code> property.</td>
 </tr>
 </table>
 
@@ -458,7 +458,7 @@ conversion when reading from/writing to user store.
 <td>user_search_base</td>
 <td>User Search Base</td>
 <td>DN of the context or object under which the user entries are stored in the user store. When the user store searches for users, it will start from this location of the directory.
-<p>Default: cn=Users,dc=wso2,dc=org</p></td>
+<p>Default: <code>cn=Users,dc=wso2,dc=org</code></p></td>
 </tr>
 </tbody>
 </table>

--- a/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
+++ b/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
@@ -34,7 +34,7 @@ should be active_directory_unique_id.
 <td>User Search Base</td>
 <td>DN of the base directory where the <b>Users</b> container (which holds user entries) is stored in the user store.
 When the user store searches for users, it will start from this location of the directory and search inside the <b>Users</b> container for users.<br />
-Sample values: dc=wso2,dc=org
+Sample values: <code>dc=wso2,dc=org</code>
 
 <b>Note:</b> By default, <code>cn=Users</code> is appended to this <code>base_dn</code> value for the <code>UserSearchBase</code>. If the users are stored inside a different context or object, add the DN of it as an additional property through the <code>UserSearchBase</code> property.</td>
 </tr>

--- a/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
+++ b/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
@@ -32,8 +32,11 @@ should be active_directory_unique_id.
 <tr class="odd">
 <td>base_dn</td>
 <td>User Search Base</td>
-<td>DN of the context or object under which the user entries are stored in the user store. When the user store searches for users, it will start from this location of the directory<br />
-Sample values: ou=Users,dc=wso2,dc=org</td>
+<td>DN of the base directory where Users container with user entries is stored in the user store.
+When the userstore searches for users, it will start from this location of the directory and search inside the Users container for users.<br />
+Sample values: dc=wso2,dc=org
+
+Note: By default, cn=Users is appended to this base_dn value for the UserSearchBase. If the users are stored inside a different context or object, add the DN of it as an additional property through the UserSearchBase property.</td>
 </tr>
 </table>
 
@@ -449,6 +452,13 @@ Default: not configured</td>
 <td>This is a comma-separated list of user store attributes that have the data type of Timestamp and may require a 
 conversion when reading from/writing to user store.
 <p>Default: not configured</p></td>
+</tr>
+<tr class="odd">
+<td>UserSearchBase</td>
+<td>user_search_base</td>
+<td>User Search Base</td>
+<td>DN of the context or object under which the user entries are stored in the user store. When the user store searches for users, it will start from this location of the directory.
+<p>Default: cn=Users,dc=wso2,dc=org</p></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Purpose
This PR modifies the description of base_dn property and provides more clarification for a user on how to set the property correctly. The sample value set for this config will be corrected by this PR and adds additional information needed if a user needs to add a different DN for the UserSearchBase property than the default DN.

Resolves: https://github.com/wso2/product-is/issues/13886