### PR TITLE
Add the connector downloading step

### DIFF
--- a/en/docs/guides/tenants/user-operation-notifications.md
+++ b/en/docs/guides/tenants/user-operation-notifications.md
@@ -16,7 +16,7 @@ information on how to send an email when a user operation takes place.
 3.  Enable the email sending configurations of the WSO2 Identity Server
     as explained [here]({{base_path}}/deploy/configure-email-sending/)
     
-2.  Configure the
+4.  Configure the
     `           <IS_HOME>/repository/conf/identity/msg-mgt.properties          `
     file with the desired destination configurations and template
     configurations. The following is a sample configuration for sending

--- a/en/docs/guides/tenants/user-operation-notifications.md
+++ b/en/docs/guides/tenants/user-operation-notifications.md
@@ -10,7 +10,9 @@ The configuration differs based on the type of notifications you want to
 send to the external endpoint. The following instructions provide
 information on how to send an email when a user operation takes place.
 
-1.  Enable the email sending configurations of the WSO2 Identity Server
+1.  Download the Email Notification Handler from [here](https://store.wso2.com/store/assets/isconnector/details/959b792a-efce-4b12-af9b-4744c650f6b2) and add the `org.wso2.carbon.identity.notification.mgt.email-x.x.x.jar` file in the `<IS_HOME>/repository/components/dropins` directory.
+
+3.  Enable the email sending configurations of the WSO2 Identity Server
     as explained [here]({{base_path}}/deploy/configure-email-sending/)
     
 2.  Configure the

--- a/en/docs/guides/tenants/user-operation-notifications.md
+++ b/en/docs/guides/tenants/user-operation-notifications.md
@@ -10,7 +10,8 @@ The configuration differs based on the type of notifications you want to
 send to the external endpoint. The following instructions provide
 information on how to send an email when a user operation takes place.
 
-1.  Download the Email Notification Handler from [here](https://store.wso2.com/store/assets/isconnector/details/959b792a-efce-4b12-af9b-4744c650f6b2) and add the `org.wso2.carbon.identity.notification.mgt.email-x.x.x.jar` file in the `<IS_HOME>/repository/components/dropins` directory.
+1.  Download the [Email Notification Handler](https://store.wso2.com/store/assets/isconnector/details/959b792a-efce-4b12-af9b-4744c650f6b2).
+2. Add the downloaded `org.wso2.carbon.identity.notification.mgt.email-x.x.x.jar` file into the `<IS_HOME>/repository/components/dropins` directory.
 
 3.  Enable the email sending configurations of the WSO2 Identity Server
     as explained [here]({{base_path}}/deploy/configure-email-sending/)


### PR DESCRIPTION
## Purpose
User operation notification process [1] do not work if the user didn't add the `Email Notification Handler` connector into dropins folder. That step needs to be included in the documentation. 

[1] https://is.docs.wso2.com/en/latest/guides/tenants/user-operation-notifications