### PR TITLE
Update `site_url` to latest documentation URL

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Identity Server Documentation
 site_description: Documentation for WSO2 Identity Server
 site_author: WSO2
-site_url: https://wso2.com/identity-and-access-management/
+site_url: https://is.docs.wso2.com/en/latest/
 
 # Repository
 repo_name: wso2/docs-is


### PR DESCRIPTION
## Purpose
Update `site_url` to point to the latest WSO2 Identity Server documentation URL.