### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -353,7 +353,7 @@ Possible values:<br />
 SHA - Uses SHA digest method. SHA-1, SHA-256<br />
 MD5 - Uses MD 5 digest method.<br />
 PLAIN_TEXT - Plain text passwords.(Default)</p>
-<p>If you just configure as SHA, It is considered as SHA-1, It is always better to configure algorithm with higher bit value as digest bit size would be increased.<br />
+<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use at least SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since digest bit size would be increased.<br />
 <br />
 Most of the LDAP servers (such as OpenLdap, OpenDJ, AD, ApacheDS and etc.) are supported to store passwords as salted hashed values (SSHA).<br />
 Therefore, the WSO2 IS requires the password fed in to the connected userstore as a plain text value. Then the LDAP userstore can store them as a salted hashed value. To feed the plain text into the LDAP server, you need to set PasswordHashMethod to “PLAIN_TEXT”.<br />

--- a/en/docs/deploy/configure-a-read-write-ldap-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-ldap-user-store.md
@@ -321,7 +321,7 @@ Possible values:<br />
 SHA - Uses SHA digest method. SHA-1, SHA-256<br />
 MD5 - Uses MD 5 digest method.<br />
 PLAIN_TEXT - Plain text passwords.(Default)</p>
-<p>If you just configure as SHA, It is considered as SHA-1, It is always better to configure algorithm with higher bit value as digest bit size would be increased.<br />
+<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use at least SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since digest bit size would be increased.<br />
 <br />
 Most of the LDAP servers (such as OpenLdap, OpenDJ, AD, ApacheDS and etc..) are supported to store password as salted hashed values (SSHA)<br />
 Therefore WSO2IS server just wants to feed password into the connected userstore as a plain text value. Then LDAP userstore can store them as salted hashed value. To feed the plain text into the LDAP server, you need to set PasswordHashMethod to “PLAIN_TEXT”<br />

--- a/en/docs/guides/identity-federation/configure-saml-2.0-web-sso.md
+++ b/en/docs/guides/identity-federation/configure-saml-2.0-web-sso.md
@@ -159,12 +159,12 @@ To configure manually,
 			<tr class="odd">
 				<td>Signature Algorithm</td>
 				<td><p>Specifies the ‘SignatureMethod’ algorithm to be used in the ‘Signature’ element in POST binding and “SigAlg” HTTP Parameter in REDIRECT binding. The expandable Signature Algorithms table below lists the usable algorithms and their respective URIs that will be sent in the actual SAMLRequest.</p></td>
-				<td>Default value: <code>RSA with SHA1</code></td>
+				<td>Default value: <code>RSA with SHA256</code></td>
 			</tr>
 			<tr class="even">
 				<td>Digest Algorithm</td>
 				<td><p>Specifies the ‘DigestMethod’ algorithm to be used in the ‘Signature’ element in POST binding. The Digest Algorithms table below lists the usable algorithms and their respective URIs that will be sent in the actual SAMLRequest.</p></td>
-				<td>Default value: <code>SHA1</code></td>
+				<td>Default value: <code>SHA256</code></td>
 			</tr>
 			<tr class="odd">
 				<td>Attribute Consuming Service Index</td>

--- a/en/docs/guides/login/saml-app-config-advanced.md
+++ b/en/docs/guides/login/saml-app-config-advanced.md
@@ -108,7 +108,7 @@ Specifies the `SignatureMethod` algorithm to be used in the `Signature` element 
 signing_alg="signing algorithm"
 ```
 
-If it is not provided the default algorithm is `RSA­SHA 1`, at URI `http://www.w3.org/2000/09/xmldsig#rsa­sha1`.
+If it is not provided the default algorithm is `RSA­SHA 256`, at URI `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256`.
 
 ----
 
@@ -121,7 +121,7 @@ Specifies the `DigestMethod` algorithm to be used in the `Signature` element in 
 digest_alg="digest algorithm"
 ```
 
-If it is not provided, the default algorithm is `SHA 1` at URI `http://www.w3.org/2000/09/xmldsig#sha1`.
+If it is not provided, the default algorithm is `SHA 256` at URI `http://www.w3.org/2001/04/xmlenc#sha256`.
 
 ----
 

--- a/en/docs/guides/mfa/sms-otp-config-advanced.md
+++ b/en/docs/guides/mfa/sms-otp-config-advanced.md
@@ -81,7 +81,7 @@ Define whether to use a backup code instead of the actual SMS code or not.
 
 #### usecase 
 
-This parameter defines how the mobile ID will be retrieved. You can configure the following possible values:
+This parameter defines how the username will be retrieved and this has to be configured if the previous authenticator is not a Local Authenticator (eg: Basic Auth). You can configure the following possible values:
 
 - **local**: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.
 

--- a/en/docs/guides/mfa/sms-otp-config-advanced.md
+++ b/en/docs/guides/mfa/sms-otp-config-advanced.md
@@ -20,7 +20,7 @@ usecase = "local"
 secondaryUserstore = "primary"
 SMSOTPMandatory = false
 SendOtpToFederatedMobile = false
-federatedMobileAttributeKey = "phone_number"
+federatedMobileAttributeKey = "mobile"
 CaptureAndUpdateMobileNumber = true
 SendOTPDirectlyToMobile = false
 redirectToMultiOptionPageOnFailure = false
@@ -85,11 +85,11 @@ This parameter defines how the mobile ID will be retrieved. You can configure th
 
 - **local**: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.
 
-- **association**: The federated username must be associated with the local account in advance in the WSO2 Identity Server My Account. The local username is retrieved from the association. <!-- For information on creating an association, see the [My Account help](insertlink). -->
+- **association**: The federated username must be associated with the local account in advance in the WSO2 Identity Server My Account. The local username is retrieved from the association.
 
 - **subjectUri**: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.
 
-- **userAttribute**: The name of the federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the `[authentication.authenticator.sms_otp.parameters]` section in the `deployment.toml` file and enter the relevant value.
+- **userAttribute**: The name of the federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the `[authentication.authenticator.sms_otp.parameters]` section in the `deployment.toml` file and enter the relevant value, e.g., email and screen_name, id.
 
     ```toml
     [authentication.authenticator.sms_otp.parameters]

--- a/en/docs/guides/mfa/sms-otp-config-advanced.md
+++ b/en/docs/guides/mfa/sms-otp-config-advanced.md
@@ -92,8 +92,8 @@ This parameter defines how the mobile ID will be retrieved. You can configure th
 - **userAttribute**: The name of the federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the `[authentication.authenticator.sms_otp.parameters]` section in the `deployment.toml` file and enter the relevant value.
 
     ```toml
-    [authentication.authenticator.email_otp.parameters]
-    userAttribute = "phone_number"
+    [authentication.authenticator.sms_otp.parameters]
+    userAttribute = "email"
     ```
 
 ----

--- a/en/docs/guides/mfa/sms-otp-config-advanced.md
+++ b/en/docs/guides/mfa/sms-otp-config-advanced.md
@@ -85,8 +85,6 @@ This parameter defines how the mobile ID will be retrieved. You can configure th
 
 - **local**: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.
 
-- **association**: The federated username must be associated with the local account in advance in the WSO2 Identity Server My Account. The local username is retrieved from the association.
-
 - **subjectUri**: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.
 
 - **userAttribute**: The name of the federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the `[authentication.authenticator.sms_otp.parameters]` section in the `deployment.toml` file and enter the relevant value, e.g., email and screen_name, id.

--- a/en/docs/guides/mfa/sms-otp-config-advanced.md
+++ b/en/docs/guides/mfa/sms-otp-config-advanced.md
@@ -16,7 +16,11 @@ RetryEnable = true
 ResendEnable = true
 BackupCode = true
 SMSOTPEnableByUserClaim = true
+usecase = "local"
+secondaryUserstore = "primary"
 SMSOTPMandatory = false
+SendOtpToFederatedMobile = false
+federatedMobileAttributeKey = "phone_number"
 CaptureAndUpdateMobileNumber = true
 SendOTPDirectlyToMobile = false
 redirectToMultiOptionPageOnFailure = false
@@ -75,9 +79,68 @@ Define whether to use a backup code instead of the actual SMS code or not.
 
 ----
 
+#### usecase 
+
+This parameter defines how the mobile ID will be retrieved. You can configure the following possible values:
+
+- **local**: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.
+
+- **association**: The federated username must be associated with the local account in advance in the WSO2 Identity Server My Account. The local username is retrieved from the association. <!-- For information on creating an association, see the [My Account help](insertlink). -->
+
+- **subjectUri**: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.
+
+- **userAttribute**: The name of the federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the `[authentication.authenticator.sms_otp.parameters]` section in the `deployment.toml` file and enter the relevant value.
+
+    ```toml
+    [authentication.authenticator.email_otp.parameters]
+    userAttribute = "phone_number"
+    ```
+
+----
+
+#### secondaryUserstore
+
+You can define multiple user stores per tenant as comma separated values.
+
+```tab="Example"
+secondaryUserstore = "jdbc, abc, xyz"
+```
+
+The user store configurations are maintained per tenant.
+
+- If you use a super tenant, set all the parameter values in the `<IS_HOME>/repository/conf/deployment.toml` file.
+
+- If you use a tenant: 
+
+1. Upload the XML file (`<IS_HOME>/repository/conf/identity/application-authentication.xml`) into a specific registry location (`/_system/governance/SMSOTP`).
+
+2. Create a collection named "SMSOTP", add the resource, and upload the `application-authentication.xml` file into the registry.
+
+While doing the authentication,the system first checks whether there is an `.xml` file uploaded to the registry. If so, it reads it from the registry but does not take the local file. If there is no file in the registry, then it only takes the property values from the local file.
+You can use the registry or local file to get the property values.
+
+----
+
 #### SMSOTPMandatory 
 
 If the value is true, the second step will be enabled by the admin. The user cannot be authenticated without SMS OTP authentication. This parameter is used for both super tenant and tenant in the configuration. The value can be *true* or *false*.
+
+----
+
+#### SendOtpToFederatedMobile
+
+When `SMSOTPMandatory` and this parameter are set to *true* and the user is not found in the active directory, the OTP is sent to the mobile number defined in the federated authenticator claim.
+
+When `SMSOTPMandatory` is set to *false*, an error page gets displayed.
+
+When `SMSOTPMandatory` is set to `false `and the user is not found in the active directory, the authentication mechanism gets terminated at the first step of the 2FA/MFA. This parameter is not required in such a scenario.
+
+----
+
+#### federatedMobileAttributeKey
+
+This parameter identifies the mobile attribute of the federated authenticator (e.g., Foursquare).
+Configure this parameter if `SendOtpToFederatedMobile` is set to *true*. Example: http://wso2.org/foursquare/claims/phone_number
 
 ----
 


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usages of SHA1 to SHA256.

### Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

### Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162