### PR TITLE
[5.11.0] Re-enable Search

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -855,6 +855,7 @@ markdown_extensions:
   - pymdownx.tilde
 
 plugins:
+    - search
     - redirects:
           redirect_maps:
               'develop/setting-up-my-account-in-a-dev-environment.md': 'https://github.com/wso2/identity-apps/'


### PR DESCRIPTION
The Search for IS 5.11.0 docs was removed by mistake by [1]. When `Plugins` are introduced, we need to add `Search` manually.

[1] https://github.com/wso2/docs-is/pull/3455