### PR TITLE
Fix placeholders in callback URL

### DIFF
--- a/en/docs/guides/access-delegation/auth-code-playground.md
+++ b/en/docs/guides/access-delegation/auth-code-playground.md
@@ -48,7 +48,7 @@ This page guides you through using a sample Playground application to try out au
 
     - **Client ID**: The OAuth Client Key received when registering the service provider.
 
-    - **Callback URL**: `http://<IS_HOST>:<IS_PORT>/playground2/oauth2client`
+    - **Callback URL**: `http://<TOMCAT_HOST>:<TOMCAT_PORT>/playground2/oauth2client`
 
     - **Authorize Endpoint**: `https://<IS_HOST>:<IS_PORT>/oauth2/authorize`
 
@@ -92,7 +92,7 @@ This page guides you through using a sample Playground application to try out au
 
 5. Provide the requested consent and enter the following details on the screen that appears. 
 
-    - **Callback URL:** `http://<IS_HOST>:<IS_PORT>/playground2/oauth2client`
+    - **Callback URL:** `http://<TOMCAT_HOST>:<TOMCAT_PORT>/playground2/oauth2client`
 
     - **Access Token Endpoint:** `https://<IS_HOST>:<IS_PORT>/oauth2/token` 
 

--- a/en/docs/guides/access-delegation/implicit-playground.md
+++ b/en/docs/guides/access-delegation/implicit-playground.md
@@ -48,7 +48,7 @@ This page guides you through using a sample Playground application to try out au
     
     - **Client ID**: The OAuth Client Key received when registering the service provider.
     
-    - **Callback URL**: `http://<IS_HOST>:<IS_PORT>/playground2/oauth2client`
+    - **Callback URL**: `http://<TOMCAT_HOST>:<TOMCAT_PORT>/playground2/oauth2client`
 
 	- **Authorize Endpoint**: `https://<IS_HOST>:<IS_PORT>/oauth2/authorize`
     


### PR DESCRIPTION
## Purpose
Placeholders in the callback URL should include the tomcat host and the tomcat port.