### PR TITLE
[6.1.0] Change base path to 6.1.0

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -803,6 +803,7 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
   - attr_list
+
 plugins:
     - search
     - markdownextradata: {}
@@ -1452,7 +1453,7 @@ extra:
     - type: linkedin
       link: https://www.linkedin.com/company/wso2
   site_version: 6.0.0
-  base_path: https://is.docs.wso2.com/en/6.0.0
+  base_path: https://is.docs.wso2.com/en/6.1.0
   #base_path: http://127.0.0.1:8000
 
   nav_list:


### PR DESCRIPTION
Included changes:

- Changing base path to 6.1.0 URL
- Temporarily removing the version picker until GA. 