### PR TITLE
Removed unnecessary section divider

### DIFF
--- a/en/docs/guides/access-delegation/saml2-bearer-assertion-profile.md
+++ b/en/docs/guides/access-delegation/saml2-bearer-assertion-profile.md
@@ -270,7 +270,6 @@ For example,
         }]
     }
     ```
-----
 
 !!! info "Related topics"
     -   [Concept: SAML2 Bearer Assertion Profile for OAuth 2.0]({{base_path}}/references/concepts/authorization/saml2-bearer-assertion-profile)


### PR DESCRIPTION
## Purpose
There was a unexpected subsection under the [Set Up SAML2 Bearer Assertion Profile](https://is.docs.wso2.com/en/latest/guides/access-delegation/saml2-bearer-assertion-profile/#log-in-with-saml) section. This was caused by an unnecessary section divider.

## Related issues
- https://github.com/wso2/product-is/issues/15387

<img width="1143" alt="Screenshot 2023-01-20 at 11 59 33" src="https://user-images.githubusercontent.com/47152272/213631898-e33af9d7-91bd-4d0b-aec7-25cdf6e5462f.png">

## Test environment
- JDK versions - 11
- operating systems macOS
- browser/versions - Firefox, Chrome
 