### PR TITLE
Config for tenant-wise email OTP sending

### DIFF
--- a/en/docs/learn/configuring-email-otp.md
+++ b/en/docs/learn/configuring-email-otp.md
@@ -52,7 +52,7 @@ SendGrid APIs. Follow the instructions in **one** of **Option1** or
            <subject>WSO2 IS Email OTP</subject>
            <body>
               Hi,
-              Please use this one time password {OTPCode} to sign-in to your application.
+              Please use this one time password {{OTPCode}} to sign-in to your application.
            </body>
            <footer>
               Best Regards,
@@ -87,6 +87,7 @@ SendGrid APIs. Follow the instructions in **one** of **Option1** or
         CaptureAndUpdateEmailAddress = true
         showEmailAddressInUI = true
         tokenExpirationTime = 300000
+        useEventHandlerBasedEmailSender = true
         ``` 
     
     

--- a/en/docs/learn/configuring-email-otp.md
+++ b/en/docs/learn/configuring-email-otp.md
@@ -52,7 +52,7 @@ SendGrid APIs. Follow the instructions in **one** of **Option1** or
            <subject>WSO2 IS Email OTP</subject>
            <body>
               Hi,
-              Please use this one time password {{OTPCode}} to sign-in to your application.
+              Please use this one-time password {{OTPCode}} to sign in to your application.
            </body>
            <footer>
               Best Regards,


### PR DESCRIPTION
## Purpose
This PR fixes the issue of not  sending email OTP according to the tenant-wise configurations.

## Issue
* Issue [IS 5.8] : https://github.com/wso2/product-is/issues/8544

## Description
The email OTP must be able to be sent by using separate tenant-wise configurations. But it was only sent using the default admin configs that we provide in the deployment.toml file, even though we provided separate configurations. This was caused due to not adding the `useEventHandlerBasedEmailSender = true` config. 

This PR also fixes the example email template formatting for this scenario.

## Goals
This enables the configuration which enables the use of tenant-wise notification sender.

## Documentation
* Configuring Email OTP: https://is.docs.wso2.com/en/5.9.0/learn/configuring-email-otp/

## Related PRs
* PR fixing the issue mentioned above [IS 5.9]: https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/87