### PR TITLE
Add correct sample request to Use Advanced Parameters in Authentication Requests flow

### DIFF
--- a/en/docs/guides/login/oidc-parameters-in-auth-request.md
+++ b/en/docs/guides/login/oidc-parameters-in-auth-request.md
@@ -167,7 +167,7 @@ Use the `prompt=login` parameter with the authentication request to force authen
 !!! abstract ""
     **Sample Request**
     ```
-    https://<host>:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&prompt=none&scope=openid
+    https://<host>:9443/oauth2/authorize?response_type=token&client_id=NgTICXFPYnt7ETUm6Fc8NMU8K38a&redirect_uri=http://localhost:8080/playground2/oauth2client&prompt=login&scope=openid
     ```
 
 If the user is successfully re-authenticated with WSO2 Identity Server, you will receive a successful response as follows.


### PR DESCRIPTION
## Purpose
> Replace existing sample request in prompt=login [section](https://is.docs.wso2.com/en/6.0.0/guides/login/oidc-parameters-in-auth-request/#promptlogin) with correct parameters. 

