### PR TITLE
[6.2.0] JWT reuseability when preventToeknReuse is fasle

### DIFF
--- a/en/docs/guides/access-delegation/private-key-jwt-client-authentication-for-oidc.md
+++ b/en/docs/guides/access-delegation/private-key-jwt-client-authentication-for-oidc.md
@@ -57,7 +57,7 @@ artifacts.
 
     | Property              | Description                                                                                                                                                                                             |
     |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-    | PreventTokenReuse     | If this is set to "false," the JWT can be reused again within its expiration period.  If this is set to "true," the JWT can be used only once. |
+    | PreventTokenReuse     | If this is set to "false," the JWT can be reused within its expiration period.  If this is set to "true," the JWT can be used only once. |
     | RejectBeforeInMinutes | The JWT should be rejected and considered as a too old token, if the issued time of the JWT exceeds the configured time.                                                                                |
     | TokenEndpointAlias    | An audience that can be added from the above configuration.                                                                                                                                             |
 

--- a/en/docs/guides/access-delegation/private-key-jwt-client-authentication-for-oidc.md
+++ b/en/docs/guides/access-delegation/private-key-jwt-client-authentication-for-oidc.md
@@ -57,7 +57,7 @@ artifacts.
 
     | Property              | Description                                                                                                                                                                                             |
     |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-    | PreventTokenReuse     | If this is set to "true", the JTI in the JWT should be unique per the request if the previously used JWT is not already expired. JTI (JWT ID) is a claim that provides a unique identifier for the JWT. |
+    | PreventTokenReuse     | If this is set to "false," the JWT can be reused again within its expiration period.  If this is set to "true," the JWT can be used only once. |
     | RejectBeforeInMinutes | The JWT should be rejected and considered as a too old token, if the issued time of the JWT exceeds the configured time.                                                                                |
     | TokenEndpointAlias    | An audience that can be added from the above configuration.                                                                                                                                             |
 


### PR DESCRIPTION
## Purpose
We are changing the behavior of preventToeknReuse configuration. 

As an improvement with common industrial practice, If token reuse is configured then we should allow reusing the token within the expiry time. Hence the expected behaviors are,
1. If preventToeknReuse is false, the token can be reused again within its expiration period.
2. If preventToeknReuse is true, the token can be used only once irrespective of expiration time.
