### PR TITLE
Added new API /applications/{applicationId}/exportFile

### DIFF
--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -142,11 +142,11 @@ paths:
       tags:
         - Applications
       summary: |
-        Create application from an exported XML file
+        Create application from an exported XML, YAML, or JSON file
       operationId: importApplication
       description: >
-        This API provides the capability to store the application information,
-        provided as a file.<br>
+        This API provides the capability to create an application based on the 
+        information provided in an XML, YAML, or JSON file.<br>
           <b>Permission required:</b> <br>
               * /permission/admin/manage/identity/applicationmgt/create <br>
           <b>Scope required:</b> <br>
@@ -191,10 +191,11 @@ paths:
       tags:
         - Applications
       summary: |
-        Update application from an exported XML file
+        Update application from an exported XML, YAML, or JSON file
       operationId: importApplicationForUpdate
       description: >
-        This API provides the capability to update an application from information that has been exported as an XML file.<br>
+        This API provides the capability to update an application based on the 
+        information provided in an XML, YAML, or JSON file.<br>
           <b>Permission required:</b> <br>
               * /permission/admin/manage/identity/applicationmgt/update <br>
           <b>Scope required:</b> <br>

--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -446,6 +446,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /applications/{applicationId}/exportFile:
+    get:
+      tags:
+        - Applications
+      operationId: exportApplicationAsFile
+      summary: |
+        Export application in XML, YAML, or JSON file formats.
+      description: |
+        This API provides the capability to retrieve the application in XML, YAML, or JSON format.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/applicationmgt/view <br>
+          <b>Scope required:</b> <br>
+              * internal_application_mgt_view
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/exportSecretsQueryParam'
+        - $ref: '#/components/parameters/fileTypeHeaderParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 'Sample application configuration in the requested format'
+            application/yaml:
+              schema:
+                type: string
+              example: 'Sample application configuration in the requested format'
+            application/xml:
+              schema:
+                type: string
+              example: 'Sample application configuration in the requested format'
+            application/octet-stream:
+              schema:
+                type: string
+              example: 'Sample application configuration in the requested format'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /applications/{applicationId}/owner:
     put:
       tags:
@@ -2267,6 +2331,21 @@ components:
       schema:
         type: boolean
         default: false
+    fileTypeHeaderParam:
+      in: header
+      name: Accept
+      required: false
+      description: |
+        Content type of the file.
+      schema:
+        type: string
+        default: application/xml
+        enum:
+          - application/json
+          - application/xml
+          - application/yaml
+          - application/x-yaml
+          - text/yaml
     inboundProtocolsCustomOnly:
       in: query
       name: customOnly

--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -191,7 +191,7 @@ paths:
       tags:
         - Applications
       summary: |
-        Update application from an exported XML, YAML, or JSON file
+        Update application from an exported XML, YAML, or JSON file.
       operationId: importApplicationForUpdate
       description: >
         This API provides the capability to update an application based on the 

--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -142,7 +142,7 @@ paths:
       tags:
         - Applications
       summary: |
-        Create application from an exported XML, YAML, or JSON file
+        Create application from an exported XML, YAML, or JSON file.
       operationId: importApplication
       description: >
         This API provides the capability to create an application based on the 


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15461

Add support for SP configurations export in XML, YAML, and JSON file formats.

## Goals
When the required file type is given, this will export/import Service Providers in either XML, YAML, or JSON file formats.

## Approach
New API is added to accept and export a file in a given file type.

**GET  /applications/{applicationId}/exportFile**

Existing APIs are updated to import/update a SP with the given file type.

**POST  /applications/import**
**PUT  /applications/import**

## Related PRs
https://github.com/wso2/identity-api-server/pull/426
https://github.com/wso2/carbon-identity-framework/pull/4451