### PR TITLE
Update typingdna-based-adaptive-auth.md

### DIFF
--- a/en/docs/guides/adaptive-auth/typingdna-based-adaptive-auth.md
+++ b/en/docs/guides/adaptive-auth/typingdna-based-adaptive-auth.md
@@ -1,6 +1,6 @@
 # Configure TypingDNA-based adaptive Authentication
 
-[Typing DNA](https://www.typingdna.com/) uses AI-based technology to identify users according to the way they type.
+[Typing DNA](https://www.typingdna.com/) uses AI-based technology to authenticate users according to the way they type.
 
 You can integrate typingDNA with WSO2 Identity Server to provide risk-based adaptive authentication for users.
 


### PR DESCRIPTION
Summary: TypingDNA doesn't do **identification**, but **authentication** (very different in the context of identity access), I think it needs to be clear, hence the proposed 1 word change.

