### PR TITLE
[5.11.0] - Add missing details to the configuring active directory documentation

### DIFF
--- a/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
+++ b/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
@@ -94,6 +94,22 @@ connection_url = "ldaps://10.100.1.102:639"
 connection_name = "cn=admin,ou=system"
 connection_password = "admin"
 ```
+
+In addition to the above, please make sure that you import the Active Directory user store public certificate to the
+WSO2 Identity Server’s client trust store. To perform this, you need to navigate to the
+`<IS_HOME>repository/resources/security` directory and execute the following command to import the certificate to
+client-truststore of WSO2 Identity Server.
+
+```
+keytool -import -alias certalias -file <certificate>.pem -keystore client-truststore.jks -storepass wso2carbon
+```
+
+!!! note
+    `wso2carbon` is the keystore password of the default client-truststore.jks file of WSO2 Identity Server.
+
+Furthermore, please make sure to follow the steps mentioned in [Configure Active Directory Userstores for SCIM 2.0 based Inbound Provisioning](../../learn/configuring-active-directory-user-stores-for-scim-2.0-based-inbound-provisioning)
+since SCIM enabled by default from the WSO2 Identity Server 5.10.0 onwards.
+
 ## Properties used in Read-write Active Directory userstore manager
 
 The following table lists the properties used in Read-write Active

--- a/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
+++ b/en/docs/setup/configuring-a-read-write-active-directory-user-store.md
@@ -108,7 +108,7 @@ keytool -import -alias certalias -file <certificate>.pem -keystore client-trusts
     `wso2carbon` is the keystore password of the default client-truststore.jks file of WSO2 Identity Server.
 
 Furthermore, please make sure to follow the steps mentioned in [Configure Active Directory Userstores for SCIM 2.0 based Inbound Provisioning](../../learn/configuring-active-directory-user-stores-for-scim-2.0-based-inbound-provisioning)
-since SCIM enabled by default from the WSO2 Identity Server 5.10.0 onwards.
+since SCIM is enabled by default from the WSO2 Identity Server 5.10.0 onwards.
 
 ## Properties used in Read-write Active Directory userstore manager
 


### PR DESCRIPTION
## Purpose
- Add missing details about Configuring a Read-Write Active Directory User Store.