### PR TITLE
[6.1.0] TEMPORARY Remove version drop down

### DIFF
--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -40,24 +40,26 @@
           {% else %}
             <span class="md-header-nav__topic">
               {{ config.site_name | replace('WSO2', '') }}
-              <span class="beta-badge">This documentation version is <b>work in progress.</b></span>
+              <span class="beta-badge">This is the documentation for WSO2 IS 6.1.0 RC and it is currently <b>work in progress.</b></span>
             </span>
             <span class="md-header-nav__topic">
               {{ page.title }}
             </span>
           {% endif %}
         </div>
+        <!--
         <div class="md-flex__ellipsis md-header__version-select">
           <div class="mb-tabs__dropdown version-select">
               <a class="md-tabs__link md-tabs__dropdown-link" href="#!" data-target="version-select-dropdown">{{ config.extra.site_version }}</a>
               <ul id="version-select-dropdown" class="mb-tabs__dropdown-content" tabindex="0">
-                  <!-- Versions will added here dynamically -->
+                   Versions will added here dynamically
                   <li class="md-tabs__item mb-tabs__dropdown">
                       <a href="#" id="show-all-versions-link">Show all</a>
                   </li>
               </ul>
           </div>
         </div>
+        -->
       </div>
       <div class="md-flex__cell md-flex__cell--shrink">
         {% if "search" in config["plugins"] %}


### PR DESCRIPTION
Removing the versions drop-down menu from the 6.1.0 site temporarily until GA.

<img width="1526" alt="Screenshot 2023-01-24 at 23 07 51" src="https://user-images.githubusercontent.com/21237558/214366860-82fbb5b4-10db-4cb0-9e06-48d18c3c9bda.png">
