### PR TITLE
Removing includes with image links

### DIFF
--- a/en/docs/deploy/configure-email-sending.md
+++ b/en/docs/deploy/configure-email-sending.md
@@ -156,6 +156,3 @@ Follow the steps given below to enable the email sender per tenant.
     
 5.	Since these configurations will be applicable during the tenant loading process, [configure tenant loading and 
 unloading for your tenant]({{base_path}}/guides/tenants/configure-the-tenant-loading-policy).
-
-<!-- !!! note
-    {!./includes/google-two-factor.md !}-->

--- a/en/docs/guides/access-delegation/auth-code-playground.md
+++ b/en/docs/guides/access-delegation/auth-code-playground.md
@@ -6,7 +6,37 @@ This page guides you through using a sample Playground application to try out au
 
 ## Set up the sample application
 
-{!./includes/oauth-playground.md!}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 

--- a/en/docs/guides/access-delegation/authorization-code-with-pkce.md
+++ b/en/docs/guides/access-delegation/authorization-code-with-pkce.md
@@ -14,9 +14,29 @@ to configure authentication for native mobile applications.
 
 ## Configure the service provider
 
-{!./includes/oauth-app-pkce.md!}
+Make the following changes to the created service provider.
 
-----
+1. Expand **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+2. Make sure **Code** is selected from the **Allowed Grant Types** list.
+        
+3. Enter the **Callback Url**.
+
+    !!! tip
+        The **Callback Url** is the exact location in the service provider's application to which an access token will 
+        be sent. This URL should be the URL of the page that the user is redirected to after successful authentication.
+
+4. Select **PKCE Mandatory** in order to enable PKCE. 
+
+    ![enable-pkce]({{base_path}}/assets/img/guides/enable-pkce.png)
+           
+5. Click **Add**. 
+
+    !!! note
+        - Note the generated **OAuth Client Key** and **OAuth Client Secret**. You will need these values later on when sending 
+        the requesting the code and the access token.
+        
+        - To configure more advanced configurations, see [OAuth/OpenID Connect Configurations]({{base_path}}/guides/login/oauth-app-config-advanced).
 
 ## Authorization code grant type
 

--- a/en/docs/guides/access-delegation/client-credentials-playground.md
+++ b/en/docs/guides/access-delegation/client-credentials-playground.md
@@ -6,7 +6,37 @@ This page guides you through using a sample Playground application to try out au
 
 ## Set up the sample application
 
-{!./includes/oauth-playground.md !}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 

--- a/en/docs/guides/access-delegation/implicit-playground.md
+++ b/en/docs/guides/access-delegation/implicit-playground.md
@@ -6,7 +6,37 @@ This page guides you through using a sample Playground application to try out au
 
 ## Set up the sample application
 
-{!./includes/oauth-playground.md !}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 

--- a/en/docs/guides/access-delegation/oidc-token-encryption-sample.md
+++ b/en/docs/guides/access-delegation/oidc-token-encryption-sample.md
@@ -4,7 +4,37 @@ This page guides you through configuring token encryption for ID tokens using th
 
 ## Set up the sample application
 
-{!./includes/oauth-playground.md!}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 
@@ -31,7 +61,72 @@ This page guides you through configuring token encryption for ID tokens using th
 
 -----
 
-{!./includes/encrypt-id-tokens.md!}
+## Configure the public certificate
+
+The following steps describe how to configure a service provider public certificate.
+
+1.  Create a new keystore.
+
+    ``` java
+    keytool -genkey -alias wso2carbon -keyalg RSA -keysize 2048 -keystore testkeystore.jks -dname "CN=*.test.com,OU=test,O=test,L=MPL,ST=MPL,C=FR" -storepass wso2carbon -keypass wso2carbon -validity 10950
+    ```
+
+2.  Create a file and name it as the client ID of the OAuth application service provider. Export the public key of the new keystore to the file you created.
+
+    ``` java
+    keytool -export -alias wso2carbon -file <client-id> -keystore testkeystore.jks
+    ```
+
+3.  Get the cert in X509 format.
+
+    ``` java
+    keytool -printcert -rfc -file <client-id>
+    ```
+
+    You will see the public certificate in X509 format in the console.
+    
+4. Copy the content of the certificate. A sample output is shown below. 
+
+    ``` java
+	-----BEGIN CERTIFICATE-----
+	MIIDVzCCAj+gAwIBAgIETCZA8zANBgkqhkiG9w0BAQsFADBcMQswCQYDVQQGEwJG
+	UjEMMAoGA1UECBMDTVBMMQwwCgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTAL
+	BgNVBAsTBHRlc3QxEzARBgNVBAMMCioudGVzdC5jb20wHhcNMTgwMjE0MDYzNjE3
+	WhcNNDgwMjA3MDYzNjE3WjBcMQswCQYDVQQGEwJGUjEMMAoGA1UECBMDTVBMMQww
+	CgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTALBgNVBAsTBHRlc3QxEzARBgNV
+	BAMMCioudGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCz
+	Gc/BcXCiIagLhXs1g90H+PbfZyXLzwFJ+YmsKMikcffhyopDD+fnFjHb1+XXSnUh
+	4XzQlFba6m2vIOK8uquMhZKMv/E7Vxkl/ADTuw/BgpZRut4p88Fn8OWZlrJfoi3o
+	hvgfxSMratvxLMp1Qe0BzjwoBDB9r+h9pj8kCpHC824eUGIR0FZsW9lnoJP2LegL
+	nAcOJuNBoeWC0wwNu0sgIJwjsKp3G3glm8B4GdZvbF8aW1QRAk36sh8+0GXrRnAz
+	aGcRAqt7CjeZmt5Dsuy0lfp5i1xf5myPOH7MwKHqQQ56Wu9O479NdDVLkJ0xne2r
+	ZTCwMeGhQQH5hI+SYlxjAgMBAAGjITAfMB0GA1UdDgQWBBTzS+bja//25xb+4wcP
+	gMN6cJZwoDANBgkqhkiG9w0BAQsFAAOCAQEAdhZ8romzQQKF9c8tJdIhUS4i7iJh
+	oSjBzN+Ex9+OJcW6ubcLb8pai/J3hcvMadAybR1A17FkETLFmG9HkuEN9o2jfU7c
+	9Yz5d0pqO8qNKXSqHky5c+zA4vzLZGsgKyDZ5a0p9Qpsat3wnA3UGZPRoVGV5153
+	Mb0J1n1uubxGobEEzR2BXaKO9YEWAMQwGRdQCGBaIeGUOpqSUJMLYirDXL03je3g
+	mYzWclLTEHpIYy+a66tmF9uTGgyys33LPm2pQ+kWd8FikWolKKBqp+IPU5QdUQi1
+	DdFHsyNqrnms6EOQAY57Vnf91RyS7lnO1T/lVR6SDk9+/KDBEL1b1cy7Dg==
+	-----END CERTIFICATE-----
+    ```
+
+4.  Click **Service Providers > List** and **Edit** the service provider you created. 
+
+5. Select **Upload SP Certificate** under  **Select SP Certificate Type**.
+
+6. Paste the certificate content copied in step 4 as the **Application Certificate**.
+
+    ![Upload SP certificate]({{base_path}}/assets/img/guides/upload-sp-cert.png)
+    
+    !!! note
+
+		Instead of uploading the service provider certificate as shown
+		above, you can choose to use the JWKS enpoint as shown below and
+		add the relevant JWKS URI.
+
+		![JWKS URI]({{base_path}}/assets/img/guides/jwks-uri.png)
+
+7. Click **Update**.
 
 ----
 

--- a/en/docs/guides/access-delegation/password-playground.md
+++ b/en/docs/guides/access-delegation/password-playground.md
@@ -4,7 +4,37 @@ This page guides you through using a sample Playground application to try out au
 
 ----
 
-{!./includes/oauth-playground.md !}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 

--- a/en/docs/guides/adaptive-auth/acr-based-adaptive-auth.md
+++ b/en/docs/guides/adaptive-auth/acr-based-adaptive-auth.md
@@ -8,7 +8,37 @@ Consider a scenario where you want users to be authenticated into an application
 
 ----
 
-{!./includes/oauth-playground.md !}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 

--- a/en/docs/guides/adaptive-auth/adaptive-auth-with-function-lib.md
+++ b/en/docs/guides/adaptive-auth/adaptive-auth-with-function-lib.md
@@ -18,7 +18,21 @@ This guide assumes you have your own application. If you wish to try out this fl
 
 ----
 
-{!./includes/add-function-library-lvl3.md!}
+## Add a function library
+
+Follow the steps below to add a function library using the WSO2 Identity Server Management Console.
+
+1. Access the Management Console (`https://<IS_HOST>:<PORT>/carbon`).
+
+2. Click **Manage** > **Function Libraries** >  **Add**.
+   
+    <img src="{{base_path}}/assets/img/guides/add-function-library.png" width="300" alt="Add function library option"/>
+   
+3. Fill in the **Function Library Name**, provide a brief **Description** and write the **Function Library Script** for the function library.
+
+    ![Add new function library]({{base_path}}/assets/img/guides/add-new-function-library.png)
+
+4. Click **Register** to add the new function library.
 
 ----
 

--- a/en/docs/guides/adaptive-auth/configure-adaptive-auth.md
+++ b/en/docs/guides/adaptive-auth/configure-adaptive-auth.md
@@ -28,7 +28,14 @@ Make the following changes to the created service provider.
 
 To add an authentication script to the service provider:
 
-{!./includes/add-adaptive-script.md!}
+1. On the Management Console, go to **Main > Identity > Service Providers**.
+2. Click **List**, select the service provider you want to configure, and click on the corresponding **Edit** link.
+3. Expand **Local and Outbound Authentication Configuration** and click
+    **Advanced Configuration**.  
+    ![Advanced Authentication Configuration](../../../../assets/img/fragments/advanced-authentication.png)
+
+4. You can add authentication steps or use a template to configure
+    adaptive authentication depending on your requirement.
 
     If required, you can also use the script editor to introduce new functions and fields to an authentication script based on your requirement, and then engage the script to the service provider’s authentication step configuration. 
 
@@ -67,7 +74,7 @@ To add an authentication script to the service provider:
     }
     ```
 
-3. Click **Update** to save changes.
+5. Click **Update** to save changes.
 
 !!! info "Related topics"
     - [Concept: Adaptive-Authentication]({{base_path}}/references/concepts/authentication/adaptive-authentication)

--- a/en/docs/guides/adaptive-auth/user-store-based-adaptive-auth.md
+++ b/en/docs/guides/adaptive-auth/user-store-based-adaptive-auth.md
@@ -79,7 +79,33 @@ To configure user store-based authentication:
 
 ----
 
-{!./includes/create-ldap-server.md!}
+## Create an LDAP Server
+
+1.  Open Apache Directory Studio.
+
+2.  On the **LDAP Servers** tab found on the bottom left corner,click **New Server**.  
+
+    ![new-server]({{base_path}}/assets/img/fragments/new-server.png)
+
+3.  Select **LDAP server ApacheDS 2.0.0** and click **Finish**.  
+
+    ![select-ldap-server]({{base_path}}/assets/img/fragments/select-ldap-server.png)
+
+4.  Right-click on the newly created server and click **Open Configuration**.
+
+    ![ldap-server-config]({{base_path}}/assets/img/fragments/ldap-server-config.png)
+
+5.  Port offset the LDAP and LDAP server ports by changing the LDAP port to 10390 and the LDAP server port to 10637. This ensures that the embedded LDAP server running in the prior installation of WSO2 IS does not conflict with the current installation.
+
+    ![ldap-port-offset]({{base_path}}/assets/img/fragments/ldap-port-offset.png)
+
+6.  Right-click on the new server and click **Create a Connection**.  
+
+    ![create-an-ldap-connection]({{base_path}}/assets/img/fragments/create-ldap-connection.png)
+
+7.  Right-click on the server and click **Run** to start the server.
+
+    ![run-ldap-server]({{base_path}}/assets/img/fragments/run-ldap-server.png) 
 
 ----
 

--- a/en/docs/guides/adaptive-auth/work-with-acr-amr.md
+++ b/en/docs/guides/adaptive-auth/work-with-acr-amr.md
@@ -24,9 +24,14 @@ This guide assumes you have your own application. If you wish to try out this fl
 
 ## Add the adaptive authentication script
 
-{!./includes/add-adaptive-acr-script-portal.md!}
+1.	**Edit** the same service provider you created previously to configure the **ACR-Based** authentication flow.
+    
+2.	Expand **Local and Outbound Configuration** and click **Advanced Configuration**.
+   
+3.	Click on **Templates** on the right side of the **Script Based Conditional Authentication** field and then click **ACR-Based**.  
+    ![acr-based-template-config]({{base_path}}/assets/img/fragments/acr-based-template-config.png)
 
-1.  Replace the authentication script added from the template with the following. 
+4.  Replace the authentication script added from the template with the following. 
 
     ```
     var supportedAcrValues = ['LOA1', 'LOA2', 'LOA3'];

--- a/en/docs/guides/identity-federation/configure-shibboleth-idp-as-a-trusted-identity-provider.md
+++ b/en/docs/guides/identity-federation/configure-shibboleth-idp-as-a-trusted-identity-provider.md
@@ -398,7 +398,74 @@ To configure the service provider, do the following.
 
 {!./includes/deploy-travelocity.md !}
 
-{!./includes/deploy-travelocity-sp.md !}
+### Configure the service provider
+
+!!! note "Important"
+
+    SAML2 POST Binding requires CORS configurations. Before configuring the service provider, add the following configurations to the `<IS_HOME>/repository/conf/deployment.toml` file to allow HTTP POST requests. 
+
+    ```toml
+    [cors]
+    allow_generic_http_requests = true
+    allow_any_origin = false
+    allowed_origins = [
+        "http://localhost:8080"
+    ]
+    allow_subdomains = false
+    supported_methods = [
+        "GET",
+        "POST",
+        "HEAD",
+        "OPTIONS"
+    ]
+    support_any_header = true
+    supported_headers = []
+    exposed_headers = []
+    supports_credentials = true
+    max_age = 3600
+    tag_requests = false
+    ```
+
+The next step is to configure the service provider.
+
+1.  Return to the WSO2 IS management console.
+
+2.  Navigate to **Main**>**Identity**>**Service Providers** and click **Add**.
+
+3.  Enter **travelocity.com** in the **Service Provider Name** text box,
+    and click **Register**.
+
+4.  In the **Inbound Authentication Configuration** section, click
+    **Configure** under the **SAML2 Web SSO Configuration** section.
+
+    1.  Now set the configurations as follows:
+
+        1.  **Issuer** : `               travelocity.com              `
+
+        2.  **Assertion Consumer URL** :
+            `                               http://wso2is.local:8080/travelocity.com/home.jsp                        `  
+            Click Yes, in the message that appears.
+
+    2.  Select the following check-boxes:
+        1.  **Enable Response Signing**
+
+        2.  **Enable Single Logout**
+
+        3.  **Enable Attribute Profile**
+
+        4.  **Include Attributes in the Response Always**  
+        
+        5.  **Enable Signature Validation in Authentication Requests and Logout Requests**
+            
+
+    ![edit-service-provider]({{base_path}}/assets/img/fragments/edit-service-provider-configs.png)
+    
+    !!! tip
+        For more information on the advanced configurations
+        see, [Configuring SAML2 WEB Single-Sign-On]({{base_path}}/guides/identity-federation/configure-saml-2.0-web-sso).
+
+5.  Click **Register** to save the changes.  
+    Now you are sent back to the Service Providers page.
 
 6.  Expand the **Local and Inbound Authentication** section and do one of the following configurations.
     1.  Configure Shibboleth as a **Federated Authentication** mechanism

--- a/en/docs/guides/identity-federation/facebook.md
+++ b/en/docs/guides/identity-federation/facebook.md
@@ -53,7 +53,21 @@ Follow the steps given below to configure WSO2 Identity Server to authenticate u
 
 Now you have finished configuring Facebook as an Identity Provider.
 
-{!./includes/fb-review.md !}
+!!!	info "About accessing the app"
+	The app is not available to the general public yet. To make the app available
+	to every Facebook user, you have to submit the app for review. After a
+	review, Facebook makes the app available to every Facebook user. You can
+	find more information on the review process by clicking on **App
+	Review** in the left navigation menu of your app's dashboard.
+
+	The review process may take some time, so for the purposes of this
+	sample, you can specify some Facebook users as Developers or Testers.
+	Only the users specified here can use this app to log in with Facebook
+	until the app goes public. To do this, click on **Roles** in the left
+	navigation menu of the dashboard and specify the required Facebook users
+	as Developers or Testers.
+	
+	![submit-fb-app-for-review]({{base_path}}/assets/img/samples/add-app-roles.png)
 
 ---
 

--- a/en/docs/guides/identity-lifecycles/admin-creation-workflow.md
+++ b/en/docs/guides/identity-lifecycles/admin-creation-workflow.md
@@ -4,7 +4,13 @@ Administrators can add new users in a tenant by manually registering the user de
 
 ## Use the management console
 
-{!./includes/add-new-user.md !}
+1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
+
+2. Navigate to **Main** > **Identity** > **Users and Roles** > **Add**.
+
+3.  Click **Add New User**.
+
+    ![add-a-new-user]({{base_path}}/assets/img/fragments/add-a-new-user.png)
 
 3. In the **Domain** list, select the user store in which you want to create this user account (e.g., `Primary`). This list includes the user stores you have configured. 
 

--- a/en/docs/guides/identity-lifecycles/configure-recaptcha-for-self-registration.md
+++ b/en/docs/guides/identity-lifecycles/configure-recaptcha-for-self-registration.md
@@ -18,7 +18,29 @@ brute force attacks.
 
 ---
 
-{!./includes/configure-recaptcha-api-keys.md !}
+## Configure reCAPTCHA API keys
+
+[reCAPTCHA](https://developers.google.com/recaptcha/) is a free widget service provided by Google that can be used for protection against spam or other forms of internet abuse by verifying whether a user is a human or a robot. The following section guides you through setting up reCAPTCHA with WSO2 Identity Server.
+
+First, you need to register and create an API key pair for the required domain. The key pair consists of a site key and secret. The site key is used when a reCAPTCHA widget is displayed on a page. After verification, a new parameter called g-recaptcha-response appears on the form which the user submits. From the server side, you can verify the submitted captcha response by calling the Google API with the secret key.
+
+1.  Go to <https://www.google.com/recaptcha/admin>.
+
+2.  Fill in the fields to register
+    your identity server domain and click **Register**. The following
+    are sample values:
+    -   **Label:** WSO2 Identity Server
+    -   Select the reCAPTCHA V2 option.
+    -   **Domains:** is.wso2.com  
+
+3.	Accept the terms of service. 
+
+4.  Click **Submit**.
+
+    ![configuring-recaptcha-api-keys]({{base_path}}/assets/img/fragments/recaptcha-new-sso.png) 
+
+5.  Take note of the site key and secret that you receive.
+    ![note-site-key-secret]({{base_path}}/assets/img/fragments/copy-key.png) 
 
 ---
 

--- a/en/docs/guides/identity-lifecycles/enable-email-as-username.md
+++ b/en/docs/guides/identity-lifecycles/enable-email-as-username.md
@@ -1,3 +1,125 @@
 ## Configure Email Address as the Username
 
-{!./includes/enable-email-as-username.md!}
+!!! warning
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. Therefore,
+    **make sure to configure it before you begin working with WSO2 IS**.
+    
+
+1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+   
+2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
+
+    ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
+    
+3. Click **Update** to save the changes.
+
+4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+
+5.  Add the following configuration to enable email authentication.
+
+    ``` toml
+    [tenant_mgt]
+    enable_email_domain= true
+    ```
+    
+6. Configure the following set of parameters in the userstore
+    configuration, depending on the type of userstore you are connected
+    to (LDAP/Active Directory/ JDBC).
+    <table>
+    <thead>
+    <tr class="header">
+    <th>Parameter</th>
+    <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="odd">
+    <td><p><code>                UserNameAttribute               </code></p>
+    <p><br />
+    </p></td>
+    <td><div class="content-wrapper">
+    <p>Set the mail attribute of the user. <strong>LDAP/Active Directory only</strong></p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>user_name_attribute = &quot;mail&quot;</code></pre>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UserNameSearchFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user instead of <code>                 cn                </code> or <code>                 uid                </code> . <strong>LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=person)(mail=?))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=user)(mail=?))"`</pre></code>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>               UserNameListFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user if <strong>necessary. LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=person)(!(sn=Service)))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=user)(!(sn=Service)))"`</code>
+    </pre>
+    <div class="admonition tip">
+    <p class="admonition-title">Tip</p>
+    <p>If you are trying with the default embedded LDAP userstore, this configuration change is not needed.</p>
+    </div> 
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><div class="content-wrapper">
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>          UsernameJavaRegEx           </code></td>
+    <td><div class="content-wrapper">
+    <p>This is a regular expression to validate usernames. By default, strings have a length of 5 to 30. Only non-empty characters are allowed. You can provide ranges of alphabets, numbers and also ranges of ASCII values in the RegEx properties.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}&apos;</code></pre></div>
+    </div>
+    </div>
+    </td>
+    </tr>
+    <tr class="even">
+    <td>Realm configurations</td>
+    <td><div class="content-wrapper">
+    <p>The username must use the email attribute of the admin user.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[super_admin]<br>username = &quot;admin@wso2.com&quot;<br>password = &quot;admin&quot;</code></pre>
+    </div>
+    </div>
+    <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
+    <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+
+    !!! info 
+        - With these configuration users can log in to super tenant with both
+        email username (**`alex@gmail.com`**) or
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
+        ***@carbon.super*** at the end of usernames.
+
+7.  Restart the server.

--- a/en/docs/guides/identity-lifecycles/invitation-workflow.md
+++ b/en/docs/guides/identity-lifecycles/invitation-workflow.md
@@ -135,7 +135,13 @@ true in the SCIM2 user create request.
 
 Follow the steps below to test the account creation using the password option.
 
-{!./includes/add-new-user.md !}
+1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
+
+2. Navigate to **Main** > **Identity** > **Users and Roles** > **Add**.
+
+3.  Click **Add New User**.
+
+    ![add-a-new-user]({{base_path}}/assets/img/fragments/add-a-new-user.png)
 
 4.  Fill in the form:
 

--- a/en/docs/guides/identity-lifecycles/lock-account.md
+++ b/en/docs/guides/identity-lifecycles/lock-account.md
@@ -9,7 +9,57 @@ Account locking and account disabling are security features in WSO2 Identity Ser
 If you have not already configured WSO2 identity Server (WSO2 IS) for
 account locking, follow the instructions given below.
 
-{!./includes/enable-account-locking.md !}
+1. 	Ensure that the identity listener with the
+   `              priority=50             ` is set to **false** and
+   the identity listener with the `              priority=95             ` is set to
+   **true**  by adding the following configuration to the
+   `              <IS_HOME>/repository/conf/deployment.toml             ` file.  
+
+	!!! note
+		If you haven't changed these configurations previously, you can skip this step since these are the default values. 
+
+		``` xml
+		[event.default_listener.identity_mgt]
+		priority= "50"
+		enable = false
+		[event.default_listener.governance_identity_mgt]
+		priority= "95"
+		enable = true
+		```
+
+
+2.  <a name="lockingaspecificuseraccount"></a>Start the Identity Server and log into the management console (`https://<IS_HOST>:<PORT>/carbon`) using
+   your tenant credentials.
+      
+3.  Click **Main** > **Identity** > **Identity Providers** > **Resident**.
+4.  Expand the **Login Attempts Security** tab.
+5.  Expand the **Account Lock** tab and select the **Lock user accounts** checkbox. Click **Update** to save changes.  
+	
+	![login-policies]({{base_path}}/assets/img/guides/login-policies.png) 
+
+	!!! tip
+		If a user is assigned the **Internal/system** role, the user can
+		bypass account locking even if the user exceeds the specified number
+		of **Maximum failed login attempts**.
+   
+		!!! note
+			 WSO2 Identity Server has the **Internal/ki8system** role configured by
+			default. However, generally a new user is not assigned the
+			**Internal/system** role by default. Required roles can be assigned
+			to a user depending on the set of permission a user needs to have.
+			For more information on roles and permission, see [Configuring Roles
+			and
+			Permissions]({{base_path}}/guides/identity-lifecycles/manage-roles-overview/)
+
+			 Although the **Internal/system** role is configured by default in
+			WSO2 Identity Server, you can delete the role if necessary. To allow
+			users with the **Internal/system** role to bypass account locking,
+			you need to ensure that the role exists in WSO2 Identity Server.
+         
+         
+6.  To enable account locking for other tenants, log out and repeat the
+   steps given above from [step 2](#lockingaspecificuseraccount)
+   onwards.
     
 ---
 

--- a/en/docs/guides/identity-lifecycles/lock-accounts-by-failed-login-attempts.md
+++ b/en/docs/guides/identity-lifecycles/lock-accounts-by-failed-login-attempts.md
@@ -9,7 +9,57 @@ disabling. The following section explain how to configure this.
 
 ## Configure WSO2 IS for account locking
 
-{!./includes/enable-account-locking.md !}
+1. 	Ensure that the identity listener with the
+   `              priority=50             ` is set to **false** and
+   the identity listener with the `              priority=95             ` is set to
+   **true**  by adding the following configuration to the
+   `              <IS_HOME>/repository/conf/deployment.toml             ` file.  
+
+	!!! note
+		If you haven't changed these configurations previously, you can skip this step since these are the default values. 
+
+		``` xml
+		[event.default_listener.identity_mgt]
+		priority= "50"
+		enable = false
+		[event.default_listener.governance_identity_mgt]
+		priority= "95"
+		enable = true
+		```
+
+
+2.  <a name="lockingaspecificuseraccount"></a>Start the Identity Server and log into the management console (`https://<IS_HOST>:<PORT>/carbon`) using
+   your tenant credentials.
+      
+3.  Click **Main** > **Identity** > **Identity Providers** > **Resident**.
+4.  Expand the **Login Attempts Security** tab.
+5.  Expand the **Account Lock** tab and select the **Lock user accounts** checkbox. Click **Update** to save changes.  
+	
+	![login-policies]({{base_path}}/assets/img/guides/login-policies.png) 
+
+	!!! tip
+		If a user is assigned the **Internal/system** role, the user can
+		bypass account locking even if the user exceeds the specified number
+		of **Maximum failed login attempts**.
+   
+		!!! note
+			WSO2 Identity Server has the **Internal/ki8system** role configured by
+			default. However, generally a new user is not assigned the
+			**Internal/system** role by default. Required roles can be assigned
+			to a user depending on the set of permission a user needs to have.
+			For more information on roles and permission, see [Configuring Roles
+			and
+			Permissions]({{base_path}}/guides/identity-lifecycles/manage-roles-overview/)
+
+			Although the **Internal/system** role is configured by default in
+			WSO2 Identity Server, you can delete the role if necessary. To allow
+			users with the **Internal/system** role to bypass account locking,
+			you need to ensure that the role exists in WSO2 Identity Server.
+         
+         
+6.  To enable account locking for other tenants, log out and repeat the
+   steps given above from [step 2](#lockingaspecificuseraccount)
+   onwards.
 
 The following table describes the configuration properties and
 descriptions you need to configure:

--- a/en/docs/guides/identity-lifecycles/manage-user-attributes.md
+++ b/en/docs/guides/identity-lifecycles/manage-user-attributes.md
@@ -11,12 +11,55 @@ There two main ways to view, add, edit, and delete attributes of a user.
 
 ## Claim mapping when using multiple user stores
 
-{!./includes/attribute-mapping.md !}
+When you are using more than one user store, you must map the attributes
+correctly by [adding a claim mapping](../../../../guides/dialects/add-claim-mapping/.
 
+Under “Mapped Attribute(s)”, you need to follow the pattern.
+
+![mapped-attributes]({{base_path}}/assets/img/fragments/mapped-attributes.png)
+
+However, for the default user store, you do not need to provide the
+domain name. As an example, if you have two user stores, one is the
+default and another one with domain “DEMO” then the pattern would be as
+follows for `http://wso2.org/claims/emailaddress`.
+
+``` java
+DEMO/mail
+```
 
 ### Attributes with multiple values
 
-{!./includes/attributes-with-multiple-values.md !}
+If your user store supports multiple values for attributes, the
+WSO2 Identity Server can view, add, update, or delete them (normally
+LDAP/AD offer support for this). The following are the different ways
+you can do this.
+
+1.  In WSO2 Identity Server Management Console, multiple attribute values are separated by commas. If you want to update two email addresses
+    using the user profile UI, you must provide it as follows:
+
+    ``` java
+    asela@soasecurity.com,aselapathberiya@soasecurity.com
+    ```
+
+    See the following screen for how this will look in the user
+    interface of the Identity Server Management Console.  
+    ![is-user-interface]({{base_path}}/assets/img/fragments/is-user-interface.png)
+
+2.  When using the `RemoteUserStoreManagerService` API, call it as follows.
+
+    ``` java
+    setUserClaimValue("username", "http://wso2.org/claims/emailaddress", "asela@soasecurity.org,aselapathberiya@gmail.com", null)
+    ```
+
+    The GET results are returned in the form of comma separated values
+    for the attribute.
+
+    ``` java
+    "asela@soasecurity.org,aselapathberiya@gmail.com"
+    ```
+
+    The following screen shows how this looks in the LDAP.  
+    ![ldap-interface]({{base_path}}/assets/img/fragments/ldap-interface.png)
 
 ## Write custom attributes
 

--- a/en/docs/guides/identity-lifecycles/outbound-provisioning-with-google.md
+++ b/en/docs/guides/identity-lifecycles/outbound-provisioning-with-google.md
@@ -269,7 +269,25 @@ Provider.
 
 ## Configure WSO2 IS as the resident service provider
 
-{!./includes/resident-sp.md !}
+1.  In the **Main** menu under the **Identity** section, click
+    **Resident** under **Service Providers**.
+2.  Expand the **Outbound Provisioning Configuration** on the screen
+    that appears.
+3.  Select the Google identity provider you configured from the drop
+    down and click the
+    ![outbound-provisioning-icon]({{base_path}}/assets/img/guides/outbound-provisioning-icon.png) button.
+
+    !!! info
+        If you enable **Blocking**, Identity Server will wait for the
+        response from the Identity Provider to continue.
+
+        If you enable **Enable Rules** and **Blocking,** blocking will block
+        the provisioning till the rule completely evaluates and get the
+        response back to the WSO2 IdP. Afterwards, you need to enable the
+        XACML policy. For more information, see [Rule-Based
+        Provisioning]({{base_path}}/guides/identity-lifecycles/rule-based-provisioning/)
+
+4.  Click **Update**.
 
 ---
 

--- a/en/docs/guides/identity-lifecycles/outbound-provisioning-with-salesforce.md
+++ b/en/docs/guides/identity-lifecycles/outbound-provisioning-with-salesforce.md
@@ -172,7 +172,129 @@ new users.
 
 When you log into Salesforce, you normally use an email address. So, to integrate this with the Identity Server, you need to configure WSO2 IS to enable users to log in using their email addresses. In order to do that, follow the steps given below.
 
-{!./includes/enable-email-as-username.md !}
+!!! warning
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. Therefore,
+    **make sure to configure it before you begin working with WSO2 IS**.
+    
+
+1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+   
+2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
+
+    ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
+    
+3. Click **Update** to save the changes.
+
+4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+
+5.  Add the following configuration to enable email authentication.
+
+    ``` toml
+    [tenant_mgt]
+    enable_email_domain= true
+    ```
+    
+6. Configure the following set of parameters in the userstore
+    configuration, depending on the type of userstore you are connected
+    to (LDAP/Active Directory/ JDBC).
+    <table>
+    <thead>
+    <tr class="header">
+    <th>Parameter</th>
+    <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="odd">
+    <td><p><code>                UserNameAttribute               </code></p>
+    <p><br />
+    </p></td>
+    <td><div class="content-wrapper">
+    <p>Set the mail attribute of the user. <strong>LDAP/Active Directory only</strong></p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>user_name_attribute = &quot;mail&quot;</code></pre>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UserNameSearchFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user instead of <code>                 cn                </code> or <code>                 uid                </code> . <strong>LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=person)(mail=?))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=user)(mail=?))"`</pre></code>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>               UserNameListFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user if <strong>necessary. LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=person)(!(sn=Service)))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=user)(!(sn=Service)))"`</code>
+    </pre>
+    <div class="admonition tip">
+    <p class="admonition-title">Tip</p>
+    <p>If you are trying with the default embedded LDAP userstore, this configuration change is not needed.</p>
+    </div> 
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><div class="content-wrapper">
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>          UsernameJavaRegEx           </code></td>
+    <td><div class="content-wrapper">
+    <p>This is a regular expression to validate usernames. By default, strings have a length of 5 to 30. Only non-empty characters are allowed. You can provide ranges of alphabets, numbers and also ranges of ASCII values in the RegEx properties.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}&apos;</code></pre></div>
+    </div>
+    </div>
+    </td>
+    </tr>
+    <tr class="even">
+    <td>Realm configurations</td>
+    <td><div class="content-wrapper">
+    <p>The username must use the email attribute of the admin user.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[super_admin]<br>username = &quot;admin@wso2.com&quot;<br>password = &quot;admin&quot;</code></pre>
+    </div>
+    </div>
+    <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
+    <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+
+    !!! info 
+        - With these configuration users can log in to super tenant with both
+        email username (**`alex@gmail.com`**) or
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
+        ***@carbon.super*** at the end of usernames.
+
+7.  Restart the server.
 
 ---
 

--- a/en/docs/guides/login/client-side-app.md
+++ b/en/docs/guides/login/client-side-app.md
@@ -14,9 +14,29 @@ grant type with PKCE for client side applications (e.g.,mobile application , sin
 
 ## Configure the service provider
 
-{!./includes/oauth-app-pkce.md!}
+Make the following changes to the created service provider.
 
-----
+1. Expand **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+2. Make sure **Code** is selected from the **Allowed Grant Types** list.
+        
+3. Enter the **Callback Url**.
+
+    !!! tip
+        The **Callback Url** is the exact location in the service provider's application to which an access token will 
+        be sent. This URL should be the URL of the page that the user is redirected to after successful authentication.
+
+4. Select **PKCE Mandatory** in order to enable PKCE. 
+
+    ![enable-pkce]({{base_path}}/assets/img/guides/enable-pkce.png)
+           
+5. Click **Add**. 
+
+    !!! note
+        - Note the generated **OAuth Client Key** and **OAuth Client Secret**. You will need these values later on when sending 
+        the requesting the code and the access token.
+        
+        - To configure more advanced configurations, see [OAuth/OpenID Connect Configurations]({{base_path}}/guides/login/oauth-app-config-advanced).
 
 ## Try it
 

--- a/en/docs/guides/login/configure-recaptcha-for-single-sign-on.md
+++ b/en/docs/guides/login/configure-recaptcha-for-single-sign-on.md
@@ -10,7 +10,29 @@ attacks.
     -   For more information on brute force attacks, see [Mitigating Brute
     Force Attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-brute-force-attacks/).
 
-{!./includes/configure-recaptcha-api-keys.md !}
+## Configure reCAPTCHA API keys
+
+[reCAPTCHA](https://developers.google.com/recaptcha/) is a free widget service provided by Google that can be used for protection against spam or other forms of internet abuse by verifying whether a user is a human or a robot. The following section guides you through setting up reCAPTCHA with WSO2 Identity Server.
+
+First, you need to register and create an API key pair for the required domain. The key pair consists of a site key and secret. The site key is used when a reCAPTCHA widget is displayed on a page. After verification, a new parameter called g-recaptcha-response appears on the form which the user submits. From the server side, you can verify the submitted captcha response by calling the Google API with the secret key.
+
+1.  Go to <https://www.google.com/recaptcha/admin>.
+
+2.  Fill in the fields to register
+    your identity server domain and click **Register**. The following
+    are sample values:
+    -   **Label:** WSO2 Identity Server
+    -   Select the reCAPTCHA V2 option.
+    -   **Domains:** is.wso2.com  
+
+3.	Accept the terms of service. 
+
+4.  Click **Submit**.
+
+    ![configuring-recaptcha-api-keys]({{base_path}}/assets/img/fragments/recaptcha-new-sso.png) 
+
+5.  Take note of the site key and secret that you receive.
+    ![note-site-key-secret]({{base_path}}/assets/img/fragments/copy-key.png) 
 
 
 ---
@@ -19,7 +41,39 @@ attacks.
 
 ## Configure reCAPTCHA for SSO
 
-{!./includes/configure-recaptcha-for-sso.md !}
+1. Log in to the management console  (`https://<IS_HOST>:<IS_PORT>/carbon`).
+
+2. Click **Main** > **Identity** > **Identity Providers** > **Resident**.
+
+3. Expand the **Login Attempts Security** tab. Then, expand the **reCaptcha for SSO Login** tab.
+
+4. Select the relevant option according to your requirement:
+
+    - **Always prompt reCaptcha:** 
+
+        Select this option to prompt users for reCaptcha with every SSO login attempt. 
+
+    - **Prompt reCaptcha after max failed attempts:** 
+    
+        Select this option to prompt reCAPTCHA only after the number of max failed attempts exceed. 
+    
+        If you select this option, enter a value for the **Max failed attempts for reCaptcha** field as well. For example, if you enter 3, reCaptcha will be re-enabled after 3 failed attempts.  
+        
+        ![configure-captcha-for-sso]({{base_path}}/assets/img/guides/recaptcha-sso.png)
+        
+        Note the following when selecting this option:
+        
+        - Account locking must be enabled to enable **Prompt reCaptcha after max failed attempts**.
+
+        - The **Max failed attempts for reCaptcha** value must be lower than the **Maximum failed login attempts** value configured under the **Account Lock** tab.
+    
+          ![configure-account-locking]({{base_path}}/assets/img/guides/configure-account-locking.png)
+    
+5.  You have now successfully configured reCAPTCHA for the single sign
+    on flow. If the number of failed attempts reaches the maximum
+    configured value, the following reCAPTCHA window appears.  
+
+    ![captcha-login-failed]({{base_path}}/assets/img/guides/captcha-login-failed.png)
 
 !!! Info
      If the user exceeds the maximum allowed failed login attempts as well, be sure to [configure email notifications for account locking]({{base_path}}/guides/tenants/email-account-locking).

--- a/en/docs/guides/login/log-into-google-using-is.md
+++ b/en/docs/guides/login/log-into-google-using-is.md
@@ -61,7 +61,129 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 
 ## Configure Email Address as the Username
 
-{!./includes/enable-email-as-username.md!}
+!!! warning
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. Therefore,
+    **make sure to configure it before you begin working with WSO2 IS**.
+    
+
+1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+   
+2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
+
+    ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
+    
+3. Click **Update** to save the changes.
+
+4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+
+5.  Add the following configuration to enable email authentication.
+
+    ``` toml
+    [tenant_mgt]
+    enable_email_domain= true
+    ```
+    
+6. Configure the following set of parameters in the userstore
+    configuration, depending on the type of userstore you are connected
+    to (LDAP/Active Directory/ JDBC).
+    <table>
+    <thead>
+    <tr class="header">
+    <th>Parameter</th>
+    <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="odd">
+    <td><p><code>                UserNameAttribute               </code></p>
+    <p><br />
+    </p></td>
+    <td><div class="content-wrapper">
+    <p>Set the mail attribute of the user. <strong>LDAP/Active Directory only</strong></p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>user_name_attribute = &quot;mail&quot;</code></pre>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UserNameSearchFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user instead of <code>                 cn                </code> or <code>                 uid                </code> . <strong>LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=person)(mail=?))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=user)(mail=?))"`</pre></code>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>               UserNameListFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user if <strong>necessary. LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=person)(!(sn=Service)))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=user)(!(sn=Service)))"`</code>
+    </pre>
+    <div class="admonition tip">
+    <p class="admonition-title">Tip</p>
+    <p>If you are trying with the default embedded LDAP userstore, this configuration change is not needed.</p>
+    </div> 
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><div class="content-wrapper">
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>          UsernameJavaRegEx           </code></td>
+    <td><div class="content-wrapper">
+    <p>This is a regular expression to validate usernames. By default, strings have a length of 5 to 30. Only non-empty characters are allowed. You can provide ranges of alphabets, numbers and also ranges of ASCII values in the RegEx properties.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}&apos;</code></pre></div>
+    </div>
+    </div>
+    </td>
+    </tr>
+    <tr class="even">
+    <td>Realm configurations</td>
+    <td><div class="content-wrapper">
+    <p>The username must use the email attribute of the admin user.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[super_admin]<br>username = &quot;admin@wso2.com&quot;<br>password = &quot;admin&quot;</code></pre>
+    </div>
+    </div>
+    <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
+    <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+
+    !!! info 
+        - With these configuration users can log in to super tenant with both
+        email username (**`alex@gmail.com`**) or
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
+        ***@carbon.super*** at the end of usernames.
+
+7.  Restart the server.
 
 -----
 

--- a/en/docs/guides/login/log-into-salesforce-using-is.md
+++ b/en/docs/guides/login/log-into-salesforce-using-is.md
@@ -166,7 +166,129 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
 
 ## Configure Email Address as the Username
 
-{!./includes/enable-email-as-username.md!}
+!!! warning
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. Therefore,
+    **make sure to configure it before you begin working with WSO2 IS**.
+    
+
+1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+   
+2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
+
+    ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
+    
+3. Click **Update** to save the changes.
+
+4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+
+5.  Add the following configuration to enable email authentication.
+
+    ``` toml
+    [tenant_mgt]
+    enable_email_domain= true
+    ```
+    
+6. Configure the following set of parameters in the userstore
+    configuration, depending on the type of userstore you are connected
+    to (LDAP/Active Directory/ JDBC).
+    <table>
+    <thead>
+    <tr class="header">
+    <th>Parameter</th>
+    <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="odd">
+    <td><p><code>                UserNameAttribute               </code></p>
+    <p><br />
+    </p></td>
+    <td><div class="content-wrapper">
+    <p>Set the mail attribute of the user. <strong>LDAP/Active Directory only</strong></p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>user_name_attribute = &quot;mail&quot;</code></pre>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UserNameSearchFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user instead of <code>                 cn                </code> or <code>                 uid                </code> . <strong>LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=person)(mail=?))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_search_filter = `"(&amp;(objectClass=user)(mail=?))"`</pre></code>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>               UserNameListFilter              </code></td>
+    <td><div class="content-wrapper">
+    <p>Use the mail attribute of the user if <strong>necessary. LDAP/Active Directory only</strong> <br/>For example:</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"> In LDAP,<code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=person)(!(sn=Service)))"`</code> <br> In Active Directory, <code>[user_store]<br>user_name_list_filter = `"(&amp;(objectClass=user)(!(sn=Service)))"`</code>
+    </pre>
+    <div class="admonition tip">
+    <p class="admonition-title">Tip</p>
+    <p>If you are trying with the default embedded LDAP userstore, this configuration change is not needed.</p>
+    </div> 
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="even">
+    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><div class="content-wrapper">
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    </div>
+    </div>
+    </div></td>
+    </tr>
+    <tr class="odd">
+    <td><code>          UsernameJavaRegEx           </code></td>
+    <td><div class="content-wrapper">
+    <p>This is a regular expression to validate usernames. By default, strings have a length of 5 to 30. Only non-empty characters are allowed. You can provide ranges of alphabets, numbers and also ranges of ASCII values in the RegEx properties.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}&apos;</code></pre></div>
+    </div>
+    </div>
+    </td>
+    </tr>
+    <tr class="even">
+    <td>Realm configurations</td>
+    <td><div class="content-wrapper">
+    <p>The username must use the email attribute of the admin user.</p>
+    <div class="code panel pdl" style="border-width: 1px;">
+    <div class="codeContent panelContent pdl">
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[super_admin]<br>username = &quot;admin@wso2.com&quot;<br>password = &quot;admin&quot;</code></pre>
+    </div>
+    </div>
+    <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
+    <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+
+    !!! info 
+        - With these configuration users can log in to super tenant with both
+        email username (**`alex@gmail.com`**) or
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
+        ***@carbon.super*** at the end of usernames.
+
+7.  Restart the server.
 
 -----
 

--- a/en/docs/guides/login/log-into-simplesaml-using-is.md
+++ b/en/docs/guides/login/log-into-simplesaml-using-is.md
@@ -166,14 +166,33 @@ This page guides you through using WSO2 Identity Server to log in to SimpleSAMLp
 
 {!./includes/register-a-service-provider.md !}
 
+1.	Expand **Inbound Authentication Configuration > SAML Configuration** and click **Configure**.
 
-{!./includes/simplesaml-config-sample.md !}
+2.	Enter the following details and keep the values of the rest of the fields as it is. 
+
+	-	**Issuer**:simplesaml
+
+    -	**Assertion Consumer URL**:
+    	http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/wso2-sp
+
+    -	**Enable Single Logout**: True
+
+    -	**SLO Response URL**:
+    	http://localhost/simplesamlphp/www/module.php/saml/sp/saml2-logout.php/wso2-sp
+
+3.	Click **Register**
+
+    ![simplesamlphp-sp.png]({{base_path}}/assets/img/fragments/simplesamlphp-sp.png)
 
 ## Configure a resident identity provider in WSO2 IS
 
-{!./includes/resident-saml-sample.md !}
+1.	In the **Main** menu of the Management Console (`https://<IS_HOST>:<PORT>/carbon`), click **Resident** under **Identity Providers**.
 
------
+2.	On the page that appears, open the **SAML2 Web SSO Configuration** section under **Inbound Authentication Configuration**.
+    
+3.	Make the value of the **Identity Provider Entity ID** field as same as the SAML endpoint of WSO2 Identity Server: `https://{yourhost}:{port}/samlsso`		
+	
+	![simeplesamlphp-resident]({{base_path}}/assets/img/fragments/simplesamlphp-resident.png)
 
 ### Test SimpleSAMLphp
 

--- a/en/docs/guides/login/oidc-request-object.md
+++ b/en/docs/guides/login/oidc-request-object.md
@@ -9,7 +9,72 @@ If you want to pass any sensitive parameter with the authentication request whic
 
 ----
 
-{!./includes/encrypt-id-tokens.md!}
+## Configure the public certificate
+
+The following steps describe how to configure a service provider public certificate.
+
+1.  Create a new keystore.
+
+    ``` java
+    keytool -genkey -alias wso2carbon -keyalg RSA -keysize 2048 -keystore testkeystore.jks -dname "CN=*.test.com,OU=test,O=test,L=MPL,ST=MPL,C=FR" -storepass wso2carbon -keypass wso2carbon -validity 10950
+    ```
+
+2.  Create a file and name it as the client ID of the OAuth application service provider. Export the public key of the new keystore to the file you created.
+
+    ``` java
+    keytool -export -alias wso2carbon -file <client-id> -keystore testkeystore.jks
+    ```
+
+3.  Get the cert in X509 format.
+
+    ``` java
+    keytool -printcert -rfc -file <client-id>
+    ```
+
+    You will see the public certificate in X509 format in the console.
+    
+4. Copy the content of the certificate. A sample output is shown below. 
+
+    ``` java
+	-----BEGIN CERTIFICATE-----
+	MIIDVzCCAj+gAwIBAgIETCZA8zANBgkqhkiG9w0BAQsFADBcMQswCQYDVQQGEwJG
+	UjEMMAoGA1UECBMDTVBMMQwwCgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTAL
+	BgNVBAsTBHRlc3QxEzARBgNVBAMMCioudGVzdC5jb20wHhcNMTgwMjE0MDYzNjE3
+	WhcNNDgwMjA3MDYzNjE3WjBcMQswCQYDVQQGEwJGUjEMMAoGA1UECBMDTVBMMQww
+	CgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTALBgNVBAsTBHRlc3QxEzARBgNV
+	BAMMCioudGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCz
+	Gc/BcXCiIagLhXs1g90H+PbfZyXLzwFJ+YmsKMikcffhyopDD+fnFjHb1+XXSnUh
+	4XzQlFba6m2vIOK8uquMhZKMv/E7Vxkl/ADTuw/BgpZRut4p88Fn8OWZlrJfoi3o
+	hvgfxSMratvxLMp1Qe0BzjwoBDB9r+h9pj8kCpHC824eUGIR0FZsW9lnoJP2LegL
+	nAcOJuNBoeWC0wwNu0sgIJwjsKp3G3glm8B4GdZvbF8aW1QRAk36sh8+0GXrRnAz
+	aGcRAqt7CjeZmt5Dsuy0lfp5i1xf5myPOH7MwKHqQQ56Wu9O479NdDVLkJ0xne2r
+	ZTCwMeGhQQH5hI+SYlxjAgMBAAGjITAfMB0GA1UdDgQWBBTzS+bja//25xb+4wcP
+	gMN6cJZwoDANBgkqhkiG9w0BAQsFAAOCAQEAdhZ8romzQQKF9c8tJdIhUS4i7iJh
+	oSjBzN+Ex9+OJcW6ubcLb8pai/J3hcvMadAybR1A17FkETLFmG9HkuEN9o2jfU7c
+	9Yz5d0pqO8qNKXSqHky5c+zA4vzLZGsgKyDZ5a0p9Qpsat3wnA3UGZPRoVGV5153
+	Mb0J1n1uubxGobEEzR2BXaKO9YEWAMQwGRdQCGBaIeGUOpqSUJMLYirDXL03je3g
+	mYzWclLTEHpIYy+a66tmF9uTGgyys33LPm2pQ+kWd8FikWolKKBqp+IPU5QdUQi1
+	DdFHsyNqrnms6EOQAY57Vnf91RyS7lnO1T/lVR6SDk9+/KDBEL1b1cy7Dg==
+	-----END CERTIFICATE-----
+    ```
+
+4.  Click **Service Providers > List** and **Edit** the service provider you created. 
+
+5. Select **Upload SP Certificate** under  **Select SP Certificate Type**.
+
+6. Paste the certificate content copied in step 4 as the **Application Certificate**.
+
+    ![Upload SP certificate]({{base_path}}/assets/img/guides/upload-sp-cert.png)
+    
+    !!! note
+
+		Instead of uploading the service provider certificate as shown
+		above, you can choose to use the JWKS enpoint as shown below and
+		add the relevant JWKS URI.
+
+		![JWKS URI]({{base_path}}/assets/img/guides/jwks-uri.png)
+
+7. Click **Update**.
 
 ## Configure claims
 

--- a/en/docs/guides/login/oidc-token-encryption.md
+++ b/en/docs/guides/login/oidc-token-encryption.md
@@ -39,7 +39,72 @@ Make the following changes to the created service provider.
 
 ----
 
-{!./includes/encrypt-id-tokens.md!}
+## Configure the public certificate
+
+The following steps describe how to configure a service provider public certificate.
+
+1.  Create a new keystore.
+
+    ``` java
+    keytool -genkey -alias wso2carbon -keyalg RSA -keysize 2048 -keystore testkeystore.jks -dname "CN=*.test.com,OU=test,O=test,L=MPL,ST=MPL,C=FR" -storepass wso2carbon -keypass wso2carbon -validity 10950
+    ```
+
+2.  Create a file and name it as the client ID of the OAuth application service provider. Export the public key of the new keystore to the file you created.
+
+    ``` java
+    keytool -export -alias wso2carbon -file <client-id> -keystore testkeystore.jks
+    ```
+
+3.  Get the cert in X509 format.
+
+    ``` java
+    keytool -printcert -rfc -file <client-id>
+    ```
+
+    You will see the public certificate in X509 format in the console.
+    
+4. Copy the content of the certificate. A sample output is shown below. 
+
+    ``` java
+	-----BEGIN CERTIFICATE-----
+	MIIDVzCCAj+gAwIBAgIETCZA8zANBgkqhkiG9w0BAQsFADBcMQswCQYDVQQGEwJG
+	UjEMMAoGA1UECBMDTVBMMQwwCgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTAL
+	BgNVBAsTBHRlc3QxEzARBgNVBAMMCioudGVzdC5jb20wHhcNMTgwMjE0MDYzNjE3
+	WhcNNDgwMjA3MDYzNjE3WjBcMQswCQYDVQQGEwJGUjEMMAoGA1UECBMDTVBMMQww
+	CgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTALBgNVBAsTBHRlc3QxEzARBgNV
+	BAMMCioudGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCz
+	Gc/BcXCiIagLhXs1g90H+PbfZyXLzwFJ+YmsKMikcffhyopDD+fnFjHb1+XXSnUh
+	4XzQlFba6m2vIOK8uquMhZKMv/E7Vxkl/ADTuw/BgpZRut4p88Fn8OWZlrJfoi3o
+	hvgfxSMratvxLMp1Qe0BzjwoBDB9r+h9pj8kCpHC824eUGIR0FZsW9lnoJP2LegL
+	nAcOJuNBoeWC0wwNu0sgIJwjsKp3G3glm8B4GdZvbF8aW1QRAk36sh8+0GXrRnAz
+	aGcRAqt7CjeZmt5Dsuy0lfp5i1xf5myPOH7MwKHqQQ56Wu9O479NdDVLkJ0xne2r
+	ZTCwMeGhQQH5hI+SYlxjAgMBAAGjITAfMB0GA1UdDgQWBBTzS+bja//25xb+4wcP
+	gMN6cJZwoDANBgkqhkiG9w0BAQsFAAOCAQEAdhZ8romzQQKF9c8tJdIhUS4i7iJh
+	oSjBzN+Ex9+OJcW6ubcLb8pai/J3hcvMadAybR1A17FkETLFmG9HkuEN9o2jfU7c
+	9Yz5d0pqO8qNKXSqHky5c+zA4vzLZGsgKyDZ5a0p9Qpsat3wnA3UGZPRoVGV5153
+	Mb0J1n1uubxGobEEzR2BXaKO9YEWAMQwGRdQCGBaIeGUOpqSUJMLYirDXL03je3g
+	mYzWclLTEHpIYy+a66tmF9uTGgyys33LPm2pQ+kWd8FikWolKKBqp+IPU5QdUQi1
+	DdFHsyNqrnms6EOQAY57Vnf91RyS7lnO1T/lVR6SDk9+/KDBEL1b1cy7Dg==
+	-----END CERTIFICATE-----
+    ```
+
+4.  Click **Service Providers > List** and **Edit** the service provider you created. 
+
+5. Select **Upload SP Certificate** under  **Select SP Certificate Type**.
+
+6. Paste the certificate content copied in step 4 as the **Application Certificate**.
+
+    ![Upload SP certificate]({{base_path}}/assets/img/guides/upload-sp-cert.png)
+    
+    !!! note
+
+		Instead of uploading the service provider certificate as shown
+		above, you can choose to use the JWKS enpoint as shown below and
+		add the relevant JWKS URI.
+
+		![JWKS URI]({{base_path}}/assets/img/guides/jwks-uri.png)
+
+7. Click **Update**.
 
 ----
 

--- a/en/docs/guides/login/request-object.md
+++ b/en/docs/guides/login/request-object.md
@@ -2,11 +2,106 @@
 
 This page guides you through passing OpenID Connect authentication request parameters in a self contained JWT, instead of passing plain request parameters using a sample application. A JWT that contains a set of request parameters as its claims is known as a request object.
 
-{!./includes/oauth-playground.md!}
+{!./includes/deploying-sample-apps.md!}
+
+
+{!./includes/deploy-playground.md!}
+
+
+{!./includes/deploy-playground-with-check-session.md!}
+
+---
+
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
 
 ----
 
-{!./includes/encrypt-id-tokens.md!}
+## Configure the public certificate
+
+The following steps describe how to configure a service provider public certificate.
+
+1.  Create a new keystore.
+
+    ``` java
+    keytool -genkey -alias wso2carbon -keyalg RSA -keysize 2048 -keystore testkeystore.jks -dname "CN=*.test.com,OU=test,O=test,L=MPL,ST=MPL,C=FR" -storepass wso2carbon -keypass wso2carbon -validity 10950
+    ```
+
+2.  Create a file and name it as the client ID of the OAuth application service provider. Export the public key of the new keystore to the file you created.
+
+    ``` java
+    keytool -export -alias wso2carbon -file <client-id> -keystore testkeystore.jks
+    ```
+
+3.  Get the cert in X509 format.
+
+    ``` java
+    keytool -printcert -rfc -file <client-id>
+    ```
+
+    You will see the public certificate in X509 format in the console.
+    
+4. Copy the content of the certificate. A sample output is shown below. 
+
+    ``` java
+	-----BEGIN CERTIFICATE-----
+	MIIDVzCCAj+gAwIBAgIETCZA8zANBgkqhkiG9w0BAQsFADBcMQswCQYDVQQGEwJG
+	UjEMMAoGA1UECBMDTVBMMQwwCgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTAL
+	BgNVBAsTBHRlc3QxEzARBgNVBAMMCioudGVzdC5jb20wHhcNMTgwMjE0MDYzNjE3
+	WhcNNDgwMjA3MDYzNjE3WjBcMQswCQYDVQQGEwJGUjEMMAoGA1UECBMDTVBMMQww
+	CgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTALBgNVBAsTBHRlc3QxEzARBgNV
+	BAMMCioudGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCz
+	Gc/BcXCiIagLhXs1g90H+PbfZyXLzwFJ+YmsKMikcffhyopDD+fnFjHb1+XXSnUh
+	4XzQlFba6m2vIOK8uquMhZKMv/E7Vxkl/ADTuw/BgpZRut4p88Fn8OWZlrJfoi3o
+	hvgfxSMratvxLMp1Qe0BzjwoBDB9r+h9pj8kCpHC824eUGIR0FZsW9lnoJP2LegL
+	nAcOJuNBoeWC0wwNu0sgIJwjsKp3G3glm8B4GdZvbF8aW1QRAk36sh8+0GXrRnAz
+	aGcRAqt7CjeZmt5Dsuy0lfp5i1xf5myPOH7MwKHqQQ56Wu9O479NdDVLkJ0xne2r
+	ZTCwMeGhQQH5hI+SYlxjAgMBAAGjITAfMB0GA1UdDgQWBBTzS+bja//25xb+4wcP
+	gMN6cJZwoDANBgkqhkiG9w0BAQsFAAOCAQEAdhZ8romzQQKF9c8tJdIhUS4i7iJh
+	oSjBzN+Ex9+OJcW6ubcLb8pai/J3hcvMadAybR1A17FkETLFmG9HkuEN9o2jfU7c
+	9Yz5d0pqO8qNKXSqHky5c+zA4vzLZGsgKyDZ5a0p9Qpsat3wnA3UGZPRoVGV5153
+	Mb0J1n1uubxGobEEzR2BXaKO9YEWAMQwGRdQCGBaIeGUOpqSUJMLYirDXL03je3g
+	mYzWclLTEHpIYy+a66tmF9uTGgyys33LPm2pQ+kWd8FikWolKKBqp+IPU5QdUQi1
+	DdFHsyNqrnms6EOQAY57Vnf91RyS7lnO1T/lVR6SDk9+/KDBEL1b1cy7Dg==
+	-----END CERTIFICATE-----
+    ```
+
+4.  Click **Service Providers > List** and **Edit** the service provider you created. 
+
+5. Select **Upload SP Certificate** under  **Select SP Certificate Type**.
+
+6. Paste the certificate content copied in step 4 as the **Application Certificate**.
+
+    ![Upload SP certificate]({{base_path}}/assets/img/guides/upload-sp-cert.png)
+    
+    !!! note
+
+		Instead of uploading the service provider certificate as shown
+		above, you can choose to use the JWKS enpoint as shown below and
+		add the relevant JWKS URI.
+
+		![JWKS URI]({{base_path}}/assets/img/guides/jwks-uri.png)
+
+7. Click **Update**.
 
 ----
 

--- a/en/docs/guides/login/saas-application.md
+++ b/en/docs/guides/login/saas-application.md
@@ -6,4 +6,13 @@ To enable users from other tenants to access your application too, follow the in
 
 Configure service provider to enable SaaS:
 
-{!./includes/saas-application.md !}
+1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
+
+2. Navigate to the **Service Providers** tab listed under the **Identity** section and click **List**.
+
+3. Click **Edit** adjacent to the service provider for which you want to enable SaaS. 
+
+4.  Enable **SaaS application**. 
+    ![saas-enable]({{base_path}}/assets/img/guides/saas-enable.png)
+
+5.  Click **Update** to save the changes.

--- a/en/docs/guides/login/session-management-logout.md
+++ b/en/docs/guides/login/session-management-logout.md
@@ -8,7 +8,13 @@ This page guides you through [managing user sessions and logout]({{base_path}}/r
 
 {!./includes/oauth-app-config-basic.md!}
 
-{!./includes/local-outbound-tenant-domain-in-sub-lvl3.md!}
+## Configure to sign the ID token with the user's tenant domain
+
+1. Expand the **Local & Outbound Authentication Configuration** section and select **Use tenant domain in local subject identifier** to sign the ID token with the user's tenant domain.
+    
+    ![use-tenant-domain-in-subject.png]({{base_path}}/assets/img/guides/use-tenant-domain-in-subject.png)
+    
+2. Click **Update** to save the changes.
 
 !!! note
         **Alternatively,** to sign the ID token with the service provider's

--- a/en/docs/guides/login/skip-user-consent.md
+++ b/en/docs/guides/login/skip-user-consent.md
@@ -5,13 +5,22 @@ The user's [consent]({{base_path}}/references/concepts/consent-management/) is r
 !!! info "Important"
     As explained below, consent management can be disabled globally and per service provider. If consent management is disabled globally, the service provider configuration will be skipped.
 
-----
-
 ## Disable consent per service provider
 
 Configure service provider to skip user consent:
 
-{!./includes/skip-user-consent.md !}
+1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
+
+2. Navigate to the **Service Providers** tab listed under the **Identity** section and click **List**.
+
+3. Click **Edit** adjacent to the service provider for which you want to skip the consent step.  
+
+3. Expand **Local & Outbound Authentication Configuration**. 
+
+4.  Enable **Skip Login consent**. 
+    ![skip login consent]({{base_path}}/assets/img/guides/skip-login-consent.png)
+    
+5.  Click **Update** to save the changes.
 
 ## Disable consent globally
   

--- a/en/docs/guides/login/use-certificates-with-applications.md
+++ b/en/docs/guides/login/use-certificates-with-applications.md
@@ -7,7 +7,72 @@ Follow the steps given below to configure your application to use a public certi
 
 ---
 
-{!./includes/encrypt-id-tokens.md!}
+## Configure the public certificate
+
+The following steps describe how to configure a service provider public certificate.
+
+1.  Create a new keystore.
+
+    ``` java
+    keytool -genkey -alias wso2carbon -keyalg RSA -keysize 2048 -keystore testkeystore.jks -dname "CN=*.test.com,OU=test,O=test,L=MPL,ST=MPL,C=FR" -storepass wso2carbon -keypass wso2carbon -validity 10950
+    ```
+
+2.  Create a file and name it as the client ID of the OAuth application service provider. Export the public key of the new keystore to the file you created.
+
+    ``` java
+    keytool -export -alias wso2carbon -file <client-id> -keystore testkeystore.jks
+    ```
+
+3.  Get the cert in X509 format.
+
+    ``` java
+    keytool -printcert -rfc -file <client-id>
+    ```
+
+    You will see the public certificate in X509 format in the console.
+    
+4. Copy the content of the certificate. A sample output is shown below. 
+
+    ``` java
+	-----BEGIN CERTIFICATE-----
+	MIIDVzCCAj+gAwIBAgIETCZA8zANBgkqhkiG9w0BAQsFADBcMQswCQYDVQQGEwJG
+	UjEMMAoGA1UECBMDTVBMMQwwCgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTAL
+	BgNVBAsTBHRlc3QxEzARBgNVBAMMCioudGVzdC5jb20wHhcNMTgwMjE0MDYzNjE3
+	WhcNNDgwMjA3MDYzNjE3WjBcMQswCQYDVQQGEwJGUjEMMAoGA1UECBMDTVBMMQww
+	CgYDVQQHEwNNUEwxDTALBgNVBAoTBHRlc3QxDTALBgNVBAsTBHRlc3QxEzARBgNV
+	BAMMCioudGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCz
+	Gc/BcXCiIagLhXs1g90H+PbfZyXLzwFJ+YmsKMikcffhyopDD+fnFjHb1+XXSnUh
+	4XzQlFba6m2vIOK8uquMhZKMv/E7Vxkl/ADTuw/BgpZRut4p88Fn8OWZlrJfoi3o
+	hvgfxSMratvxLMp1Qe0BzjwoBDB9r+h9pj8kCpHC824eUGIR0FZsW9lnoJP2LegL
+	nAcOJuNBoeWC0wwNu0sgIJwjsKp3G3glm8B4GdZvbF8aW1QRAk36sh8+0GXrRnAz
+	aGcRAqt7CjeZmt5Dsuy0lfp5i1xf5myPOH7MwKHqQQ56Wu9O479NdDVLkJ0xne2r
+	ZTCwMeGhQQH5hI+SYlxjAgMBAAGjITAfMB0GA1UdDgQWBBTzS+bja//25xb+4wcP
+	gMN6cJZwoDANBgkqhkiG9w0BAQsFAAOCAQEAdhZ8romzQQKF9c8tJdIhUS4i7iJh
+	oSjBzN+Ex9+OJcW6ubcLb8pai/J3hcvMadAybR1A17FkETLFmG9HkuEN9o2jfU7c
+	9Yz5d0pqO8qNKXSqHky5c+zA4vzLZGsgKyDZ5a0p9Qpsat3wnA3UGZPRoVGV5153
+	Mb0J1n1uubxGobEEzR2BXaKO9YEWAMQwGRdQCGBaIeGUOpqSUJMLYirDXL03je3g
+	mYzWclLTEHpIYy+a66tmF9uTGgyys33LPm2pQ+kWd8FikWolKKBqp+IPU5QdUQi1
+	DdFHsyNqrnms6EOQAY57Vnf91RyS7lnO1T/lVR6SDk9+/KDBEL1b1cy7Dg==
+	-----END CERTIFICATE-----
+    ```
+
+4.  Click **Service Providers > List** and **Edit** the service provider you created. 
+
+5. Select **Upload SP Certificate** under  **Select SP Certificate Type**.
+
+6. Paste the certificate content copied in step 4 as the **Application Certificate**.
+
+    ![Upload SP certificate]({{base_path}}/assets/img/guides/upload-sp-cert.png)
+    
+    !!! note
+
+		Instead of uploading the service provider certificate as shown
+		above, you can choose to use the JWKS enpoint as shown below and
+		add the relevant JWKS URI.
+
+		![JWKS URI]({{base_path}}/assets/img/guides/jwks-uri.png)
+
+7. Click **Update**.
 
 ---
 

--- a/en/docs/guides/login/webapp-sts.md
+++ b/en/docs/guides/login/webapp-sts.md
@@ -10,11 +10,42 @@ This guide assumes you have your own application. If you wish to try out this fl
 
 ----
 
-{!./includes/configure-resident-idp.md!}
+## Configure the resident IdP
+
+1. Log in to the [Management Console](insertlink) using admin/admin credentials. 
+
+2. Click **Identity Providers > Resident**. 
+
+    ![resident-idp]({{base_path}}/assets/img/fragments/resident-idp.png)
+
+3. Configure the following. 
+
+    - **Home Realm Identifier**: This is the domain name of the identity provider. If you do not enter a value here, when an authentication request comes to WSO2 Identity Server, a user will be prompted to specify a domain. You can enter multiple identifiers as a comma-separated list.
+
+    - **Idle Session Time Out**: This is the duration in minutes for which an SSO session can be idle for. If WSO2 Identity Server does not receive any SSO authentication requests for the given duration, a session time out occurs. 
+
+    - **Remember Me Period**: This is the duration in weeks for which WSO2 Identity Server should remember an SSO session given that the **Remember Me** option is selected in the WSO2 Identity Server login screen.
+
+        <img name='configure-resident-idp' src='{{base_path}}/assets/img/fragments/configure-resident-idp.png' class='img-zoomable'/>
 
 ----
 
-{!./includes/sts-idp-config-basic.md!}
+## Configure STS for the IdP
+
+1. Expand **Inbound Authentication Configuration > Security Token Service Configuration** and click **Apply Security Policy**.
+
+    ![apply-security-policy]({{base_path}}/assets/img/fragments/apply-security-policy.png)
+
+2. Select **Yes** in the **Enable Security?** drop down and select a pre-configured security scenario according to your requirements. 
+
+    ![enable-security-sts]({{base_path}}/assets/img/fragments/enable-security-sts.png)
+
+3. Click **Next**. 
+
+4. The next step depends on the selected security scenario. Follow the wizard and click **Finish**. 
+
+You have successfully configured and secured the Security Token Service. 
+
 Next, configure the client application for WS-Trust STS.
 ----
 
@@ -22,7 +53,19 @@ Next, configure the client application for WS-Trust STS.
 
 ----
 
-{!./includes/sts-app-config-basic.md!}
+## Configure STS for the client app
+
+1. Expand **Inbound Authentication Configuration > WS-Trust Security Token Service Configuration** and click **Configure**.
+
+2. Enter the **Endpoint Address** and the **Certificate Alias**. 
+
+    - The **Endpoint Address** is the trusted relying party's endpoint address, which is the endpoint address of the Security Token Service. The endpoint must be used as the service URL to which the token gets delivered by the STS client.
+
+    - The **Certificate Alias** is the name given to the CA certificate that is imported to the keystore.  
+
+        ![configure-sts]({{base_path}}/assets/img/fragments/configure-sts.png)
+
+3. Click **Update** to save the changes. 
 
 ----
 

--- a/en/docs/guides/login/webapp-ws-federation.md
+++ b/en/docs/guides/login/webapp-ws-federation.md
@@ -16,5 +16,49 @@ This page guides you through enabling login for a WS-Federation based web applic
 
 ---
 
-{!./includes/ws-fed-app-config.md!}
+## Configure WS-Federation
+
+1.  Expand **Inbound Authentication Configuration** followed by the
+    **WS-Federation (Passive) Configuration** section and provide the
+    following values. 
+
+    -   **Passive STS Realm** - This should be a unique identifier for
+        the web app. Provide the same realm name given to the web app
+        you are configuring WS-Federation for.
+
+    -   **Passive STS WReply URL** - Provide the URL of the web app you
+        are configuring WS-Federation for.  This endpoint URL will
+        handle the token response.
+        
+        ![ws-federation-passive.png]({{base_path}}/assets/img/guides/ws-federation-passive.png)
+
+        !!! tip
+        
+            If you want to configure an expiration time for the security
+            token, you need to add the following configuration in the
+            `<IS_HOME>/repository/conf/deployment.toml`
+            file and restart the server.
+
+            ``` java
+            [sts]
+            time_to_live = "8000"
+            ```
+
+            Here, the expiration time should be specified in milliseconds.
+
+2.  Expand the **Claim Configuration** section and map the relevant claims. 
+    <!--See [Request Attributes for the Application](../../../../guides/login/request-attributes/) for more information.-->
+    
+3.  Click **Update** to save changes.
+
+!!! tip
+    Currently the signing algorithm used for passive STS by default is `rsa-sha1` and the digest algorithm used is `sha1`. 
+    To change the default algorithms, add the following configuration in the `deployment.toml` file found in the `<IS_HOME>/repository/conf` directory. 
+    The example given below sets the signing algorithm to `rsa-sha256` and the digest algorithm to `sha256`.
+
+    ```toml
+    [sts]
+    signature_algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+    digest_algorithm = "http://www.w3.org/2001/04/xmlenc#sha256"
+    ```
 

--- a/en/docs/guides/mfa/2fa-sms-otp.md
+++ b/en/docs/guides/mfa/2fa-sms-otp.md
@@ -3,7 +3,22 @@
 This page guides you through configuring [two-factor authentication]({{base_path}}/references/concepts/authentication/intro-authentication#two-factor-authentication) for a web application using SMS OTP as the second factor.
 
 ## Set up SMS OTP provider
-{!./includes/connect-sms-provider.md!}
+
+1. Download the certificate of the SMS provider.
+
+    !!! example
+        If you wish to have NEXMO as your SMS provider:
+
+        1. Go to the SMS provider's website, [https://www.nexmo.com](https://www.nexmo.com/).
+        2. Click on the security padlock next to the URL, and export the certificate.
+
+2. Navigate to the `<IS_HOME>/repository/resources/security` directory and import the downloaded certificate into the WSO2 IS client keystore.
+
+    ``` java
+    keytool -importcert -file <CERTIFICATE_FILE_PATH> -keystore client-truststore.jks -alias "Nexmo" 
+    ```
+
+3. You are prompted to enter the keystore password. The default `client-truststore.jks` password is `wso2carbon`.
 
 ## Enable SMS OTP for an SP
 

--- a/en/docs/guides/mfa/x509.md
+++ b/en/docs/guides/mfa/x509.md
@@ -4,7 +4,335 @@ This page guides you through configuring the X509 certificate authenticator with
 
 ---
 
-{!./includes/work-with-certificates.md !}
+## Work with certificates
+
+X509 authentication requires the client to possess a Public Key Certificate (PKC). <!--- To know more about Public Key Certificate (PKC) and Certificate Authority (CA), refer [Working with certificates](TO DO: Concepts) -->
+
+
+To create a sample certificate and create your own Certificate Authority to sign the certificates, follow the following steps:
+
+1.  The first step is to create the private RSA key:
+
+    ```
+    openssl genrsa -out rootCA.key 2048
+    ```
+
+    Here, the specified key size is 2048 bit. You can specify the key size for your private key.
+
+2.  Based on this key you can now generate an actual certificate which is valid for 10 years using the following command:
+
+    ```
+    openssl req -new -x509 -days 3650 -key rootCA.key -out rootCA.crt
+    ```
+
+3.  You are prompted to provide the following details, and the details you provide are incorporated into the certificate request. 
+    An example is shown below. Make sure you use the values that fit your use case.
+
+    - Country Name (2 letter code) [AU]: SL
+    - State or Province Name (full name) [Some-State]: Western
+    - Locality Name (eg, city) [ ]: Colombo
+    - Organization Name (eg, company) [Internet Widgits Pty Ltd]: WSO2
+    - Organizational Unit Name (eg, section) [ ]: QA
+    - Common Name (e.g. serverFQDN or YOUR name) [ ]: wso2is.com 
+    - Email Address [ ]: kim@wso2.com
+
+4.  An OpenSSL CA requires new files and supporting directories. Therefore, create a new directory.
+    Create the directory structure according to your `openssl.conf` format.
+
+    ```
+    mkdir -p demoCA/newcerts
+    ```
+
+5.  You also need some initial files inside your CA directory structure.
+
+    ```
+    touch demoCA/index.txt
+    echo '01' > demoCA/serial
+    ```
+
+6.  For the JVM to trust your newly created certificate import your certificate into your JVM trust store by executing the following command:
+
+    ```
+    keytool -import -noprompt -trustcacerts -alias rootCA -file rootCA.crt -keystore /Library/Java/JavaVirtualMachines/jdk1.8.0_191.jdk/Contents/Home/jre/lib/security/cacerts -storepass changeit
+    ```
+
+    !!! info "Got the 'permission denied' error?"
+        Note that when adding the certificate to the JVM trust store you may get the permission denied error. Running this command as an administrator resolves this permission issue. 
+
+        For example, if you are a Mac user, you can use sudo in front of this command to fix the permission issue.  
+
+7. Now you have created the CA to sign the certificate. To create the server certificate follow the steps given below:
+
+    1. Create the keystore that includes the private key by executing the following command:
+
+        ```
+        keytool -genkey -v -alias localcrt -keyalg RSA -validity 3650 -keystore localcrt.jks -storepass localpwd -keypass localpwd
+        ```
+
+        !!! tip
+            You are prompted for details after executing the above command. For "What is your first and last name?" you need to give a name without space(e.g., wso2). 
+
+        This command will create a keystore with the following details: 
+            - **Keystore name:** localcrt.jks
+            - **Alias of public certificate:** localcrt
+            - **Keystore password:** localpwd
+            - **Private key password:** localpwd (this is required to be the same as keystore password)
+    
+    2. Execute the following command to generate the certificate signing request(CSR) using the generated keystore file.
+
+        ```
+        keytool -certreq -alias localcrt -file localcrt.csr -keystore localcrt.jks -storepass localpwd
+        ```
+
+    3.  To enable CRL or OCSP based certificate revocation validation, configure the necessary openSSL extension configurations.
+
+        1.  Open either of the following files.
+            -  `validation.cnf`
+            -  `/usr/lib/ssl/openssl.cnf`
+
+        2.  Set the following properties under `x509\_extensions`.
+
+            ``` java
+            crlDistributionPoints = URI:http://pki.google.com/GIAG2.crl
+            authorityInfoAccess = OCSP;URI: http://clients1.google.com/ocsp
+            ```
+
+    4.  Once it is done, sign the CSR, which requires the CA root key.
+
+        ``` xml
+        openssl ca -batch -startdate 150813080000Z -enddate 250813090000Z -keyfile rootCA2.key -cert rootCA2.crt -policy policy_anything -config {File_Path}/openssl.cnf -notext -out localcrt.crt -infiles localcrt.csr
+        ```
+
+        This creates a signed certificate called `localcrt.crt` that is valid for a specified period that is denoted by the `startdate` and `enddate`.
+
+    5.  The next step is to import the CA and signed certificate into the keystore.
+
+        ``` xml
+        keytool -importcert -alias rootCA -file rootCA.crt -keystore localcrt.jks -storepass localpwd -noprompt
+        
+        keytool -importcert -alias localcrt -file demoCA/newcerts/01.pem -keystore localcrt.jks -storepass localpwd -noprompt
+        ```
+
+    6.  Now, get the `pkcs12` out of `.crt` file using the command given below as it is been used to import certificates to the browser.
+
+        ``` xml
+        keytool -importkeystore -srckeystore localcrt.jks -destkeystore localhost.p12 -srcstoretype JKS -deststoretype PKCS12 -srcstorepass localpwd -deststorepass browserpwd -srcalias localcrt -destalias browserKey -srckeypass localpwd -destkeypass browserpwd -noprompt
+        ```
+
+        Make sure to use the same password you used when creating the keystore for the `srcstorepass` in the above step. Now you have the `localhost.p12` file that you can import into your browser as explained in the [import certificate](#import-certificate) section.
+
+7.  Next, create a new trust store and import the server certificate into the trust store using the following commands:
+
+    ``` xml
+    keytool -import -keystore cacerts.jks -storepass cacertspassword -alias rootCA -file rootCA.crt -noprompt
+    keytool -importcert -alias localcrt -file localcrt.crt -keystore cacerts.jks -storepass cacertspassword -noprompt
+    ```
+
+    !!! tip "CN"
+        The User objects in the LDAP directory hierarchy have designators that start with CN, meaning Common Name. The CN designator applies to all but a few object types. Active Directory only uses two other object designators (although LDAP defines several).
+
+Once you have done the above steps, you have the keystore (`localcrt.jks`), truststore (`cacerts.jks`), and pkcs12 (`localhost.p12`) files that you need to use later on in this guide.
+
+---
+
+## Configure the X509 certificate for the app
+
+1.  Download the [WSO2 Identity Server](http://wso2.com/products/identity-server/).
+
+2.  Replace your keystore file path, keystore password, trust store file path and trust store password (you can use the keystore and
+    truststore, which you created in the [Work with Certificates](#work-with-certificates) section) in the following configuration and add it to the
+    `<IS_HOME>/repository/conf/deployment.toml` file.
+
+    ``` toml 
+    [custom_transport.x509.properties]
+    protocols="HTTP/1.1"
+    port="8443"
+    maxThreads="200"
+    scheme="https"
+    secure=true
+    SSLEnabled=true
+    keystoreFile="/path/to/keystore.jks"
+    keystorePass="keystorepwd"
+    truststoreFile="/path/to/truststore.jks"
+    truststorePass="truststorespassword"
+    bindOnInit=false
+    clientAuth="want"
+    ssl_protocol = "TLS"
+    ```
+
+    !!! note
+    
+        1.   To function properly, this connector should come first in the order. Otherwise, when mutual SSL takes place, the already existing connector (9443) will be picked up and the certificate will not be retrieved correctly.
+
+        2.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
+            -   `true` : valid client certificate required for a connection to succeed
+            -   `want` : use a certificate if available, but still connect if no certificate is available
+            -   `false` : no client certificate is required or validated
+    
+        3.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
+
+---
+
+## Disable certificate validation
+    
+The location that is used to disable certificate validation depends on whether WSO2 Identity Server was started at least once or not.
+
+-   If you have never started WSO2 Identity Server before, the configurations should be made on the `deployment.toml` file.
+
+-   If you have started WSO2 Identity Server at least once, the configurations should be made on the registry parameters.
+
+---
+
+### Disable certificate validation in an unstarted WSO2 IS Pack
+
+Follow the steps below to disable certificate validation if your WSO2 Identity Server pack has never been started.
+
+1.  Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
+
+2.  Add the following configuration to disable CRL-based certificate validation and OCSP-based certificate validation.
+
+    ```
+    [certificate_validation]
+    ocsp_validator_enabled = false
+    crl_validator_enabled = false
+    ```
+    
+    !!! info
+        - CRL is a list of digital certificates that have been revoked by the issuing CA.
+        - OCSP is an internet protocol that is used for obtaining the revocation status of an X509 digital certificate using the certificate serial number.
+
+---
+
+### Disable certificate validation in an already-started WSO2 IS pack
+
+Follow the steps below to disable certificate validation if WSO2 Identity Server was started before.
+
+1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
+
+2.  Click **Main > Registry > Browse**.  
+    ![registry]({{base_path}}/assets/img/guides/registry.png)
+    
+3.  Disable CRL certificate validation.
+
+    1.  Locate the CRL parameter by entering
+        `            _system/governance/repository/security/certificate/validator/crlvalidator           `
+        in the **Location** search box.  
+        ![location]({{base_path}}/assets/img/guides/browse-registry-location.png)
+        
+    2.  Expand **Properties**.  
+        ![crlvalidator-properties]({{base_path}}/assets/img/guides/crlvalidator-properties.png)
+        
+    3.  Click **Edit** pertaining to the **Enable** property.  
+        ![crlvalidator-enable-property]({{base_path}}/assets/img/guides/crlvalidator-enable-property.png)  
+        
+    4.  Change the value to `            false           ` and click
+        **Save**.  
+        ![save-crlvalidator-disable]({{base_path}}./assets/img/guides/save-crlvalidator-disable.png)
+        
+4.  Similarly, disable OCSP certificate validation in the
+    `          _system/governance/repository/security/certificate/validator/ocspvalidator         `
+    registry parameter.
+
+<!--- For more information on CRL and OCSP certificate validation, see
+[Configuring Certificate Revocation Validation](https://docs.wso2.com/display/ISCONNECTORS/Configuring+Certificate+Revocation+Validation). -->
+
+
+---
+
+## Configure the Authentication Endpoint
+
+1.  Open the `          deployment.toml         ` file in
+    the `          <IS_HOME>/repository/conf/         `
+    directory.
+2.  Add the following configuration to the file.
+
+    ``` toml
+    [authentication.authenticator.x509_certificate.parameters]
+    name ="x509CertificateAuthenticator"
+    enable=true
+    AuthenticationEndpoint="https://localhost:8443/x509-certificate-servlet"
+    username= "CN"
+    ```
+    
+    !!! info
+        - `name` : This attribute identifies the authenticator that is configured as the second authentication step. 
+        - `enable`: This attribute, when set to true makes the authenticator capable of being involved in the authentication process. 
+        - `AuthenticationEndpoint` : This is the URL with the port that is secured with the certificate, 
+            e.g., `https://localhost:8443/x509-certificate-servlet`. 
+            Update this based on your host name.
+        - `username` : This attribute value will be taken as the authenticated user subject identifier. Update this
+             with any of the certificate attributes, e.g., CN and Email.
+
+    !!! note
+        When X509 authentication is configured as the second authentication
+        step, the certificate will be validated to check whether it is
+        associated with the authenticated user in the first authentication
+        step. For that, the `           username          ` parameter will
+        be used. For that, the authenticated user name considered in the
+        first authentication step will be validated with the certificate
+        attribute in this property.
+    
+        When X509 authentication is configured as the first step, this
+        certificate attribute will be treated as the authenticated user
+        subject identifier.
+    
+
+3.  If you are using the identity claim dialect URI to store X509
+    certificate, add the following parameter.
+
+    ``` toml
+    [authentication.authenticator.x509_certificate.parameters]
+    setClaimURI = "http://wso2.org/claims/identity/userCertificate"
+    ```
+
+4.  To enable storing the X509 certificate as a user claim, add the
+    following parameter.
+
+    ``` toml 
+    [authentication.authenticator.x509_certificate.parameters]
+    EnforceSelfRegistration = true
+    ```
+
+5. Restart the server to apply the changes.
+
+---
+
+## Add a claim mapping for the certificate
+
+If storing the certificate as a user claim is enabled, the X509
+certificate will be stored as a user claim and verified with the
+retrieved certificate from the request.
+
+1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator 
+   credentials (`admin:admin`).
+
+2.  On the **Main** tab, click **Claims > Add**. 
+ 
+    ![add-claim]({{base_path}}/assets/img/fragments/add-claim.png)
+    
+3.  Click **Add Local Claim**.  
+
+    ![add-local-claim]({{base_path}}/assets/img/fragments/add-local-claim.png)
+    
+4.  Add a new claim for the **certificate** by giving the details as
+    below, e.g., select a mapped attribute for the claim that is
+    supported by the underlying database type.
+    
+    ![claim-mapped-attribute]({{base_path}}/assets/img/fragments/claim-mapped-attribute.png)
+    
+5.  Click **Add**.
+
+---
+
+## Update the column size of the database for X509 certificates
+
+Make note of the following points and configure your database to match
+your use case:  
+  
+-   [Disabling Certificate Validation in an Unstarted WSO2 IS
+    Pack](#disable-certificate-validation-in-an-unstarted-wso2-is-pack)
+-   [Disabling Certificate Validation in an Already-started WSO2 IS
+    Pack](#disable-certificate-validation-in-an-already-started-wso2-is-pack)
 
 ---
 
@@ -13,7 +341,31 @@ This page guides you through configuring the X509 certificate authenticator with
 
 ---
 
-{!./includes/import-certificates.md !}
+## Import certificate
+
+-   **Chrome**
+    1.  In your browser, navigate to **Settings &gt; Security &gt; HTTPS/SSL &gt; Manage
+    certificates**.  
+    ![import-cert-chrome]({{base_path}}/assets/img/guides/import-cert-chrome.png)
+    2.  Click on **Import,** select the **localhost.p12** file, and then
+    click **Open**. Note that you may have to enter the password that
+    you used to generate the p12 file, (browserpwd) to open it.
+
+-   **Firefox**
+    1.  Click on the menu option on the right of the screen and select
+        **Preferences**.  
+    
+        ![preferences-firefox]({{base_path}}/assets/img/guides/preferences-firefox.png)
+
+    2.  Click Privacy & Security in the left navigation and scroll down to
+        the **Certificates** section. Click **View Certificates**.  
+        
+        ![view-certificates]({{base_path}}/assets/img/guides/view-certificates.png)
+    3.  In the window that appears, click **Import**.  
+        ![import-firefox]({{base_path}}/assets/img/guides/import-firefox.png)
+    4.  Select the **localhost.p12** file, and then click **Open**. Note
+        that you may have to enter the password that you used to generate
+        the p12 file, (browserpwd) to open it.
 
 ---
 

--- a/en/docs/guides/password-mgt/recaptcha-challenge-question-attempts.md
+++ b/en/docs/guides/password-mgt/recaptcha-challenge-question-attempts.md
@@ -8,7 +8,29 @@ This topic guides you through configuring reCAPTCHA for secret questions in the 
 
 ---
 
-{!./includes/configure-recaptcha-api-keys.md !}
+## Configure reCAPTCHA API keys
+
+[reCAPTCHA](https://developers.google.com/recaptcha/) is a free widget service provided by Google that can be used for protection against spam or other forms of internet abuse by verifying whether a user is a human or a robot. The following section guides you through setting up reCAPTCHA with WSO2 Identity Server.
+
+First, you need to register and create an API key pair for the required domain. The key pair consists of a site key and secret. The site key is used when a reCAPTCHA widget is displayed on a page. After verification, a new parameter called g-recaptcha-response appears on the form which the user submits. From the server side, you can verify the submitted captcha response by calling the Google API with the secret key.
+
+1.  Go to <https://www.google.com/recaptcha/admin>.
+
+2.  Fill in the fields to register
+    your identity server domain and click **Register**. The following
+    are sample values:
+    -   **Label:** WSO2 Identity Server
+    -   Select the reCAPTCHA V2 option.
+    -   **Domains:** is.wso2.com  
+
+3.	Accept the terms of service. 
+
+4.  Click **Submit**.
+
+    ![configuring-recaptcha-api-keys]({{base_path}}/assets/img/fragments/recaptcha-new-sso.png) 
+
+5.  Take note of the site key and secret that you receive.
+    ![note-site-key-secret]({{base_path}}/assets/img/fragments/copy-key.png) 
 
 ---
 

--- a/en/docs/guides/password-mgt/recaptcha-password-recovery.md
+++ b/en/docs/guides/password-mgt/recaptcha-password-recovery.md
@@ -13,7 +13,29 @@ By configuring reCAPTCHA, you can mitigate or block brute force attacks.
 
 ---
 
-{!./includes/configure-recaptcha-api-keys.md!}
+## Configure reCAPTCHA API keys
+
+[reCAPTCHA](https://developers.google.com/recaptcha/) is a free widget service provided by Google that can be used for protection against spam or other forms of internet abuse by verifying whether a user is a human or a robot. The following section guides you through setting up reCAPTCHA with WSO2 Identity Server.
+
+First, you need to register and create an API key pair for the required domain. The key pair consists of a site key and secret. The site key is used when a reCAPTCHA widget is displayed on a page. After verification, a new parameter called g-recaptcha-response appears on the form which the user submits. From the server side, you can verify the submitted captcha response by calling the Google API with the secret key.
+
+1.  Go to <https://www.google.com/recaptcha/admin>.
+
+2.  Fill in the fields to register
+    your identity server domain and click **Register**. The following
+    are sample values:
+    -   **Label:** WSO2 Identity Server
+    -   Select the reCAPTCHA V2 option.
+    -   **Domains:** is.wso2.com  
+
+3.	Accept the terms of service. 
+
+4.  Click **Submit**.
+
+    ![configuring-recaptcha-api-keys]({{base_path}}/assets/img/fragments/recaptcha-new-sso.png) 
+
+5.  Take note of the site key and secret that you receive.
+    ![note-site-key-secret]({{base_path}}/assets/img/fragments/copy-key.png) 
 
 ---
 

--- a/en/docs/guides/request-path-auth/basic-auth-request-path.md
+++ b/en/docs/guides/request-path-auth/basic-auth-request-path.md
@@ -23,9 +23,13 @@ Now, let's configure the service provider you registered.
 
 ### Local & Outbound
 
-{!./includes/local-outbound-for-request-path.md!}
+1. Expand the **Local & Outbound Authentication Configuration** section and then the **Request Path Authentication Configuration** section.
 
-----
+2. Select **basic-auth** from the dropdown list and click **Add**.
+
+    ![basic-auth-request-path-config]({{base_path}}/assets/img/fragments/basic-auth-request-path-config.png)
+
+3. Click **Update** to save changes to the service provider.
 
 ## Configure the client application
 

--- a/en/docs/includes/add-adaptive-acr-script-portal.md
+++ b/en/docs/includes/add-adaptive-acr-script-portal.md
@@ -1,7 +1,8 @@
-
+<!--
 1.	**Edit** the same service provider you created previously to configure the **ACR-Based** authentication flow.
     
 2.	Expand **Local and Outbound Configuration** and click **Advanced Configuration**.
    
 3.	Click on **Templates** on the right side of the **Script Based Conditional Authentication** field and then click **ACR-Based**.  
     ![acr-based-template-config](../../../../assets/img/fragments/acr-based-template-config.png)
+-->

--- a/en/docs/includes/add-adaptive-script.md
+++ b/en/docs/includes/add-adaptive-script.md
@@ -1,3 +1,4 @@
+<!--
 1. On the Management Console, go to **Main > Identity > Service Providers**.
 2. Click **List**, select the service provider you want to configure, and click on the corresponding **Edit** link.
 3. Expand **Local and Outbound Authentication Configuration** and click
@@ -6,3 +7,4 @@
 
 4. You can add authentication steps or use a template to configure
     adaptive authentication depending on your requirement.
+-->

--- a/en/docs/includes/add-certificate-to-sp.md
+++ b/en/docs/includes/add-certificate-to-sp.md
@@ -1,3 +1,4 @@
+<!--
 # Configure a certificate to the service provider
 
 
@@ -18,6 +19,7 @@ Follow the steps below to configure a public certificate for the application:
         ![jwks-uri](../../../../assets/img/guides/jwks-uri.png)
 
 3.  Click **Update**.
+-->
 
 
 

--- a/en/docs/includes/add-custom-attributes-saml.md
+++ b/en/docs/includes/add-custom-attributes-saml.md
@@ -1,3 +1,4 @@
+<!--
 1.	Select **Main** > **Identity** > **Service Providers** > **List** and select the Service Provider you created in the first step.
 
 2.	Click **Edit**.
@@ -9,3 +10,4 @@
 5.	Click **Add Claim URI** and add the following claims.
     
     ![claim-mapping-saml](../../../../assets/img/fragments/claim-mapping-saml.png)
+-->

--- a/en/docs/includes/add-function-library-lvl2.md
+++ b/en/docs/includes/add-function-library-lvl2.md
@@ -1,4 +1,5 @@
 
+<!--
 ## Add a function library
 
 To add a function library:
@@ -10,3 +11,4 @@ To add a function library:
     ![Add new function library](../../../../assets/img/guides/add-new-function-library.png)
 
 3. Click **Register** to add the new function library.
+-->

--- a/en/docs/includes/add-function-library-lvl3.md
+++ b/en/docs/includes/add-function-library-lvl3.md
@@ -1,4 +1,4 @@
-
+<!--
 ## Add a function library
 
 Follow the steps below to add a function library using the WSO2 Identity Server Management Console.
@@ -14,3 +14,4 @@ Follow the steps below to add a function library using the WSO2 Identity Server 
     ![Add new function library](../../../../assets/img/guides/add-new-function-library.png)
 
 4. Click **Register** to add the new function library.
+-->

--- a/en/docs/includes/add-new-user.md
+++ b/en/docs/includes/add-new-user.md
@@ -1,3 +1,4 @@
+<!--
 1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
 
 2. Navigate to **Main** > **Identity** > **Users and Roles** > **Add**.
@@ -5,4 +6,4 @@
 3.  Click **Add New User**.
 
     ![add-a-new-user](../../../../assets/img/fragments/add-a-new-user.png)
-    
+-->

--- a/en/docs/includes/add-user-role.md
+++ b/en/docs/includes/add-user-role.md
@@ -1,3 +1,4 @@
+<!--
 1. Navigate **Main** > **Identity** and click **Users and Roles > Add**. 
 
     ![add-users-roles](../../../../assets/img/fragments/add-users-roles.png)
@@ -10,4 +11,5 @@
 
     ![enter-role-details](../../../../assets/img/fragments/enter-role-details.png)
 
-4. Click **Finish** or you can click **Next** to specify permissions for the role. 
+4. Click **Finish** or you can click **Next** to specify permissions for the role.
+-->

--- a/en/docs/includes/artifact-binding-settings.md
+++ b/en/docs/includes/artifact-binding-settings.md
@@ -1,3 +1,4 @@
+
 ## Configure artifact expiration time
 
 According to the [SAML 2.0 Binding

--- a/en/docs/includes/attribute-dialects-oidc.md
+++ b/en/docs/includes/attribute-dialects-oidc.md
@@ -1,3 +1,4 @@
+<!--
 1.	Select **Main** > **Identity** > **Service Providers** > **List** and select the Service Provider you created in the first step.
 
 2.	Click **Edit**.
@@ -11,4 +12,5 @@
 6.	To make a selected claim mandatory, enable the corresponding checkboxes as shown below.
 	
 	![claim mapping oidc](../../../../assets/img/fragments/claim-mapping-oidc.png)
+-->
 

--- a/en/docs/includes/attribute-mapping.md
+++ b/en/docs/includes/attribute-mapping.md
@@ -1,3 +1,4 @@
+<!--
 When you are using more than one user store, you must map the attributes
 correctly by [adding a claim mapping](../../../../guides/dialects/add-claim-mapping/.
 
@@ -13,4 +14,5 @@ follows for `http://wso2.org/claims/emailaddress`.
 ``` java
 DEMO/mail
 ```
+-->
 

--- a/en/docs/includes/attributes-with-multiple-values.md
+++ b/en/docs/includes/attributes-with-multiple-values.md
@@ -1,3 +1,4 @@
+<!--
 If your user store supports multiple values for attributes, the
 WSO2 Identity Server can view, add, update, or delete them (normally
 LDAP/AD offer support for this). The following are the different ways
@@ -28,4 +29,5 @@ you can do this.
     ```
 
     The following screen shows how this looks in the LDAP.  
-    ![ldap-interface](../../../../assets/img/fragments/ldap-interface.png) 
+    ![ldap-interface](../../../../assets/img/fragments/ldap-interface.png)
+-->

--- a/en/docs/includes/configure-recaptcha-api-keys.md
+++ b/en/docs/includes/configure-recaptcha-api-keys.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure reCAPTCHA API keys
 
 [reCAPTCHA](https://developers.google.com/recaptcha/) is a free widget service provided by Google that can be used for protection against spam or other forms of internet abuse by verifying whether a user is a human or a robot. The following section guides you through setting up reCAPTCHA with WSO2 Identity Server.
@@ -21,3 +22,4 @@ First, you need to register and create an API key pair for the required domain. 
 
 5.  Take note of the site key and secret that you receive.
     ![note-site-key-secret](../../../../assets/img/fragments/copy-key.png) 
+-->

--- a/en/docs/includes/configure-recaptcha-for-sso.md
+++ b/en/docs/includes/configure-recaptcha-for-sso.md
@@ -1,4 +1,5 @@
 
+<!--
 1. Log in to the management console  (`https://<IS_HOST>:<IS_PORT>/carbon`).
 
 2. Click **Main** > **Identity** > **Identity Providers** > **Resident**.
@@ -32,5 +33,6 @@
     configured value, the following reCAPTCHA window appears.  
 
     ![captcha-login-failed](../../../../assets/img/guides/captcha-login-failed.png)
+-->
        
     

--- a/en/docs/includes/configure-resident-idp.md
+++ b/en/docs/includes/configure-resident-idp.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure the resident IdP
 
 1. Log in to the [Management Console](insertlink) using admin/admin credentials. 
@@ -15,3 +16,4 @@
     - **Remember Me Period**: This is the duration in weeks for which WSO2 Identity Server should remember an SSO session given that the **Remember Me** option is selected in the WSO2 Identity Server login screen.
 
         <img name='configure-resident-idp' src='../../../../assets/img/fragments/configure-resident-idp.png' class='img-zoomable'/>
+-->

--- a/en/docs/includes/connect-sms-provider.md
+++ b/en/docs/includes/connect-sms-provider.md
@@ -1,4 +1,5 @@
 
+<!--
 1. Download the certificate of the SMS provider.
 
     !!! example
@@ -14,3 +15,4 @@
     ```
 
 3. You are prompted to enter the keystore password. The default `client-truststore.jks` password is `wso2carbon`.
+-->

--- a/en/docs/includes/create-ldap-server.md
+++ b/en/docs/includes/create-ldap-server.md
@@ -1,3 +1,4 @@
+<!--
 ## Create an LDAP Server
 
 1.  Open Apache Directory Studio.
@@ -25,3 +26,4 @@
 7.  Right-click on the server and click **Run** to start the server.
 
     ![run-ldap-server](../../../../assets/img/fragments/run-ldap-server.png) 
+-->

--- a/en/docs/includes/deploy-travelocity-sp.md
+++ b/en/docs/includes/deploy-travelocity-sp.md
@@ -1,3 +1,4 @@
+<!--
 ### Configure the service provider
 
 !!! note "Important"
@@ -66,3 +67,4 @@ The next step is to configure the service provider.
 
 5.  Click **Register** to save the changes.  
     Now you are sent back to the Service Providers page.
+-->

--- a/en/docs/includes/edit-delete-role.md
+++ b/en/docs/includes/edit-delete-role.md
@@ -1,3 +1,4 @@
+<!--
 If you need to make modifications to a role, use the links in the
 **Actions** column on the **Roles** screen as follows:
 
@@ -13,3 +14,4 @@ If you need to make modifications to a role, use the links in the
     If the role is in an external userstore to which you are connected in
     read-only mode, you will be able to view the existing roles but not edit
     or delete them. However, you can still create new editable roles.
+-->

--- a/en/docs/includes/enable-account-locking.md
+++ b/en/docs/includes/enable-account-locking.md
@@ -1,3 +1,4 @@
+<!--
 1. 	Ensure that the identity listener with the
    `              priority=50             ` is set to **false** and
    the identity listener with the `              priority=95             ` is set to
@@ -49,3 +50,4 @@
 6.  To enable account locking for other tenants, log out and repeat the
    steps given above from [step 2](#lockingaspecificuseraccount)
    onwards.
+-->

--- a/en/docs/includes/enable-artifact-binding-console.md
+++ b/en/docs/includes/enable-artifact-binding-console.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure artifact binding
 
 1.  Click **Applications** and edit the application you registered. 
@@ -11,3 +12,4 @@
 4.  You can also enable signature validation by selecting **Enable signature validation for artifact binding**. Once this is enabled, WSO2 IS expects to receive signed artifact resolve requests and validates that signature against the service provider certificate. For more information, see the [Resolving SAML2 artifacts with WSO2 IS](../../../../quick-starts/use-artifact-binding-sample#resolve-artifacts-with-wso2-is) section.
 
 5.  Leave the rest of the default configurations as it is and click **Update**.
+-->

--- a/en/docs/includes/enable-artifact-binding.md
+++ b/en/docs/includes/enable-artifact-binding.md
@@ -1,3 +1,4 @@
+<!--
 ### Configure SAML artifact binding
 
 1.  Expand the **Inbound Authentication configuration** > **SAML2 Web SSO
@@ -17,3 +18,4 @@
 
 4.  Leave the rest of the default configurations as it is and click
     **Register**.
+-->

--- a/en/docs/includes/enable-email-as-username.md
+++ b/en/docs/includes/enable-email-as-username.md
@@ -1,3 +1,4 @@
+<!--
 !!! warning
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
@@ -121,3 +122,4 @@
         ***@carbon.super*** at the end of usernames.
 
 7.  Restart the server.
+-->

--- a/en/docs/includes/encrypt-id-tokens.md
+++ b/en/docs/includes/encrypt-id-tokens.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure the public certificate
 
 The following steps describe how to configure a service provider public certificate.
@@ -63,6 +64,7 @@ The following steps describe how to configure a service provider public certific
 
 		![JWKS URI](../../../../assets/img/guides/jwks-uri.png)
 
-7. Click **Update**. 
+7. Click **Update**.
+-->
 
 

--- a/en/docs/includes/fb-claim-mapping.md
+++ b/en/docs/includes/fb-claim-mapping.md
@@ -1,3 +1,4 @@
+<!--
 All the basic information of a user/application is stored in the form of
 claims. However, for the same information, different Identity Providers(IdP)
 have different claims. Therefore, there should be a proper mechanism to
@@ -94,3 +95,4 @@ For that follow the below steps:
 6.  Click **Update** to save changes.
 
 Now you have configured the Identity Server.
+-->

--- a/en/docs/includes/fb-review.md
+++ b/en/docs/includes/fb-review.md
@@ -1,3 +1,4 @@
+<!--
 !!!	info "About accessing the app"
 	The app is not available to the general public yet. To make the app available
 	to every Facebook user, you have to submit the app for review. After a
@@ -13,3 +14,4 @@
 	as Developers or Testers.
 	
 	![submit-fb-app-for-review](../../../../assets/img/samples/add-app-roles.png)
+-->

--- a/en/docs/includes/google-two-factor.md
+++ b/en/docs/includes/google-two-factor.md
@@ -1,6 +1,8 @@
+<!--
 If you are using a Google mail account, note that Google has restricted third-party apps and less secure apps from sending emails by default. Therefore, you need to configure your account to disable this restriction, as WSO2 Identity Server acts as a third-party application when sending emails to confirm user registrations or notifications for password reset. Follow the steps given below to enable your Google mail account to provide access to third-party applications.
 1.  Navigate to <https://myaccount.google.com/security>.
 2.  Click **Signing in to Google** and make sure that the **2-step Verification** is disabled or off.
     ![google-2-step-verification](../../../../assets/img/fragments/google-2-step-verification.png)
 3.  Click **Less secure app access** and enable **Allow less secure apps: ON**.
     ![allow-less-secure-apps](../../../../assets/img/fragments/allow-less-secure-apps.png)  
+-->

--- a/en/docs/includes/idp-facebook.md
+++ b/en/docs/includes/idp-facebook.md
@@ -1,3 +1,4 @@
+<!--
 1.  Go to **Facebook Configuration** under **Federated Authenticators**.
 
 2.  Enter the following values in the form that appears:
@@ -64,3 +65,4 @@
 4.  Click **Register**.
 
 You have now added the identity provider.
+-->

--- a/en/docs/includes/import-certificates.md
+++ b/en/docs/includes/import-certificates.md
@@ -1,3 +1,4 @@
+<!--
 ## Import certificate
 
 -   **Chrome**
@@ -23,3 +24,4 @@
     4.  Select the **localhost.p12** file, and then click **Open**. Note
         that you may have to enter the password that you used to generate
         the p12 file, (browserpwd) to open it.
+-->

--- a/en/docs/includes/local-outbound-for-request-path.md
+++ b/en/docs/includes/local-outbound-for-request-path.md
@@ -1,4 +1,5 @@
 
+<!--
 1. Expand the **Local & Outbound Authentication Configuration** section and then the **Request Path Authentication Configuration** section.
 
 2. Select **basic-auth** from the dropdown list and click **Add**.
@@ -6,3 +7,4 @@
     ![basic-auth-request-path-config](../../../../assets/img/fragments/basic-auth-request-path-config.png)
 
 3. Click **Update** to save changes to the service provider.
+-->

--- a/en/docs/includes/local-outbound-tenant-domain-in-sub-lvl2.md
+++ b/en/docs/includes/local-outbound-tenant-domain-in-sub-lvl2.md
@@ -1,3 +1,4 @@
+<!--
 ### Configure to sign the ID token with the user's tenant domain
 
 1. Expand the **Local & Outbound Authentication Configuration** section and select **Use tenant domain in local subject identifier** to sign the ID token with the user's tenant domain.
@@ -5,3 +6,4 @@
     ![use-tenant-domain-in-subject.png](../../../../assets/img/guides/use-tenant-domain-in-subject.png)
     
 2. Click **Update** to save the changes.
+-->

--- a/en/docs/includes/local-outbound-tenant-domain-in-sub-lvl3.md
+++ b/en/docs/includes/local-outbound-tenant-domain-in-sub-lvl3.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure to sign the ID token with the user's tenant domain
 
 1. Expand the **Local & Outbound Authentication Configuration** section and select **Use tenant domain in local subject identifier** to sign the ID token with the user's tenant domain.
@@ -5,3 +6,4 @@
     ![use-tenant-domain-in-subject.png](../../../../assets/img/guides/use-tenant-domain-in-subject.png)
     
 2. Click **Update** to save the changes.
+-->

--- a/en/docs/includes/oauth-app-pkce.md
+++ b/en/docs/includes/oauth-app-pkce.md
@@ -1,3 +1,4 @@
+<!--
 Make the following changes to the created service provider.
 
 1. Expand **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
@@ -21,3 +22,4 @@ Make the following changes to the created service provider.
         the requesting the code and the access token.
         
         - To configure more advanced configurations, see [OAuth/OpenID Connect Configurations](../../../../guides/login/oauth-app-config-advanced).
+-->

--- a/en/docs/includes/oauth-playground.md
+++ b/en/docs/includes/oauth-playground.md
@@ -1,5 +1,6 @@
 
 
+<!--
 {!./includes/deploying-sample-apps.md!}
 
 
@@ -10,9 +11,28 @@
 
 ---
 
-{!./includes/register-playground-application-portal.md!}
+## Register a service provider
 
-1.  Click **Update**.
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
+
+8. Click **Update**.
+-->
 
 
 

--- a/en/docs/includes/pickup-dispatch-oidc.md
+++ b/en/docs/includes/pickup-dispatch-oidc.md
@@ -1,3 +1,4 @@
+<!--
 {!./includes/deploying-sample-apps.md!}
 -   Download the sample from GitHub.
 
@@ -42,3 +43,4 @@ Next, deploy the sample web app on a web container.
 9.  Click **Add**. Note that the **OAuth Client Key** and **Client Secret** get generated. You will need these values later on when deploying the sample application.
 
 10.  Click the **Register** button to finish creating the service provider.
+-->

--- a/en/docs/includes/pickup-manager-oidc.md
+++ b/en/docs/includes/pickup-manager-oidc.md
@@ -1,4 +1,5 @@
 
+<!--
 {!./includes/deploying-sample-apps.md!}
 -   Download the sample from GitHub.
 
@@ -42,3 +43,4 @@ Next, deploy the sample web app on a web container.
         refer, [Advanced OAuth/OpenID Connect Configurations](../../../../guides/login/oauth-app-config-advanced).
 
 5.  Click **Register** to save the changes.
+-->

--- a/en/docs/includes/register-an-application-oauth-request-path.md
+++ b/en/docs/includes/register-an-application-oauth-request-path.md
@@ -1,7 +1,27 @@
-{!./includes/register-playground-application-portal.md!}
+<!--
+## Register a service provider
 
-13. Expand **Request Path Authentication**.
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
 
-14. Check **oauth-bearer** from the dropdown. 
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
 
-15. After all the configurations click **Update**.
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type](../../../references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}./guides/login/oidc-parameters-in-auth-request/).
+
+6. Click **Add**. Note that `client key` and `client secret` are generated.
+
+7. Expand **Request Path Authentication**.
+
+8. Check **oauth-bearer** from the dropdown. 
+
+9. After all the configurations click **Update**.
+-->

--- a/en/docs/includes/register-an-application-request-path.md
+++ b/en/docs/includes/register-an-application-request-path.md
@@ -1,3 +1,23 @@
-{!./includes/register-playground-application-portal.md!}
+<!--
+## Register a service provider
+
+1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
+
+2. Enter `playground2` as the **Service Provider Name** text box, and click **Register**.
+
+3. Expand the **Inbound Authentication Configuration > OAuth/OpenID Connect Configuration** and click **Configure**.
+
+4. Fill in the form that appears. By default, all **Allowed Grant Types** are selected; you can disable the grant types that are not required.
+
+    !!! note
+        The **custom** grant type will only appear on the UI if you have configured the JWT grant type. The value specified as the `name` of the `oauth.custom_grant_type` in the `deployment.toml` file when creating the custom grant type is the value that will appear on the UI. For more information on writing a custom grant type, see [Write a Custom OAuth 2.0 Grant Type]({{base_path}}/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type).
+
+5. Enter the **Callback Url** as `http://wso2is.local:8080/playground2/oauth2client`.
+
+    !!! tip
+        For more information on other advanced configurations refer, [Advanced OpenID Connect]({{base_path}}/guides/login/oidc-parameters-in-auth-request/).
+
+7. Click **Add**. Note that `client key` and `client secret` are generated.
 
 {!./includes/local-outbound-for-request-path.md!}
+-->

--- a/en/docs/includes/register-mobile-application.md
+++ b/en/docs/includes/register-mobile-application.md
@@ -1,3 +1,4 @@
+<!--
 1.	Start WSO2 IS.
 2.	Access the Management Console (https://<IS_HOST\>:<PORT\>/carbon) to create a service provider.
 	![Management Console](../../../../assets/img/fragments/android-sp.png)
@@ -18,5 +19,6 @@
 8.	Once the service provider is registered, you will be redirected to the **Service Provider Details** page. Here, expand the **Inbound Authentication Configuration** section and click the **OAuth/OpenID Connect Configuration** section. Copy the value of `OAuth Client Key` shown here.
 	
 	![android-client-id](../../../../assets/img/fragments/android-client-id.png)
+-->
 
 

--- a/en/docs/includes/register-playground-application-portal.md
+++ b/en/docs/includes/register-playground-application-portal.md
@@ -1,3 +1,4 @@
+<!--
 ## Register a service provider
 
 1. On WSO2 Identity Server Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.
@@ -17,3 +18,4 @@
         For more information on other advanced configurations refer, [Advanced OpenID Connect](../../../guides/login/oidc-parameters-in-auth-request/).
 
 7. Click **Add**. Note that `client key` and `client secret` are generated.
+-->

--- a/en/docs/includes/remember-me-console.md
+++ b/en/docs/includes/remember-me-console.md
@@ -1,3 +1,4 @@
+<!--
 1.   Access the [developer portal](insert-link). 
 
 2.   Select **Configurations** from the left panel. 
@@ -7,3 +8,4 @@
 4.   In the **Realm configurations** section, change the value for **Remember Me Period**.
 
      ![session-timeout](../../../../assets/img/fragments/session-timeout.png)
+-->

--- a/en/docs/includes/resident-saml-sample.md
+++ b/en/docs/includes/resident-saml-sample.md
@@ -1,7 +1,9 @@
+<!--
 1.	In the **Main** menu of the Management Console (`https://<IS_HOST>:<PORT>/carbon`), click **Resident** under **Identity Providers**.
 
 2.	On the page that appears, open the **SAML2 Web SSO Configuration** section under **Inbound Authentication Configuration**.
     
 3.	Make the value of the **Identity Provider Entity ID** field as same as the SAML endpoint of WSO2 Identity Server: `https://{yourhost}:{port}/samlsso`		
 	
-	![simeplesamlphp-resident](../../../../assets/img/fragments/simplesamlphp-resident.png))
+	![simeplesamlphp-resident](../../../../assets/img/fragments/simplesamlphp-resident.png)
+-->

--- a/en/docs/includes/resident-sp.md
+++ b/en/docs/includes/resident-sp.md
@@ -1,3 +1,4 @@
+<!--
 1.  In the **Main** menu under the **Identity** section, click
     **Resident** under **Service Providers**.
 2.  Expand the **Outbound Provisioning Configuration** on the screen
@@ -17,3 +18,4 @@
         Provisioning](../../../../guides/identity-lifecycles/rule-based-provisioning/)
 
 4.  Click **Update**.
+-->

--- a/en/docs/includes/saas-application-console.md
+++ b/en/docs/includes/saas-application-console.md
@@ -1,3 +1,4 @@
+<!--
 1.  Access the [developer portal](insert-link). 
 
 2.  Click the edit icon adjacent to the application for which you want to skip the consent step.  
@@ -9,3 +10,4 @@
 5.  Click **Update**.
 
      ![saas-enable](../../../../assets/img/guides/saas-enable-console.png))
+-->

--- a/en/docs/includes/saas-application.md
+++ b/en/docs/includes/saas-application.md
@@ -1,3 +1,4 @@
+<!--
 1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
 
 2. Navigate to the **Service Providers** tab listed under the **Identity** section and click **List**.
@@ -8,3 +9,4 @@
     ![saas-enable](../../../../assets/img/guides/saas-enable.png)
 
 5.  Click **Update** to save the changes.
+-->

--- a/en/docs/includes/session-timeout-console.md
+++ b/en/docs/includes/session-timeout-console.md
@@ -1,3 +1,4 @@
+<!--
 1.   Access the [developer portal](insert-link). 
 
 2.   Select **Configurations** from the left panel. 
@@ -7,3 +8,4 @@
 4.   In the **Realm configurations** section, change the value for **Idle Session Time Out**.
 
      ![session-timeout](../../../../assets/img/fragments/session-timeout.png)
+-->

--- a/en/docs/includes/set-mandatory-attributes.md
+++ b/en/docs/includes/set-mandatory-attributes.md
@@ -1,3 +1,5 @@
+<!--
 To make a selected claim mandatory, enable the corresponding checkboxes as shown below. 
 
 ![enable-mandate](../../../../assets/img/fragments/claim-mandatory-saml.png)
+-->

--- a/en/docs/includes/set-role-attribute.md
+++ b/en/docs/includes/set-role-attribute.md
@@ -1,3 +1,4 @@
+<!--
 1.	Expand **Roles/Permission Configuration**.
 
 2.	Expand **Role Mapping**.
@@ -7,3 +8,4 @@
 4.	Enter the value of the **Service Provider Role** as `Application/travelocity.com`.
     
 	![role map saml](../../../../assets/img/fragments/role-map-saml.png)
+-->

--- a/en/docs/includes/simplesaml-config-sample.md
+++ b/en/docs/includes/simplesaml-config-sample.md
@@ -1,3 +1,4 @@
+<!--
 1.	Expand **Inbound Authentication Configuration > SAML Configuration** and click **Configure**.
 
 2.	Enter the following details and keep the values of the rest of the fields as it is. 
@@ -16,4 +17,5 @@
 
 
     ![simplesamlphp-sp.png](../../../../assets/img/fragments/simplesamlphp-sp.png)
+-->
 

--- a/en/docs/includes/skip-user-consent-console.md
+++ b/en/docs/includes/skip-user-consent-console.md
@@ -1,4 +1,5 @@
 
+<!--
 1.  Access the [developer portal](insert-link). 
 
 2.  Click the edit icon adjacent to the application for which you want to skip the consent step.  
@@ -10,3 +11,4 @@
 5.  Click **Update**.
 
     ![skip login consent](../../../../assets/img/guides/skip-login-consent-console.png)
+-->

--- a/en/docs/includes/skip-user-consent.md
+++ b/en/docs/includes/skip-user-consent.md
@@ -1,4 +1,5 @@
 
+<!--
 1. Log in to the WSO2 Identity Server Management Console (`https://<IS_HOST>:<PORT>/carbon`) using administrator credentials (`admin:admin`).
 
 2. Navigate to the **Service Providers** tab listed under the **Identity** section and click **List**.
@@ -11,3 +12,4 @@
     ![skip login consent](../../../../assets/img/guides/skip-login-consent.png)
     
 5.  Click **Update** to save the changes.
+-->

--- a/en/docs/includes/sts-app-config-basic.md
+++ b/en/docs/includes/sts-app-config-basic.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure STS for the client app
 
 1. Expand **Inbound Authentication Configuration > WS-Trust Security Token Service Configuration** and click **Configure**.
@@ -10,4 +11,5 @@
 
         ![configure-sts](../../../../assets/img/fragments/configure-sts.png)
 
-3. Click **Update** to save the changes. 
+3. Click **Update** to save the changes.
+-->

--- a/en/docs/includes/sts-idp-config-basic.md
+++ b/en/docs/includes/sts-idp-config-basic.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure STS for the IdP
 
 1. Expand **Inbound Authentication Configuration > Security Token Service Configuration** and click **Apply Security Policy**.
@@ -12,4 +13,5 @@
 
 4. The next step depends on the selected security scenario. Follow the wizard and click **Finish**. 
 
-You have successfully configured and secured the Security Token Service. 
+You have successfully configured and secured the Security Token Service.
+-->

--- a/en/docs/includes/work-with-certificates.md
+++ b/en/docs/includes/work-with-certificates.md
@@ -1,8 +1,10 @@
+<!--
 ## Work with certificates
 
-X509 authentication requires the client to possess a Public Key Certificate (PKC). <!--- To know more about Public Key Certificate (PKC) and Certificate Authority (CA), refer [Working with certificates](TO DO: Concepts) -->
+X509 authentication requires the client to possess a Public Key Certificate (PKC). 
+<!--- To know more about Public Key Certificate (PKC) and Certificate Authority (CA), refer [Working with certificates](TO DO: Concepts) -->
 
-
+<!--
 To create a sample certificate and create your own Certificate Authority to sign the certificates, follow the following steps:
 
 1.  The first step is to create the private RSA key:
@@ -230,7 +232,7 @@ Follow the steps below to disable certificate validation if WSO2 Identity Server
 <!--- For more information on CRL and OCSP certificate validation, see
 [Configuring Certificate Revocation Validation](https://docs.wso2.com/display/ISCONNECTORS/Configuring+Certificate+Revocation+Validation). -->
 
-
+<!--
 ---
 
 ## Configure the Authentication Endpoint
@@ -327,3 +329,5 @@ your use case:
     Pack](#disable-certificate-validation-in-an-unstarted-wso2-is-pack)
 -   [Disabling Certificate Validation in an Already-started WSO2 IS
     Pack](#disable-certificate-validation-in-an-already-started-wso2-is-pack)
+-->
+

--- a/en/docs/includes/ws-fed-app-config.md
+++ b/en/docs/includes/ws-fed-app-config.md
@@ -1,3 +1,4 @@
+<!--
 ## Configure WS-Federation
 
 1.  Expand **Inbound Authentication Configuration** followed by the
@@ -30,7 +31,7 @@
 
 2.  Expand the **Claim Configuration** section and map the relevant claims. 
     <!--See [Request Attributes for the Application](../../../../guides/login/request-attributes/) for more information.-->
-    
+<!--
 3.  Click **Update** to save changes.
 
 !!! tip
@@ -43,3 +44,4 @@
     signature_algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
     digest_algorithm = "http://www.w3.org/2001/04/xmlenc#sha256"
     ```
+-->


### PR DESCRIPTION
This fix is introduced for the following reasons:

- links to images in the `includes` folder (which are single sourced) are broken due to an identified issue in the framework.
- The problem only exists in the live environment and cannot be recreated locally.

Therefore, removed the single sourcing of such content to test on the master branch.