### PR TITLE
Add the content related to "showAuthFailureReasonOnLoginPage" property

### DIFF
--- a/en/docs/references/extend/errors/customize-authentication-error-messages.md
+++ b/en/docs/references/extend/errors/customize-authentication-error-messages.md
@@ -26,3 +26,15 @@ The following query parameters are sent to the web application from authenticati
 -   remainingAttempts
 
 The error messages can be customized based on these query parameters in the jsp files as in  `authenticationendpoint/login.jsp`.
+
+After adding `showAuthFailureReason` property, user will be redirected to the `retry.do` page with the above mentioned query parameters. 
+
+If any user wants to show the error message on the `login page` without redirecting to any other page, the following properties can be used to show the authentication error message on the login page.
+
+```toml
+[authentication.authenticator.basic.parameters]
+showAuthFailureReason = true
+showAuthFailureReasonOnLoginPage = true
+```
+
+

--- a/en/docs/references/extend/errors/customize-authentication-error-messages.md
+++ b/en/docs/references/extend/errors/customize-authentication-error-messages.md
@@ -27,7 +27,7 @@ The following query parameters are sent to the web application from authenticati
 
 The error messages can be customized based on these query parameters in the jsp files as in  `authenticationendpoint/login.jsp`.
 
-After adding `showAuthFailureReason` property, user will be redirected to the `retry.do` page with the above mentioned query parameters. 
+If the `showAuthFailureReason` property is enabled, the user will be redirected to the `retry.do` page with the above mentioned query parameters during the authentication flow.
 
 If any user wants to show the error message on the `login page` without redirecting to any other page, the following properties can be used to show the authentication error message on the login page.
 

--- a/en/docs/references/extend/errors/customize-authentication-error-messages.md
+++ b/en/docs/references/extend/errors/customize-authentication-error-messages.md
@@ -29,7 +29,7 @@ The error messages can be customized based on these query parameters in the jsp 
 
 If the `showAuthFailureReason` property is enabled, the user will be redirected to the `retry.do` page with the above mentioned query parameters during the authentication flow.
 
-If any user wants to show the error message on the `login page` without redirecting to any other page, the following properties can be used to show the authentication error message on the login page.
+If you want to show the error message on the login page without redirecting the user to any other page, the following properties can be used to show the authentication error message on the login page.
 
 ```toml
 [authentication.authenticator.basic.parameters]


### PR DESCRIPTION
Introduced a new toml property(**showAuthFailureReasonOnLoginPage**) to show the authentication error message on the login page.

This property is connected with the **showAuthFailureReason** property.

```
[authentication.authenticator.basic.parameters]
showAuthFailureReason = true
showAuthFailureReasonOnLoginPage = true
```

Enabling both properties in the deployment.toml, the account locked error message will be displayed on the login page.
