### PR TITLE
 Add proper config for cache name in Private Key JWT Client Authentication 

### DIFF
--- a/en/docs/guides/access-delegation/private-key-jwt-client-authentication-for-oidc.md
+++ b/en/docs/guides/access-delegation/private-key-jwt-client-authentication-for-oidc.md
@@ -67,7 +67,7 @@ artifacts.
 
     ```toml
     [[cache.manager]]
-    name="IdentityApplicationManagementCacheManager"
+    name="PrivateKeyJWT"
     timeout="10"
     capacity="5000"
     ```


### PR DESCRIPTION
## Purpose
Config Provided in the Doc is wrong. Correct name is `PrivateKeyJWT` (Tested)

Ref: https://github.com/wso2-extensions/identity-oauth-addons/blob/68c95b51fe3cbd1f49c01e4e8c7243448054e08b/component/client-handler/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/cache/JWTCache.java#L28

Master PR: https://github.com/wso2/docs-is/pull/3582