### PR TITLE
[5.9.0] - Add missing configuration

### DIFF
--- a/en/docs/learn/configuring-claims-for-an-identity-provider.md
+++ b/en/docs/learn/configuring-claims-for-an-identity-provider.md
@@ -19,6 +19,17 @@ In the **Claim Configuration** form, there are two sub forms.
 -   Advanced claim configuration - This involves more advanced mapping, where the mapped claims can
     have specific default values.
 
+!!! Note
+
+    If your considering to define a custom claim dialect, the following configuration should be added to the 
+    `<IS_HOME>/repository/conf/deployment.toml` file for that to take effect, otherwise the protocol specific claim 
+    dialect such as the OIDC dialect is always picked.
+
+    ```toml
+    [authentication.endpoint]
+    enable_custom_claim_mappings = true
+    ```
+
 Let's get started!
 
 To view the claim configuration section, expand the **Claim

--- a/en/docs/learn/configuring-claims-for-an-identity-provider.md
+++ b/en/docs/learn/configuring-claims-for-an-identity-provider.md
@@ -21,9 +21,9 @@ In the **Claim Configuration** form, there are two sub forms.
 
 !!! Note
 
-    If your considering to define a custom claim dialect, the following configuration should be added to the 
-    `<IS_HOME>/repository/conf/deployment.toml` file for that to take effect, otherwise the protocol specific claim 
-    dialect such as the OIDC dialect is always picked.
+    To define a custom claim dialect, the configuration given below is required in the 
+    `<IS_HOME>/repository/conf/deployment.toml` file of your WSO2 Identity Server. Otherwise the protocol-specific claim 
+    dialect such as the OIDC dialect is always used.
 
     ```toml
     [authentication.endpoint]


### PR DESCRIPTION
## Purpose
- Add missing IdP claim configuration that is required when custom claim mapping is used.