### PR TITLE
Update x509certificate-authenticator.md

### DIFF
--- a/en/docs/learn/x509certificate-authenticator.md
+++ b/en/docs/learn/x509certificate-authenticator.md
@@ -4,7 +4,7 @@ This page provides instructions on how to configure the X509 certificate authent
 
 ## Working with certificates
 
-X509 authentication requires the client to possess a Public Key Certificate (PKC). 
+X509 authentication requires the client to possess a Public Key Certificate (PKC).
 
 ??? info "What is a Public Key Certificate (PKC) and Certificate Authority (CA)?"
     Public key cryptography relies on a public and private key pair to encrypt and decrypt the content. The keys are mathematically related, and content 
@@ -270,6 +270,12 @@ For more information on CRL and OCSP certificate validation, see
     enable=true
     AuthenticationEndpoint="https://localhost:8443/x509-certificate-servlet"
     username= "CN"
+    ```
+    
+    Please note: if you are going to access from a user from a secondary userstore, you will have to add this property:
+
+        ``` toml
+    SearchAllUserStores = true
     ```
 
     !!! note


### PR DESCRIPTION
## Purpose
Clarification about secondary user store users

## Goals
For the Doc to be more clear

Debugging the code inside the identity-outbound-auth-509 component, loging in from a secondary user store user, inside the X509CertificateUtil class you can see the if clause:

if (Boolean.valueOf(getX509Parameters().get(X509CertificateConstants.SEARCH_ALL_USERSTORES)))

Where searchAllUserstores should be true