### PR TITLE
Self-contained magic link authenticator

### DIFF
--- a/en/docs/guides/passwordless/magic-link.md
+++ b/en/docs/guides/passwordless/magic-link.md
@@ -17,7 +17,7 @@ To configure Magic Link as an authenticator:
 
 3. Expand the **Local and Outbound Authentication Configuration** section.
 
-4. For **Authentication Type**, select the **Local Authentication** radio button and select **Magic Link** from the dropdown list under **Local Authentication**.
+4. For **Authentication Type**, select the **Local Authentication** option and then select **Magic Link** from the list.
 
 5. Click **Update** to save the configurations.
 

--- a/en/docs/guides/passwordless/magic-link.md
+++ b/en/docs/guides/passwordless/magic-link.md
@@ -15,20 +15,11 @@ To configure Magic Link as an authenticator:
 
 2. Click **Edit** on the `saml2-web-app-pickup-dispatch.com` service provider.
 
-3. Expand the **Local and Outbound Authentication Configuration** section and click **Advanced Configuration**.
+3. Expand the **Local and Outbound Authentication Configuration** section.
 
-4. You will be redirected to **Advanced Configuration**.
+4. For **Authentication Type**, select the **Local Authentication** radio button and select **Magic Link** from the dropdown list under **Local Authentication**.
 
-5. Click **+ Add Authentication Step** twice to add two authentication steps.
-
-6. Select the following authentication methods from the relevant dropdowns and click **+ Add Authenticator**.
-
-    | Authentication step   | Local Authenticator      |
-    |--------------------------|-----------------------|
-    | First step    | `identity-first handler` |
-    | Second step   | `Magic Link`             |
-
-7. Click **Update** to save the configurations.
+5. Click **Update** to save the configurations.
 
 ## Try it out
 


### PR DESCRIPTION
## Purpose
The mentioned PRs introduce a self-contained magic link authenticator that no longer requires the addition of identifier first authenticator prior to adding magic link authenticator. This PR updates IS docs related to this change.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/15145

### Related PRs
- PR https://github.com/wso2/identity-apps/pull/3654
- PR https://github.com/wso2-extensions/identity-local-auth-magiclink/pull/25
- PR https://github.com/wso2/carbon-identity-framework/pull/4337