### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -353,7 +353,7 @@ Possible values:<br />
 SHA - Uses SHA digest method. SHA-1, SHA-256<br />
 MD5 - Uses MD 5 digest method.<br />
 PLAIN_TEXT - Plain text passwords.(Default)</p>
-<p>If you just configure as SHA, It is considered as SHA-1, It is always better to configure algorithm with higher bit value as digest bit size would be increased.<br />
+<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since digest bit size would be increased.<br />
 <br />
 Most of the LDAP servers (such as OpenLdap, OpenDJ, AD, ApacheDS and etc.) are supported to store passwords as salted hashed values (SSHA).<br />
 Therefore, the WSO2 IS requires the password fed in to the connected userstore as a plain text value. Then the LDAP userstore can store them as a salted hashed value. To feed the plain text into the LDAP server, you need to set PasswordHashMethod to “PLAIN_TEXT”.<br />

--- a/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -353,7 +353,7 @@ Possible values:<br />
 SHA - Uses SHA digest method. SHA-1, SHA-256<br />
 MD5 - Uses MD 5 digest method.<br />
 PLAIN_TEXT - Plain text passwords.(Default)</p>
-<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since digest bit size would be increased.<br />
+<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since the digest bit size will be increased.<br />
 <br />
 Most of the LDAP servers (such as OpenLdap, OpenDJ, AD, ApacheDS and etc.) are supported to store passwords as salted hashed values (SSHA).<br />
 Therefore, the WSO2 IS requires the password fed in to the connected userstore as a plain text value. Then the LDAP userstore can store them as a salted hashed value. To feed the plain text into the LDAP server, you need to set PasswordHashMethod to “PLAIN_TEXT”.<br />

--- a/en/docs/deploy/configure-a-read-write-ldap-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-ldap-user-store.md
@@ -321,7 +321,7 @@ Possible values:<br />
 SHA - Uses SHA digest method. SHA-1, SHA-256<br />
 MD5 - Uses MD 5 digest method.<br />
 PLAIN_TEXT - Plain text passwords.(Default)</p>
-<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since digest bit size would be increased.<br />
+<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since the digest bit size would be increased.<br />
 <br />
 Most of the LDAP servers (such as OpenLdap, OpenDJ, AD, ApacheDS and etc..) are supported to store password as salted hashed values (SSHA)<br />
 Therefore WSO2IS server just wants to feed password into the connected userstore as a plain text value. Then LDAP userstore can store them as salted hashed value. To feed the plain text into the LDAP server, you need to set PasswordHashMethod to “PLAIN_TEXT”<br />

--- a/en/docs/deploy/configure-a-read-write-ldap-user-store.md
+++ b/en/docs/deploy/configure-a-read-write-ldap-user-store.md
@@ -321,7 +321,7 @@ Possible values:<br />
 SHA - Uses SHA digest method. SHA-1, SHA-256<br />
 MD5 - Uses MD 5 digest method.<br />
 PLAIN_TEXT - Plain text passwords.(Default)</p>
-<p>If you just configure as SHA, It is considered as SHA-1, It is always better to configure algorithm with higher bit value as digest bit size would be increased.<br />
+<p>If you just configure as SHA, it is considered as SHA-1. It is recommended to use SHA-256 since SHA-1 is no longer considered as secure. It is always better to configure an algorithm with a higher bit value since digest bit size would be increased.<br />
 <br />
 Most of the LDAP servers (such as OpenLdap, OpenDJ, AD, ApacheDS and etc..) are supported to store password as salted hashed values (SSHA)<br />
 Therefore WSO2IS server just wants to feed password into the connected userstore as a plain text value. Then LDAP userstore can store them as salted hashed value. To feed the plain text into the LDAP server, you need to set PasswordHashMethod to “PLAIN_TEXT”<br />

--- a/en/docs/deploy/configure-an-sp-and-idp-using-configuration-files.md
+++ b/en/docs/deploy/configure-an-sp-and-idp-using-configuration-files.md
@@ -278,8 +278,8 @@ service provider in the ` service provider IS ` via a file.
             <EnableSingleLogout>true</EnableSingleLogout>
             <SLOResponseURL></SLOResponseURL>
             <SLORequestURL></SLORequestURL>
-            <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
-            <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+            <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</SAMLDefaultSigningAlgorithmURI>
+            <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2001/04/xmlenc#sha256</SAMLDefaultDigestAlgorithmURI>
             <SignResponse>true</SignResponse>
             <ValidateSignatures>false</ValidateSignatures>
             <EncryptAssertion>true</EncryptAssertion>

--- a/en/docs/deploy/mitigate-attacks/mitigate-cross-site-request-forgery-attacks.md
+++ b/en/docs/deploy/mitigate-attacks/mitigate-cross-site-request-forgery-attacks.md
@@ -156,7 +156,7 @@ Follow the steps below to secure web applications.
 
     | Property                                                                                                   | Description                                                                      |
     |------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-    | `               org.owasp.csrfguard.PRNG=SHA1PRNG                             `                            | Defines the hashing algorithm used to generate the CSRF token.                   |
+    | `               org.owasp.csrfguard.PRNG=DRBG                          `                                   | Defines the hashing algorithm used to generate the CSRF token.                   |
     | `               org.owasp.csrfguard.TokenLength=32              `                                          | Defines the length of the CSRF token.                                            |
     | `               org.owasp.csrfguard.action.Invalidate=org.owasp.csrfguard.action.Invalidate              ` | Invalidates the user session, if a CSRF attack attempt was blocked by CSRFGuard. |
 
@@ -240,6 +240,6 @@ Follow the steps below to secure Jaggery applications.
 
     | Property                                                                                                                  | Description                                                                      |
     |---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-    | `               org.owasp.csrfguard.PRNG=SHA1PRNG              `                                                          | Defines the hashing algorithm used to generate the CSRF token.                   |
+    | `               org.owasp.csrfguard.PRNG=DRBG           `                                                                 | Defines the hashing algorithm used to generate the CSRF token.                   |
     | `               org.owasp.csrfguard.TokenLength=32                             `                                          | Defines the length of the CSRF token.                                            |
     | `               org.owasp.csrfguard.action.Invalidate=org.owasp.csrfguard.action.Invalidate                             ` | Invalidates the user session, if a CSRF attack attempt was blocked by CSRFGuard. |

--- a/en/docs/guides/identity-federation/configure-oauth2-openid-connect.md
+++ b/en/docs/guides/identity-federation/configure-oauth2-openid-connect.md
@@ -22,7 +22,7 @@ You need to configure an oauth application in the federated authorization server
 !!! tip
     By default, the **Client Id** and **Client Secret** are stored as
     plain text values, where the **Client Secret** is generally stored
-    as a random number generated using two UUIDs and HMAC-SHA1 hash
+    as a random number generated using two UUIDs and HMAC-SHA256 hash
     function, which is known to resist the strongest attack known
     against HMAC.
 

--- a/en/docs/guides/identity-federation/configure-saml-2.0-web-sso.md
+++ b/en/docs/guides/identity-federation/configure-saml-2.0-web-sso.md
@@ -159,12 +159,12 @@ To configure manually,
 			<tr class="odd">
 				<td>Signature Algorithm</td>
 				<td><p>Specifies the ‘SignatureMethod’ algorithm to be used in the ‘Signature’ element in POST binding and “SigAlg” HTTP Parameter in REDIRECT binding. The expandable Signature Algorithms table below lists the usable algorithms and their respective URIs that will be sent in the actual SAMLRequest.</p></td>
-				<td>Default value: <code>RSA with SHA1</code></td>
+				<td>Default value: <code>RSA with SHA256</code></td>
 			</tr>
 			<tr class="even">
 				<td>Digest Algorithm</td>
 				<td><p>Specifies the ‘DigestMethod’ algorithm to be used in the ‘Signature’ element in POST binding. The Digest Algorithms table below lists the usable algorithms and their respective URIs that will be sent in the actual SAMLRequest.</p></td>
-				<td>Default value: <code>SHA1</code></td>
+				<td>Default value: <code>SHA256</code></td>
 			</tr>
 			<tr class="odd">
 				<td>Attribute Consuming Service Index</td>

--- a/en/docs/guides/login/log-into-salesforce-using-fb.md
+++ b/en/docs/guides/login/log-into-salesforce-using-fb.md
@@ -349,7 +349,7 @@ Let's get started!
     </tr>
     <tr class="odd">
     <td>Request Signature Method</td>
-    <td>RSA-SHA1</td>
+    <td>RSA-SHA256</td>
     </tr>
     <tr class="even">
     <td>Assertion Decryption Certificate</td>

--- a/en/docs/guides/login/log-into-salesforce-using-is.md
+++ b/en/docs/guides/login/log-into-salesforce-using-is.md
@@ -109,7 +109,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     </tr>
     <tr class="odd">
     <td>Request Signature Method</td>
-    <td>RSA-SHA1</td>
+    <td>RSA-SHA256</td>
     </tr>
     <tr class="even">
     <td>Assertion Decryption Certificate</td>

--- a/en/docs/guides/login/log-into-salesforce-using-iwa.md
+++ b/en/docs/guides/login/log-into-salesforce-using-iwa.md
@@ -320,7 +320,7 @@ Now that you have configured the email addresses, let's configure Salesforce.
     </tr>
     <tr class="odd">
     <td>Request Signature Method</td>
-    <td>RSA-SHA1</td>
+    <td>RSA-SHA256</td>
     </tr>
     <tr class="even">
     <td>Assertion Decryption Certificate</td>

--- a/en/docs/guides/login/log-into-workday-using-is.md
+++ b/en/docs/guides/login/log-into-workday-using-is.md
@@ -144,7 +144,7 @@ Identity Server (IS) to enable logging into Workday through the WSO2 IS.
     </tr>
     <tr class="even">
     <td>Authentication Request Signature Method</td>
-    <td>SHA1</td>
+    <td>SHA256</td>
     </tr>
     </tbody>
     </table>

--- a/en/docs/guides/login/saml-app-config-advanced.md
+++ b/en/docs/guides/login/saml-app-config-advanced.md
@@ -108,7 +108,7 @@ Specifies the `SignatureMethod` algorithm to be used in the `Signature` element 
 signing_alg="signing algorithm"
 ```
 
-If it is not provided the default algorithm is `RSA­SHA 1`, at URI `http://www.w3.org/2000/09/xmldsig#rsa­sha1`.
+If it is not provided the default algorithm is `RSA­SHA 256`, at URI `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256`.
 
 ----
 
@@ -121,7 +121,7 @@ Specifies the `DigestMethod` algorithm to be used in the `Signature` element in 
 digest_alg="digest algorithm"
 ```
 
-If it is not provided, the default algorithm is `SHA 1` at URI `http://www.w3.org/2000/09/xmldsig#sha1`.
+If it is not provided, the default algorithm is `SHA 256` at URI `http://www.w3.org/2001/04/xmlenc#sha256`.
 
 ----
 

--- a/en/docs/guides/login/webapp-ws-federation.md
+++ b/en/docs/guides/login/webapp-ws-federation.md
@@ -81,14 +81,14 @@ To configure additional properties for the sample application:
 6. Click **Update** to save your configurations.
 
 !!! tip
-    Currently, the signing algorithm used for passive STS by default is `rsa-sha1`, and the digest algorithm used is `sha1`. 
+    Currently, the signing algorithm used for passive STS by default is `rsa-sha256`, and the digest algorithm used is `sha256`. 
     To change the default algorithms, add the following configuration in the `deployment.toml` file found in the `<IS_HOME>/repository/conf` directory.
-    The example given below sets the signing algorithm to `rsa-sha256` and the digest algorithm to `sha256`.
+    The example given below sets the signing algorithm to `rsa-sha512` and the digest algorithm to `sha512`.
 
     ```toml
     [sts]
-    signature_algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
-    digest_algorithm = "http://www.w3.org/2001/04/xmlenc#sha256"
+    signature_algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"
+    digest_algorithm = "http://www.w3.org/2001/04/xmlenc#sha512"
     ```
 
 ## Try it out


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usages of SHA1 to SHA256.

### Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

### Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157