### PR TITLE
Add documentation related to AuthenticationContext expiry validations

### DIFF
--- a/en/docs/deploy/migrate/what-has-changed.md
+++ b/en/docs/deploy/migrate/what-has-changed.md
@@ -77,7 +77,7 @@ From IS 6.0.0 onward the ```AuthenticationContext``` will have an expiry time an
 expire_pre_session_data_after = "60m"       // timeout in minutes.
 ```
 
-If the validations for expired authentication contexts need to be disabled, you may do so by adding following configuration to the ```deployment.toml``` file.
+If validations for expired authentication contexts need to be disabled, you may do so by adding the following configuration to the ```deployment.toml``` file.
 
 ```js
 [session.authentication.context]

--- a/en/docs/deploy/migrate/what-has-changed.md
+++ b/en/docs/deploy/migrate/what-has-changed.md
@@ -69,6 +69,21 @@ code_validity_period = <time>
 ## Authentication
 This section contains the updates done to the Authentication features of IS 6.0.0.
 
+### Authentication Context
+From IS 6.0.0 onward the ```AuthenticationContext``` will have a expiry time and expired contexts will not be considered during authentication. The expiry time is set to be equal to the temporary session data cleanup time period and can be changed by adding following configuration to the ```deployment.toml``` file.
+
+``` js
+[session_data.cleanup]
+expire_pre_session_data_after = "60m"       // timeout in minutes.
+```
+
+If the validations for expired authentication contexts need to be disabled, you may do so by adding following configuration to the ```deployment.toml``` file.
+
+```js
+[session.authentication.context]
+expiry.validation = false
+```
+
 ### OTP Authenticator
 Some significant changes have been made to the below mentioned OTP authenticators. Please follow the instructions given below to incorporate your custom OTP requirements and changes to Identity Server 6.0.0.
 

--- a/en/docs/deploy/migrate/what-has-changed.md
+++ b/en/docs/deploy/migrate/what-has-changed.md
@@ -70,7 +70,7 @@ code_validity_period = <time>
 This section contains the updates done to the Authentication features of IS 6.0.0.
 
 ### Authentication Context
-From IS 6.0.0 onward the ```AuthenticationContext``` will have a expiry time and expired contexts will not be considered during authentication. The expiry time is set to be equal to the temporary session data cleanup time period and can be changed by adding following configuration to the ```deployment.toml``` file.
+From IS 6.0.0 onward the ```AuthenticationContext``` will have an expiry time and the expired contexts will not be considered during authentication. The expiry time is set to be equal to the temporary session data cleanup time period and can be changed by adding the following configuration to the ```deployment.toml``` file.
 
 ``` js
 [session_data.cleanup]


### PR DESCRIPTION
## Purpose
With the fix for https://github.com/wso2/carbon-identity-framework/pull/4327, we will be introducing an expiry time and related validations to the AuthenticationContext object. This change need to be documented properly.

## Related Issues
- https://github.com/wso2/product-is/issues/15140