### PR TITLE
Add Documentation for Userstore export and import rest apis

### DIFF
--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -67,7 +67,7 @@ paths:
     get:
       tags:
         - User Store
-      summary: Retrieve or list the configured secondary user stores.
+      summary: Retrieve the list of secondary user stores
       operationId: getSecondaryUserStores
       description: >
         This API provides the capability to list the configured secondary userstores.<br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -175,7 +175,7 @@ paths:
       operationId: getUserStoreByDomainId
       description: >
         This API provides the capability to retrieve the configurations of
-        secondary user store based on its domain id.<br>
+        a secondary user store based on its domain id.<br>
 
         <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/userstore/config/view <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -313,7 +313,7 @@ paths:
         Export a secondary user store by its domain id
       description: |
         This API provides the capability to retrieve the configurations of a
-        secondary user store based on its domain id as a XML, YAML, or JSON file.<br>
+        secondary user store based on its domain id as an `XML`, `YAML`, or `JSON` file.<br>
         <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/userstore/config/view <br>
         <b>Scope required:</b> <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -107,7 +107,7 @@ paths:
         Import a secondary user store from a file
       description: >
         This API provides the capability to import a user store from
-        the configurations provided as a YAML, JSON or XML file.<br>
+        the configurations provided as a `YAML`, `JSON`, or `XML` file.<br>
           <b>Permission required:</b> <br>
               * /permission/admin/manage/identity/userstore/config/create <br>
           <b>Scope required:</b> <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -365,7 +365,7 @@ paths:
       tags:
         - User Store
       summary: |
-        Update an existing userstore by importing user store configurations from a file.
+        Update an existing user store by importing configs from a file
       description: >
         This API provides the capability to update an existing user store by importing
         user store configurations provided as a YAML, JSON or XML file.<br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -310,7 +310,7 @@ paths:
       tags:
         - User Store
       summary: |
-        Export a secondary user store by its domain id.
+        Export a secondary user store by its domain id
       description: |
         This API provides the capability to retrieve the configurations of a
         secondary user store based on its domain id as a XML, YAML, or JSON file.<br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -104,7 +104,7 @@ paths:
       tags:
         - User Store
       summary: |
-        Import a secondary user store from a file.
+        Import a secondary user store from a file
       description: >
         This API provides the capability to import a user store from
         the configurations provided as a YAML, JSON or XML file.<br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -441,7 +441,7 @@ paths:
         Retrieve the properties of secondary user store of a given user store type.
       operationId: getUserStoreManagerProperties
       description: >
-        This API provides the capability to retrieve the properties of secondary
+        This API provides the capability to retrieve the properties of a secondary
         user store of a given class name.<br>
 
         <b>Permission required:</b> <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -274,7 +274,7 @@ paths:
       operationId: patchUserStore
       description: >
         This API provides the capability to update the secondary user store's
-        property using patch request by using its domain id.<br>
+        property by using its domain id.<br>
 
         <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/userstore/config/update <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -442,7 +442,7 @@ paths:
       operationId: getUserStoreManagerProperties
       description: >
         This API provides the capability to retrieve the properties of a secondary
-        user store of a given class name.<br>
+        user store based on a given class name.<br>
 
         <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/userstore/config/view <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -31,8 +31,10 @@ paths:
 
           To retrieve the available user store classes/types, use the **api/server/v1/userstores/meta/types** API.
 
-         <b>Permission required:</b>
-          - /permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/create <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_create
       responses:
         '201':
           description: Successful response
@@ -68,9 +70,12 @@ paths:
       summary: Retrieve or list the configured secondary user stores.
       operationId: getSecondaryUserStores
       description: >
-        This API provides the capability to list the configured secondary userstores.
-        <b>Permission required:</b>
-        */permission/admin
+        This API provides the capability to list the configured secondary userstores.<br>
+
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
       parameters:
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
@@ -94,6 +99,45 @@ paths:
           $ref: '#/components/responses/ServerError'
         '501':
           $ref: '#/components/responses/NotImplemented'
+  /userstores/import:
+    post:
+      tags:
+        - User Store
+      summary: |
+        Import a secondary user store from a file.
+      description: >
+        This API provides the capability to import a user store from
+        the configurations provided as a YAML, JSON or XML file.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/userstore/config/create <br>
+          <b>Scope required:</b> <br>
+              * internal_userstore_create
+      operationId: importUserStoreFromFile
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUpload'
+        description: This represents the user store to be created.
+      responses:
+        '201':
+          description: Successful response
+          headers:
+            Location:
+              description: >-
+                Location of the newly created secondary userstore. userstore id is generated as base-64-url-encoded(domain-name) value.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
   '/userstores/primary':
     get:
       tags:
@@ -103,10 +147,12 @@ paths:
       operationId: getPrimaryUserStore
       description: >
         This API provides the capability to retrieve the configurations of
-        primary user store.
+        primary user store.<br>
 
-          <b>Permission required:</b>
-        */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
       responses:
         '200':
           description: Successful response.
@@ -129,10 +175,12 @@ paths:
       operationId: getUserStoreByDomainId
       description: >
         This API provides the capability to retrieve the configurations of
-        secondary user store based on its domain id.
+        secondary user store based on its domain id.<br>
 
-          <b>Permission required:</b>
-        */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
       parameters:
         - $ref: '#/components/parameters/domainNamePathParam'
       responses:
@@ -155,10 +203,12 @@ paths:
       operationId: deleteUserStore
       description: >
         This API provides the capability to delete a secondary user store
-        matching to the given user store domain id.
+        matching to the given user store domain id.<br>
 
-         <b>Permission required:</b>
-         */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/delete <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_delete
       parameters:
         - $ref: '#/components/parameters/domainNamePathParam'
       responses:
@@ -177,10 +227,12 @@ paths:
       operationId: updateUserStore
       description: >
         This API provides the capability to edit a user store based on its
-        domain id.
+        domain id.<br>
 
-         <b>Permission required:</b>
-          */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/update <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_update
       parameters:
         - in: path
           name: userstore-domain-id
@@ -222,10 +274,12 @@ paths:
       operationId: patchUserStore
       description: >
         This API provides the capability to update the secondary user store's
-        property using patch request by using its domain id.
+        property using patch request by using its domain id.<br>
 
-         <b>Permission required:</b>
-         */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/update <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_update
       parameters:
         - $ref: '#/components/parameters/domainNamePathParam'
       responses:
@@ -251,6 +305,107 @@ paths:
             schema:
               $ref: '#/components/schemas/PatchRequest'
         required: true
+  /userstores/{userstore-domain-id}/export:
+    get:
+      tags:
+        - User Store
+      summary: |
+        Export a secondary user store by its domain id.
+      description: |
+        This API provides the capability to retrieve the configurations of a
+        secondary user store based on its domain id as a XML, YAML, or JSON file.<br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
+      operationId: exportUserStoreToFile
+      parameters:
+        - name: userstore-domain-id
+          in: path
+          description: ID of the user store domain.
+          required: true
+          schema:
+            type: string
+            example: SkRCQy1TRUNPTkRBUlk
+        - $ref: '#/components/parameters/fileTypeHeaderParam'
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 'Sample userstore configuration in the requested format'
+            application/yaml:
+              schema:
+                type: string
+              example: 'Sample userstore configuration in the requested format'
+            application/xml:
+              schema:
+                type: string
+              example: 'Sample userstore configuration in the requested format'
+            application/octet-stream:
+              schema:
+                type: string
+              example: 'Sample userstore configuration in the requested format'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /userstores/{userstore-domain-id}/import:
+    put:
+      tags:
+        - User Store
+      summary: |
+        Update an existing userstore by importing user store configurations from a file.
+      description: >
+        This API provides the capability to update an existing user store by importing
+        user store configurations provided as a YAML, JSON or XML file.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/userstore/config/update <br>
+          <b>Scope required:</b> <br>
+              * internal_userstore_update
+      operationId: updateUserStoreFromFile
+      parameters:
+        - name: userstore-domain-id
+          in: path
+          description: ID of the user store.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUpload'
+        description: This represents the user store to be updated.
+      responses:
+        '200':
+          description: Successfully Updated.
+          headers:
+            Location:
+              description: >-
+                Location of the updated userstore. userstore id is generated as base-64-url-encoded(domain-name) value.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /userstores/meta/types:
     get:
       tags:
@@ -259,11 +414,12 @@ paths:
       operationId: getAvailableUserStoreTypes
       description: >
         This API provides the capability to retrieve the available user store
-        types.
+        types.<br>
 
-         <b>Permission required:</b>
-
-        */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
       responses:
         '200':
           description: Successful Response.
@@ -286,11 +442,12 @@ paths:
       operationId: getUserStoreManagerProperties
       description: >
         This API provides the capability to retrieve the properties of secondary
-        user store of a given class name.
+        user store of a given class name.<br>
 
-         <b>Permission required:</b>
-
-        */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
       parameters:
         - in: path
           name: type-id
@@ -323,10 +480,12 @@ paths:
       operationId: testRDBMSConnection
       description: >
         This API provides the capability to test the connection to the
-        datasource used by a JDBC user store manager.
+        datasource used by a JDBC user store manager.<br>
 
-          <b>Permission required:</b>
-          */permission/admin
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/userstore/config/view <br>
+        <b>Scope required:</b> <br>
+            * internal_userstore_view
       responses:
         '200':
           description: Successful response.
@@ -402,6 +561,23 @@ components:
       description: Define set of user store attributes (as comma separated) to be returned.
       schema:
         type: string
+    fileTypeHeaderParam:
+      in: header
+      name: Accept
+      required: false
+      description: |
+        Content type of the file.
+      schema:
+        type: string
+        default: application/yaml
+        enum:
+          - application/json
+          - application/xml
+          - application/yaml
+          - application/x-yaml
+          - text/yaml
+          - text/xml
+          - text/json
   responses:
     NotFound:
       description: The specified resource is not found.
@@ -731,3 +907,10 @@ components:
         value:
           type: string
           example: basic
+    FileUpload:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+          description: File uploaded during import.

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -203,7 +203,7 @@ paths:
       operationId: deleteUserStore
       description: >
         This API provides the capability to delete a secondary user store
-        matching to the given user store domain id.<br>
+        based on the given user store domain id.<br>
 
         <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/userstore/config/delete <br>

--- a/en/docs/apis/restapis/user-store.yaml
+++ b/en/docs/apis/restapis/user-store.yaml
@@ -147,7 +147,7 @@ paths:
       operationId: getPrimaryUserStore
       description: >
         This API provides the capability to retrieve the configurations of
-        primary user store.<br>
+        the primary user store.<br>
 
         <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/userstore/config/view <br>


### PR DESCRIPTION
This PR adds documentation for the new secondary userstore export and import APIs.

3 new APIs are added:
Export - /userstores/{userstore-domain-id}/export- GET
Import - /userstores/import- POST
Update - /userstores/{userstore-domain-id}/import - PUT

Related Issue: https://github.com/wso2/product-is/issues/15891
Related PR: https://github.com/wso2/identity-api-server/pull/448

This PR also updates the permissions and scopes of userstore APIs according to the changes added by https://github.com/wso2/identity-api-server/pull/447