### PR TITLE
Update the API docs with application user-registrant retrieval API

### DIFF
--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -2586,6 +2586,10 @@ components:
           type: boolean
           description: Decides whether authorization policies needs to be engaged during authentication flows.
           example: true
+        fragment:
+          type: boolean
+          description: Decides whether application is a fragment application.
+          example: false
         additionalSpProperties:
           $ref: '#/components/schemas/AdditionalProperties'
     AdditionalProperties:

--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -547,6 +547,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /applications/{applicationId}/user-registrants:
+    get:
+      tags:
+        - User registrants
+      summary: |
+        Get the list of user registrants configured for the given application.
+      operationId: getConfiguredUserRegistrants
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRegistrantsList'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /applications/resident:
     get:
       tags:
@@ -2211,7 +2254,7 @@ components:
       description: |
         Specifies the required parameters in the response.
         Only 'advancedConfigurations', 'templateId', 'clientId', and 'issuer' attributes are currently supported.
-        
+
         /applications?attributes=advancedConfigurations,templateId,clientId,issuer
       schema:
         type: string
@@ -2505,15 +2548,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConfiguredAuthenticator'
-      ConfiguredAuthenticator:
-        type: object
-        properties:
-          name:
-            type: string
-            example: sampleIdP
-          type:
-            type: string
-            example: SampleAuthenticator
+    ConfiguredAuthenticator:
+      type: object
+      properties:
+        name:
+          type: string
+          example: sampleIdP
+        type:
+          type: string
+          example: SampleAuthenticator
     AdvancedApplicationConfiguration:
       type: object
       properties:
@@ -3412,6 +3455,55 @@ components:
           example: "85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
       required:
         - id
+
+    UserRegistrantsList:
+      type: object
+      properties:
+        totalResults:
+          type: integer
+          description: "Number of user registrants."
+          example: 2
+        userRegistrants:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserRegistrant'
+
+    UserRegistrant:
+      type: object
+      properties:
+        id:
+          type: string
+          description : "Unique id for the user registrant based on its name."
+          example: "8we2f4b8-0d22-8234-l4n7-1682a91b12cn"
+        name:
+          type: string
+          description : "Name of the user registrant."
+          example: "BasicAuthAttributeHandler"
+        authAttributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthAttribute'
+
+    AuthAttribute:
+      type: object
+      properties:
+        attribute:
+          type: string
+          decription: "Name of the attribute."
+          example: "password"
+        isClaim:
+          type: boolean
+          decription: "Defines whether the attribute is a claim."
+          example: true
+        isConfidential:
+          type: boolean
+          decription: "Defines whether the attribute contains confidential data."
+          example: true
+        attributeType:
+          type: string
+          decription: "Data type of value of the attribute."
+          example: "string"
+
     Error:
       type: object
       properties:


### PR DESCRIPTION
## Purpose
With the PR, https://github.com/wso2/identity-api-server/pull/417, a new endpoint is added to the application management API to retrieve the business user registration options configured against a given application. This PR is to update the API documentation accordingly.

Main Issue 
https://github.com/wso2/product-is/issues/15471