### PR TITLE
Fix typo in IS-6.0.0API docs

### DIFF
--- a/en/docs/apis/overview.md
+++ b/en/docs/apis/overview.md
@@ -58,8 +58,8 @@ To enable this feature, add the following configuration to the **deployment.toml
     
     - If the user is in the primary userstore, the incoming cert CN should just be `<username>` e.g., `john`.
     - If the user is in a secondary userstore, the incoming cert CN should be `<userstore_domain>/<username>` e.g., `SECONDARY/john`.
-    - If the user is not a super tenant and belongs to the primary userstore, the incoming cert CN should be `<username@tenant_doman>` e.g., `john@abc.com`.
-    - If the user is not a super tenant and belongs to a secondary userstore, the incoming cert CN should be `<userstore_domain>/<username@tenant_doman>` e.g.,             `SECONDARY/john@abc.com`.
+    - If the user is not a super tenant and belongs to the primary userstore, the incoming cert CN should be `<username@tenant_domain>` e.g., `john@abc.com`.
+    - If the user is not a super tenant and belongs to a secondary userstore, the incoming cert CN should be `<userstore_domain>/<username@tenant_domain>` e.g.,             `SECONDARY/john@abc.com`.
 
 ## REST API Authorization 
 
@@ -73,10 +73,10 @@ You can configure user role permissions to restrict access to resources. To do s
 
     | Parameter            |    Description                                                                                                                                                   | Sample Value                                               |
     |----------------------|    ---------------------------------------------------------------------------------------------------------------------   ----------------------------------------|------------------------------------------------------------|
-    | **context** | The resource context that needs to be secured relative to the root context, .                                                                  | `                 /api/identity/  *                `         |
+    | **context** | The resource context that needs to be secured relative to the root context, .                                                                  | `                 /api/identity/*                `         |
     | **secured**          | Enable or disable security in the given resource     context.                                                                         | `                    true                `                    |
     | **http_method**      | Specify an HTTP method i.e `                 all                `, `                   post                `, `                 get                `, etc. | `                 all                   `                     |
-    | **permissions**      | The user role permission that is required to authorize the resource. You can  enter multiple permission strings in a comma-separated list.      | `                 /permission/admin/ login                ` |
+    | **permissions**      | The user role permission that is required to authorize the resource. You can  enter multiple permission strings in a comma-separated list.      | `                 /permission/admin/login                ` |
     | **scope**      | Scopes that an access token requires to access the resource. You can enter multiple     scopes in a comma-separated list.     | `                 internal_idp_create                ` |
 
     !!! abstract ""


### PR DESCRIPTION
## Purpose
Typo:
![Screenshot - 2022-10-01T115153 974](https://user-images.githubusercontent.com/25483865/193395811-fc70afa1-6ec0-47fe-92ff-0dcff452a7b3.png)

unwanted spaces in permission strings:
![Screenshot - 2022-10-01T115622 311](https://user-images.githubusercontent.com/25483865/193396063-a87d14cd-6893-43a1-b8cf-d6c6295b48c0.png)

