### PR TITLE
Update fronting-with-the-nginx-load-balancer.md

### DIFF
--- a/en/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -2,7 +2,7 @@
 
 When setting up the WSO2 Identity Server cluster with Nginx,
 you can follow the instructions given below (you must do this **after**
-setting up the cluster following the above instructions). 
+setting up the cluster following the instructions in [deploying the identity server](../../setup/deployment-guide). 
 
 !!! tip 
     When clustering WSO2 Identity Server with a load balancer, you may need to


### PR DESCRIPTION
Linking to the correct section as "above instructions" is not valid.

Why?
Before fronting a load balancer there are changes needed to be done which are in https://is.docs.wso2.com/en/latest/setup/deployment-guide/ section. Currently we refer to this by saying "above instructions". But since this is a separate page it doesn't make sense.