### PR TITLE
Add Instructions about Claim Mappings Required to Configure AD

### DIFF
--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -96,8 +96,8 @@ connection_password = "admin"
 ```
 
 !!! note
-    It is required to edit the claim mappings in WSO2 IS according to the user claims of the Active Directory version you have configured.
-    Before starting the server, edit the file configuration in <IS_HOME>/repository/conf/claim-config.xml and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims into `whenCreated` and `whenChanged` respectively.
+    It is required to edit the claim mappings in WSO2 IS according to the user claims of the Active Directory version you have configured.<br />
+    Before starting the server, edit the `<IS_HOME>/repository/conf/claim-config.xml` configuration file and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims into `whenCreated` and `whenChanged` respectively.
     Start the server and edit the rest of the required claim mappings through the management console as explained in [edit claim mapping](../guides/dialects/edit-claim-mapping.md).
 
 ---

--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -89,11 +89,16 @@ Replace the default `user_store` configuration in the `         <IS_HOME>/reposi
 ```toml
 [user_store]
 type = "active_directory_unique_id"
-base_dn = "cn=Users,dc=wso2,dc=org"
+base_dn = "dc=wso2,dc=org"
 connection_url = "ldaps://10.100.1.102:639"
 connection_name = "cn=admin,ou=system"
 connection_password = "admin"
 ```
+
+!!! note
+    It is required to edit the claim mappings in the IS according to the user claims of the Active Directory version you have configured.
+    Before starting the server, edit the file configuration in <IS_HOME>/repository/conf/claim-config.xml and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims into `whenCreated` and `whenChanged` respectively.
+    Start the server and edit the rest of the required claim mappings through the management console as explained in [edit claim mapping](../guides/dialects/edit-claim-mapping.md).
 
 ---
 

--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -97,7 +97,7 @@ connection_password = "admin"
 
 !!! note
     It is required to edit the claim mappings in WSO2 IS according to the user claims of the Active Directory version you have configured.<br />
-    Before starting the server, edit the `<IS_HOME>/repository/conf/claim-config.xml` configuration file and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims into `whenCreated` and `whenChanged` respectively.
+    Before starting the server, edit the `<IS_HOME>/repository/conf/claim-config.xml` configuration file and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims to `whenCreated` and `whenChanged` respectively.
     Start the server and edit the rest of the required claim mappings through the management console as explained in [edit claim mapping](../guides/dialects/edit-claim-mapping.md).
 
 ---

--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -96,7 +96,7 @@ connection_password = "admin"
 ```
 
 !!! note
-    It is required to edit the claim mappings in the IS according to the user claims of the Active Directory version you have configured.
+    It is required to edit the claim mappings in WSO2 IS according to the user claims of the Active Directory version you have configured.
     Before starting the server, edit the file configuration in <IS_HOME>/repository/conf/claim-config.xml and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims into `whenCreated` and `whenChanged` respectively.
     Start the server and edit the rest of the required claim mappings through the management console as explained in [edit claim mapping](../guides/dialects/edit-claim-mapping.md).
 


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/14119

This PR adds instructions to edit the claim mappings to support the Active Directory user attributes when configuring AD as a primary userstore.
When configuring the AD, before starting the server we need to edit the claim-config.xml file and change AttributeID of the following 2 claims as shown below.

Created Time
createdDate --> whenCreated

Last Modified Time
lastModifiedDate --> whenChanged

After changing these configurations, the rest of the claim mappings can be edited from the management console.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/47671237/177489063-161d56f8-9594-4ac7-aa27-70bafc280bf3.png">
