### PR TITLE
Correct userinfo endpoint URL

### DIFF
--- a/en/docs/references/concepts/authentication/user-information.md
+++ b/en/docs/references/concepts/authentication/user-information.md
@@ -42,7 +42,7 @@ The format of the curl command is given below.
 Request
 
 ``` java
-curl -k -v -H "Authorization: Bearer <ACCESS_TOKEN>" https://<IS_HOST>:<IS_PORT>/userinfo
+curl -k -v -H "Authorization: Bearer <ACCESS_TOKEN>" https://<IS_HOST>:<IS_PORT>/oauth2/userinfo
 ```
  
  Response


### PR DESCRIPTION
## Purpose
> The userinfo URL (`https://<IS_HOST>:<IS_PORT>/userinfo`) mentioned in [this](https://is.docs.wso2.com/en/latest/references/concepts/authentication/user-information/#invoke-the-userinfo-endpoint) section of wso2 is docs is invalid. It should be corrected as `https://<IS_HOST>:<IS_PORT>/oauth2/userinfo`

## Related Issue
- https://github.com/wso2/product-is/issues/15368

## Test environment
- JDK versions - 11
- operating systems macOS
- browser/versions - chrome, firefox
 