### PR TITLE
[5.11.0] - Add slash to SMS OTP configurations

### DIFF
--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -488,9 +488,9 @@ You can configure any of the above as following in the
 
     ```toml
     [authentication.authenticator.sms_otp.parameters]
-    SMSOTPAuthenticationEndpointURL= "smsotpauthenticationendpoint/smsotp.jsp"
-    SMSOTPAuthenticationEndpointErrorPage= "smsotpauthenticationendpoint/smsotpError.jsp"
-    MobileNumberRegPage = "smsotpauthenticationendpoint/mobile.jsp"
+    SMSOTPAuthenticationEndpointURL= "/smsotpauthenticationendpoint/smsotp.jsp"
+    SMSOTPAuthenticationEndpointErrorPage= "/smsotpauthenticationendpoint/smsotpError.jsp"
+    MobileNumberRegPage = "/smsotpauthenticationendpoint/mobile.jsp"
     RetryEnable = true
     ResendEnable = true
     BackupCode = true


### PR DESCRIPTION
## Purpose
- Add slashes to SMS OTP configurations that contains URLs and locations.
- Related to https://stackoverflow.com/questions/72587861/wso2-is-sms-otp-returns-401-page-after-login.