### PR TITLE
Remove onload && extra imports

### DIFF
--- a/en/docs/apis/application-rest-api.md
+++ b/en/docs/apis/application-rest-api.md
@@ -13,13 +13,12 @@ template: templates/swagger.html
     4.  Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/application.yaml",
+     url: "../restapis/application.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -33,8 +32,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/collections/51139ad1cff6875115a1)

--- a/en/docs/apis/approvals-rest-api.md
+++ b/en/docs/apis/approvals-rest-api.md
@@ -19,10 +19,10 @@ template: templates/swagger.html
 
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/approvals.yaml",
+     url: "../restapis/approvals.yaml",
     name: "Download the yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
@@ -38,8 +38,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/5756659f9134b101dd64)

--- a/en/docs/apis/association-rest-api.md
+++ b/en/docs/apis/association-rest-api.md
@@ -33,10 +33,10 @@ template: templates/swagger.html
      
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/association.yaml",
+     url: "../restapis/association.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -51,8 +51,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/ecd26c008975ebf4eafa)

--- a/en/docs/apis/authorized-apps-rest-api.md
+++ b/en/docs/apis/authorized-apps-rest-api.md
@@ -21,10 +21,10 @@ template: templates/swagger.html
          
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/authorized-apps.yaml",
+     url: "../restapis/authorized-apps.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -39,6 +39,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/authorized-apps-v2-rest-api.md
+++ b/en/docs/apis/authorized-apps-v2-rest-api.md
@@ -15,13 +15,12 @@ template: templates/swagger.html
      IS. 
              
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/authorized-apps-v2.yaml",
+     url: "../restapis/authorized-apps-v2.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -35,8 +34,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/112cf1de37658c1b09d5)

--- a/en/docs/apis/challenge-rest-api.md
+++ b/en/docs/apis/challenge-rest-api.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/challenge.yaml",
+     url: "../restapis/challenge.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,8 +34,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4bc7377da85b9dcd0516).

--- a/en/docs/apis/claim-management-rest-api.md
+++ b/en/docs/apis/claim-management-rest-api.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/claim-management.yaml",
+     url: "../restapis/claim-management.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,8 +34,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4bc7377da85b9dcd0516).

--- a/en/docs/apis/configs-rest-api.md
+++ b/en/docs/apis/configs-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/configs.yaml",
+     url: "../restapis/configs.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,8 +33,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/3ec0e2dfffbdf3ca4a0f)

--- a/en/docs/apis/cors-rest-api.md
+++ b/en/docs/apis/cors-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/cors.yaml",
+     url: "../restapis/cors.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,8 +33,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/112cf1de37658c1b09d5)

--- a/en/docs/apis/email-templates-rest-api.md
+++ b/en/docs/apis/email-templates-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/email-templates.yaml",
+     url: "../restapis/email-templates.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,6 +33,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/fido-rest-api.md
+++ b/en/docs/apis/fido-rest-api.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
 
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/fido.yaml",
+     url: "../restapis/fido.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,6 +34,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/identity-governance-rest-api.md
+++ b/en/docs/apis/identity-governance-rest-api.md
@@ -197,10 +197,10 @@ The APIs can be used to retrieve the above mentioned categories, connectors of t
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/identity-governance.yaml",
+     url: "../restapis/identity-governance.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -215,8 +215,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/run-collection/13f70a73e4231606b363).

--- a/en/docs/apis/idp-rest-api.md
+++ b/en/docs/apis/idp-rest-api.md
@@ -13,13 +13,12 @@ template: templates/swagger.html
     4.  Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/idp.yaml",
+     url: "../restapis/idp.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -33,8 +32,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/88672dbc6afe81e8c5d2)

--- a/en/docs/apis/keystore-rest-api.md
+++ b/en/docs/apis/keystore-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     3.  Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/keystore.yaml",
+     url: "../restapis/keystore.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,8 +33,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/9ac2c33f2f4ea5f9b041)

--- a/en/docs/apis/notification-sender-rest-api.md
+++ b/en/docs/apis/notification-sender-rest-api.md
@@ -79,7 +79,7 @@ The following section provides the instructions to contruct requests for each no
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
     url: "https://raw.githubusercontent.com/wso2/identity-api-server/master/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml",
@@ -97,8 +97,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/7bc59cc3e9c958bffaf4)

--- a/en/docs/apis/oauth2-scope-management-rest-apis.md
+++ b/en/docs/apis/oauth2-scope-management-rest-apis.md
@@ -20,13 +20,12 @@ see [OIDC Scope Management REST APIs](../oidc-scope-management-rest-apis).
     3. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/api.identity.oauth2.scope.endpoint.yaml",
+     url: "../restapis/api.identity.oauth2.scope.endpoint.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -40,8 +39,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/80f948e159dd8e0a8a6a)

--- a/en/docs/apis/oidc-scope-management-rest-apis.md
+++ b/en/docs/apis/oidc-scope-management-rest-apis.md
@@ -19,13 +19,12 @@ see [OAuth2 Scope Management REST APIs](../oauth2-scope-management-rest-apis).
     3. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/oidc-scope-management.yaml",
+     url: "../restapis/oidc-scope-management.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -39,8 +38,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/fb712a9e2a2f92c54d8f)

--- a/en/docs/apis/permission-management-rest-api.md
+++ b/en/docs/apis/permission-management-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     4.  Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/permission-management.yaml",
+     url: "../restapis/permission-management.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,6 +33,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/scim2-rest-apis.md
+++ b/en/docs/apis/scim2-rest-apis.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/scim2.yaml",
+    url: "../restapis/scim2.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -35,6 +35,5 @@ window.onload = function() {
   // End Swagger UI call region
 
   window.ui = ui
-}
 </script>
 

--- a/en/docs/apis/script-library-rest-api.md
+++ b/en/docs/apis/script-library-rest-api.md
@@ -13,13 +13,12 @@ template: templates/swagger.html
     3. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/scriptLibrary.yaml",
+     url: "../restapis/scriptLibrary.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -33,8 +32,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4e49915b3a9d796419c6)

--- a/en/docs/apis/session-mgt-rest-api.md
+++ b/en/docs/apis/session-mgt-rest-api.md
@@ -33,10 +33,10 @@ template: templates/swagger.html
 
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/session.yaml",
+     url: "../restapis/session.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -51,7 +51,6 @@ window.onload = function() {
   })
   // End Swagger UI call region
   window.ui = ui
-}
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/fc9461875e367a944219)

--- a/en/docs/apis/tenant-management-rest-api.md
+++ b/en/docs/apis/tenant-management-rest-api.md
@@ -13,13 +13,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/tenant-management.yaml",
+     url: "../restapis/tenant-management.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -33,8 +32,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/collections/4b7454af08aaa3c5de3c)

--- a/en/docs/apis/totp-rest-api.md
+++ b/en/docs/apis/totp-rest-api.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
       
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/totp.yaml",
+     url: "../restapis/totp.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,6 +34,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/use-the-account-recovery-rest-apis.md
+++ b/en/docs/apis/use-the-account-recovery-rest-apis.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
 
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/scim2.yaml",
+     url: "../restapis/scim2.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,6 +34,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/use-the-authentication-rest-apis.md
+++ b/en/docs/apis/use-the-authentication-rest-apis.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/authentication.yaml",
+     url: "../restapis/authentication.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,6 +34,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>

--- a/en/docs/apis/use-the-openid-connect-dynamic-client-registration-rest-apis.md
+++ b/en/docs/apis/use-the-openid-connect-dynamic-client-registration-rest-apis.md
@@ -16,10 +16,10 @@ template: templates/swagger.html
     
 <div id="swagger-ui"></div>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/oauth-dcr.yaml",
+     url: "../restapis/oauth-dcr.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,
@@ -34,8 +34,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 

--- a/en/docs/apis/use-the-personal-information-export-rest-apis.md
+++ b/en/docs/apis/use-the-personal-information-export-rest-apis.md
@@ -4,7 +4,7 @@
 <script src="../../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
 <script src="../../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
     url: "https://github.com/wso2-extensions/identity-governance/blob/68e3f2d5e246b6a75f48e314ee1019230c662b55/components/org.wso2.carbon.identity.api.user.governance/src/main/resources/api.identity.user.yaml",
@@ -21,8 +21,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/collections/51139ad1cff6875115a1)

--- a/en/docs/apis/use-the-self-sign-up-rest-apis.md
+++ b/en/docs/apis/use-the-self-sign-up-rest-apis.md
@@ -4,10 +4,10 @@
 <script src="../../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
 <script src="../../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/api.identity.user.yaml",
+     url: "../restapis/api.identity.user.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -21,8 +21,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/collections/51139ad1cff6875115a1)

--- a/en/docs/apis/user-discoverable-applications.md
+++ b/en/docs/apis/user-discoverable-applications.md
@@ -13,13 +13,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/discoverable-application.yaml",
+     url: "../restapis/discoverable-application.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -33,8 +32,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/ebffbe675a969aafea00)

--- a/en/docs/apis/user-functionality-mgt-rest-api.md
+++ b/en/docs/apis/user-functionality-mgt-rest-api.md
@@ -13,13 +13,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/functionality.yaml",
+     url: "../restapis/functionality.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -33,8 +32,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.getpostman.com/collections/0375e453223080935e79)

--- a/en/docs/apis/userstore-rest-api.md
+++ b/en/docs/apis/userstore-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS.
 
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/userstore.yaml",
+     url: "../restapis/userstore.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,8 +33,7 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/60b25b1a87ea8779fc69)

--- a/en/docs/apis/workflow-engine-rest-api.md
+++ b/en/docs/apis/workflow-engine-rest-api.md
@@ -14,13 +14,12 @@ template: templates/swagger.html
     4. Add a `-k` header to the curl command and run the curl command on the terminal with a running instance of WSO2 IS. 
     
 <div id="swagger-ui"></div>
-<script src="../../assets/lib/swagger/swagger-ui-bundle.js"> </script>
-<script src="../../assets/lib/swagger/swagger-ui-standalone-preset.js"> </script>
+
 <script>
-window.onload = function() {
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../../restapis/workflow-engine.yaml",
+     url: "../restapis/workflow-engine.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
@@ -34,6 +33,5 @@ window.onload = function() {
   })
   // End Swagger UI call region
 
-  window.ui = ui
-}
+   window.ui = ui
 </script>


### PR DESCRIPTION
The window.onload method is not needed as the script cant execute unless the html is loaded. Each page doesn't need to reimport the swagger libs

## Purpose
> swagger.yaml files were not loading on the API pages
