### PR TITLE
[MASTER] - Add slash to SMS OTP configurations

### DIFF
--- a/en/docs/guides/mfa/sms-otp-config-advanced.md
+++ b/en/docs/guides/mfa/sms-otp-config-advanced.md
@@ -9,9 +9,9 @@ The following code snippet shows a sample SMSOTP configuration in the `<IS_HOME>
 enable=true
 
 [authentication.authenticator.sms_otp.parameters]
-SMSOTPAuthenticationEndpointURL= "smsotpauthenticationendpoint/smsotp.jsp"
-SMSOTPAuthenticationEndpointErrorPage= "smsotpauthenticationendpoint/smsotpError.jsp"
-MobileNumberRegPage = "smsotpauthenticationendpoint/mobile.jsp"
+SMSOTPAuthenticationEndpointURL= "/smsotpauthenticationendpoint/smsotp.jsp"
+SMSOTPAuthenticationEndpointErrorPage= "/smsotpauthenticationendpoint/smsotpError.jsp"
+MobileNumberRegPage = "/smsotpauthenticationendpoint/mobile.jsp"
 RetryEnable = true
 ResendEnable = true
 BackupCode = true


### PR DESCRIPTION
## Purpose
- Add slashes to SMS OTP configurations that contains URLs and locations.
- Related to https://stackoverflow.com/questions/72587861/wso2-is-sms-otp-returns-401-page-after-login.