### PR TITLE
Fix 404 url in customize error pages

### DIFF
--- a/en/docs/references/extend/errors/customize-error-pages.md
+++ b/en/docs/references/extend/errors/customize-error-pages.md
@@ -101,6 +101,6 @@ You can customize the above error message by following the instructions given be
 12. Restart WSO2 Identity Server.
 
 13. Access the following URL again to test the error page you customized: `https://localhost:9443/carbon/abc`.  
-    (make sure to login as admin in order to have access to the URL)
+    Be sure to log in as admin to have access to the URL.
     
     You will view the new error page with the following content: "Sorry, this resource is not found."

--- a/en/docs/references/extend/errors/customize-error-pages.md
+++ b/en/docs/references/extend/errors/customize-error-pages.md
@@ -3,7 +3,7 @@
 WSO2 Identity Server display errors, exceptions, and HTTP status codes in full detail. These are known as verbose error messages. These error messages contain technical details such as stack traces. There may also disclose other sensitive details. Attackers may fingerprint the server, based on the information disclosed in error messages. Alternatively, attackers may attempt to trigger specific error messages to obtain technical information about the server. You can avoid these situations by configuring the server to display generic, non-detailed error messages in Apache Tomcat.
 
 The pages that should be displayed on a certain throwable exception, error or an HTTP status code are specified in the
-`<IS_HOME>repository/conf/tomcat/carbon/WEB-INF/web.xml` file. You can customize those error pages as preferred. For example, if you try to access a resource that is not available in the Carbon server (e.g., https://localhost:9443/carbon/abc), you will see the "Error 404 - Not Found" page (make sure to login as admin in order to have access to that URL).
+`<IS_HOME>repository/conf/tomcat/carbon/WEB-INF/web.xml` file. You can customize those error pages as preferred. For example, if you try to access a resource that is not available in the Carbon server (e.g., https://localhost:9443/carbon/abc), you will see the "Error 404 - Not Found" page (be sure to log in as admin to have access to that URL).
 
 You can customize the above error message by following the instructions given below.
 

--- a/en/docs/references/extend/errors/customize-error-pages.md
+++ b/en/docs/references/extend/errors/customize-error-pages.md
@@ -3,7 +3,7 @@
 WSO2 Identity Server display errors, exceptions, and HTTP status codes in full detail. These are known as verbose error messages. These error messages contain technical details such as stack traces. There may also disclose other sensitive details. Attackers may fingerprint the server, based on the information disclosed in error messages. Alternatively, attackers may attempt to trigger specific error messages to obtain technical information about the server. You can avoid these situations by configuring the server to display generic, non-detailed error messages in Apache Tomcat.
 
 The pages that should be displayed on a certain throwable exception, error or an HTTP status code are specified in the
-`<IS_HOME>repository/conf/tomcat/carbon/WEB-INF/web.xml` file. You can customize those error pages as preferred. For example, if you try to access a resource that is not available in the Carbon server (e.g., https://localhost:9443/abc), you will see the "Error 404 - Not Found" page.
+`<IS_HOME>repository/conf/tomcat/carbon/WEB-INF/web.xml` file. You can customize those error pages as preferred. For example, if you try to access a resource that is not available in the Carbon server (e.g., https://localhost:9443/carbon/abc), you will see the "Error 404 - Not Found" page (make sure to login as admin in order to have access to that URL).
 
 You can customize the above error message by following the instructions given below.
 
@@ -100,6 +100,7 @@ You can customize the above error message by following the instructions given be
 
 12. Restart WSO2 Identity Server.
 
-13. Access the following URL again to test the error page you customized: `https://localhost:9443/abc`.  
+13. Access the following URL again to test the error page you customized: `https://localhost:9443/carbon/abc`.  
+    (make sure to login as admin in order to have access to the URL)
     
     You will view the new error page with the following content: "Sorry, this resource is not found."


### PR DESCRIPTION
## Purpose
The example URL given for an unavailable resource (in order to generate a 404) in existing **Customize Error Pages** documentation is no longer accessible. This PR updates that URL to an accessible URL which generates the 404 response.