### PR TITLE
Update `site_url` to temporarily point to 6.0.0

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -18,7 +18,7 @@
 site_name: WSO2 Identity Server Documentation
 site_description: Documentation for WSO2 Identity Server
 site_author: WSO2
-site_url: https://is.docs.wso2.com/en/latest/
+site_url: https://is.docs.wso2.com/en/6.0.0/
 
 # Repository
 repo_name: wso2/docs-is


### PR DESCRIPTION
## Purpose
Update `site_url` to temporarily point to 6.0.0 documentation. We need to update this accordingly when the next milestone starts. 