### PR TITLE
[5.11] Add missing advanced configs in SMS OTP

### DIFF
--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -441,8 +441,7 @@ the various values you can configure for the authenticator.
 			<td>This parameter defines how the username will be retrieved and this has to be configured if the previous authenticator is not a Local Authenticator (eg: Basic Auth). You can configure the following possible values:
 				<ul>
 					<li><code>local</code>: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.</li>
-					<li><code>association</code>: The federated username must be associated with the local account in advance in the **My Account**. The local username is retrieved
-						from the association. To associate the user, log into the  [**My Account**](../../learn/my-account)  and go to  **Associated Account**  by clicking  **View details**.</li>
+					<li><code>association</code>: The federated username must be associated with the local account in advance in the **My Account**. The local username is retrieved from the association. To associate the user, log into the  [**My Account**](../../learn/my-account)  and go to  **Associated Account**  by clicking  **View details**.</li>
 					<li><code>subjectUri</code>: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.</li>
 					<li>
 						<p><code>userAttribute </code>: The name of the  federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the  ```[authentication.authenticator.sms_otp.parameters]```  section in the ```deployment.toml``` file and put the value, e.g., email and screen_name, id.</p>
@@ -495,11 +494,11 @@ the various values you can configure for the authenticator.
 		</tr>
 		<tr>
 			<td>federatedMobileAttributeKey</td>
-			<td>This parameter identifies the mobile attribute of the federated authenticator, <br/> e.g. Foursquare. Set this parameter if the <code>SendOtpToFederatedMobile`</code> is set to <code>true</code>. Example: <code>http://wso2.org/foursquare/claims/phone_number</code></td>
+			<td>This parameter identifies the mobile attribute of the federated authenticator, <br/> e.g. Foursquare. Set this parameter if the <code>SendOtpToFederatedMobile</code> is set to <code>true</code>. Example: <code>http://wso2.org/foursquare/claims/phone_number</code></td>
 		</tr>
         <tr>
             <td>SMSOTPEnableByUserClaim</td>
-            <td>Disabl the 'SMS OTP disabling by user' functionality. The value can be either <code>true</code> or 
+            <td>Disable the 'SMS OTP disabling by user' functionality. The value can be either <code>true</code> or 
             <code>false</code>. If the value is set to <code>true</code>, the user can enable and disable the 
             SMS OTP according to what the admin selects in <code>SMSOTPMandatory</code> parameter value.</td>
         </tr>

--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -436,12 +436,67 @@ the various values you can configure for the authenticator.
             <td>BackupCode</td>
             <td>Define whether to use a backup code instead of the actual SMS code or not.</td>
         </tr>
+		<tr>
+			<td>usecase</td>
+			<td>This parameter defines how the username will be retrieved and this has to be configured if the previous authenticator is not a Local Authenticator (eg: Basic Auth). You can configure the following possible values:
+				<ul>
+					<li><code>local</code>: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.</li>
+					<li><code>association</code>: The federated username must be associated with the local account in advance in the **My Account**. The local username is retrieved
+						from the association. To associate the user, log into the  [**My Account**](../../learn/my-account)  and go to  **Associated Account**  by clicking  **View details**.</li>
+					<li><code>subjectUri</code>: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.</li>
+					<li>
+						<p><code>userAttribute </code>: The name of the  federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the  ```[authentication.authenticator.sms_otp.parameters]```  section in the ```deployment.toml``` file and put the value, e.g., email and screen_name, id.</p>
+						```
+						[authentication.authenticator.sms_otp.parameters]
+						userAttribute = "email"
+						```
+					</li>
+				</ul>    
+			</td>
+		</tr>
+		<tr>
+			<td>secondaryUserstore</td>
+			<td>
+				<p>You can define multiple user stores per tenant as comma separated values.</p>
+				<p>Example:</p>
+				```
+				secondaryUserstore = "jdbc, abc, xyz"
+				```
+				<details class="example">
+					<summary>Tip</summary>
+					<p>The user store configurations are maintained per tenant:</p>
+					<ul>
+						<li>If you use a <b>super tenant</b>, set all the parameter values into the <code><IS_HOME>/repository/conf/deployment.toml</code> file.</li>
+						<li>If you use a tenant,
+							<ul>
+								<li>Upload the XML file (<code><IS_HOME>/repository/conf/identity/application-authentication.xml</code>) into a specific registry location (<code>/_system/governance/SMSOTP</code>).</li>
+								<li>Create the collection named <code>SMSOTP</code>, add the resource and upload the <code>application-authentication.xml</code> file into the registry.</li>
+								<li>While doing the authentication,the system first checks whether there is an XML file uploaded to the registry. If that is so, it reads it from the registry but does not take the local file. If there is no file in the registry, then it only takes the property values from the local file.</li>
+								<li>You can use the registry or local file to get the property values.</li>
+							</ul>
+						</li>
+					</ul>
+				</details>
+			</td>
+		</tr>
         <tr>
             <td>SMSOTPMandatory</td>
             <td>If the value is true, the second step will be enabled by the admin. The user cannot be 
             authenticated without SMS OTP authentication. This parameter is used for both super tenant 
             and tenant in the configuration. The value can be <code>true</code> or <code>false</code>.</td>
         </tr>
+		<tr>
+			<td>SendOtpToFederatedMobile</td>
+			<td>
+				<p>When the <code>SMSOTPMandatory</code> and this parameter are set to <code>true</code> and the user is not found in the active directory, the OTP is sent to the mobile number defined in the federated authenticator claim.</p>
+				<p>When the <code>SMSOTPMandatory</code> is set to <code>false</code>, an error page gets displayed.</p>
+				<p>When the <code>SMSOTPMandatory</code> is set to <code>false</code> and the user is not found in the active directory, the authentication mechanism terminates at the first step of the 2FA/MFA. This parameter is not required in such a scenario.</p>
+			</td>
+		</tr>
+		<tr>
+			<td>federatedMobileAttributeKey</td>
+			<td>This parameter identifies the mobile attribute of the federated authenticator, <br/> e.g. Foursquare. Set this parameter if the <code>SendOtpToFederatedMobile`</code> is set to <code>true</code>. Example: <code>http://wso2.org/foursquare/claims/phone_number</code></td>
+		</tr>
         <tr>
             <td>SMSOTPEnableByUserClaim</td>
             <td>Disabl the 'SMS OTP disabling by user' functionality. The value can be either <code>true</code> or 
@@ -495,7 +550,11 @@ You can configure any of the above as following in the
     ResendEnable = true
     BackupCode = true
     SMSOTPEnableByUserClaim = true
+	usecase = "local"
+	secondaryUserstore = "primary"
     SMSOTPMandatory = false
+	SendOtpToFederatedMobile = false
+	federatedMobileAttributeKey = "mobile"
     CaptureAndUpdateMobileNumber = true
     SendOTPDirectlyToMobile = false
     redirectToMultiOptionPageOnFailure = false

--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -441,14 +441,13 @@ the various values you can configure for the authenticator.
 			<td>This parameter defines how the username will be retrieved and this has to be configured if the previous authenticator is not a Local Authenticator (eg: Basic Auth). You can configure the following possible values:
 				<ul>
 					<li><code>local</code>: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.</li>
-					<li><code>association</code>: The federated username must be associated with the local account in advance in the **My Account**. The local username is retrieved from the association. To associate the user, log into the  [**My Account**](../../learn/my-account)  and go to  **Associated Account**  by clicking  **View details**.</li>
+					<li><code>association</code>: The federated username must be associated with the local account in advance using the <b>My Account</b> portal. The local username is retrieved from the association. To associate the user, log into the  [My Account](../../learn/my-account) portal and go to  <b>Associated Account</b>  by clicking  <b>View details</b>.</li>
 					<li><code>subjectUri</code>: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.</li>
 					<li>
-						<p><code>userAttribute </code>: The name of the  federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the  ```[authentication.authenticator.sms_otp.parameters]```  section in the ```deployment.toml``` file and put the value, e.g., email and screen_name, id.</p>
-						```
-						[authentication.authenticator.sms_otp.parameters]
-						userAttribute = "email"
-						```
+						<p><code>userAttribute </code>: The name of the  federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the  <code>[authentication.authenticator.sms_otp.parameters]</code> section in the <code>deployment.toml</code> file and put the value, e.g., <code>email</code>, <code>screen_name</code>, <code>id</code>.</p>
+						
+						<code>[authentication.authenticator.sms_otp.parameters]</code></br>
+				                <code>userAttribute = "email"</code>
 					</li>
 				</ul>    
 			</td>
@@ -458,19 +457,17 @@ the various values you can configure for the authenticator.
 			<td>
 				<p>You can define multiple user stores per tenant as comma separated values.</p>
 				<p>Example:</p>
-				```
-				secondaryUserstore = "jdbc, abc, xyz"
-				```
+				<code>secondaryUserstore = "jdbc, abc, xyz"</code>
 				<details class="example">
 					<summary>Tip</summary>
 					<p>The user store configurations are maintained per tenant:</p>
 					<ul>
-						<li>If you use a <b>super tenant</b>, set all the parameter values into the <code><IS_HOME>/repository/conf/deployment.toml</code> file.</li>
+						<li>If you use a <b>super tenant</b>, set all the parameter values in the <code><IS_HOME>/repository/conf/deployment.toml</code> file.</li>
 						<li>If you use a tenant,
 							<ul>
 								<li>Upload the XML file (<code><IS_HOME>/repository/conf/identity/application-authentication.xml</code>) into a specific registry location (<code>/_system/governance/SMSOTP</code>).</li>
-								<li>Create the collection named <code>SMSOTP</code>, add the resource and upload the <code>application-authentication.xml</code> file into the registry.</li>
-								<li>While doing the authentication,the system first checks whether there is an XML file uploaded to the registry. If that is so, it reads it from the registry but does not take the local file. If there is no file in the registry, then it only takes the property values from the local file.</li>
+								<li>Create the collection named <code>SMSOTP</code>, add the resource, and upload the <code>application-authentication.xml</code> file into the registry.</li>
+								<li>While doing the authentication, the system first checks whether there is an XML file uploaded to the registry. If there is, it reads the file from the registry but does not take the local file. If there is no file in the registry, then it only takes the property values from the local file.</li>
 								<li>You can use the registry or local file to get the property values.</li>
 							</ul>
 						</li>
@@ -480,21 +477,21 @@ the various values you can configure for the authenticator.
 		</tr>
         <tr>
             <td>SMSOTPMandatory</td>
-            <td>If the value is true, the second step will be enabled by the admin. The user cannot be 
-            authenticated without SMS OTP authentication. This parameter is used for both super tenant 
+	<td>If the value is <code>true</code>, the second step will be enabled by the admin. The user cannot be 
+            authenticated without SMS OTP authentication. This parameter is used for both the super tenant 
             and tenant in the configuration. The value can be <code>true</code> or <code>false</code>.</td>
         </tr>
 		<tr>
 			<td>SendOtpToFederatedMobile</td>
 			<td>
 				<p>When the <code>SMSOTPMandatory</code> and this parameter are set to <code>true</code> and the user is not found in the active directory, the OTP is sent to the mobile number defined in the federated authenticator claim.</p>
-				<p>When the <code>SMSOTPMandatory</code> is set to <code>false</code>, an error page gets displayed.</p>
+				<p>When the <code>SMSOTPMandatory</code> is set to <code>false</code>, an error page is displayed.</p>
 				<p>When the <code>SMSOTPMandatory</code> is set to <code>false</code> and the user is not found in the active directory, the authentication mechanism terminates at the first step of the 2FA/MFA. This parameter is not required in such a scenario.</p>
 			</td>
 		</tr>
 		<tr>
 			<td>federatedMobileAttributeKey</td>
-			<td>This parameter identifies the mobile attribute of the federated authenticator, <br/> e.g. Foursquare. Set this parameter if the <code>SendOtpToFederatedMobile</code> is set to <code>true</code>. Example: <code>http://wso2.org/foursquare/claims/phone_number</code></td>
+			<td>This parameter identifies the mobile attribute of the federated authenticator (e.g. Foursquare). Set this parameter if the <code>SendOtpToFederatedMobile</code> is set to <code>true</code>. Example: <code>http://wso2.org/foursquare/claims/phone_number</code></td>
 		</tr>
         <tr>
             <td>SMSOTPEnableByUserClaim</td>

--- a/en/docs/learn/configuring-sms-otp.md
+++ b/en/docs/learn/configuring-sms-otp.md
@@ -441,12 +441,12 @@ the various values you can configure for the authenticator.
 			<td>This parameter defines how the username will be retrieved and this has to be configured if the previous authenticator is not a Local Authenticator (eg: Basic Auth). You can configure the following possible values:
 				<ul>
 					<li><code>local</code>: This is the default value and is based on the federated username. You must set the federated username in the local userstore. The federated username must be the same as the local username.</li>
-					<li><code>association</code>: The federated username must be associated with the local account in advance using the <b>My Account</b> portal. The local username is retrieved from the association. To associate the user, log into the  [My Account](../../learn/my-account) portal and go to  <b>Associated Account</b>  by clicking  <b>View details</b>.</li>
+					<li><code>association</code>: The federated username must be associated with the local account in advance using the <b>My Account</b> portal. The local username is retrieved from the association. To associate the user, log into the <a href="../../learn/my-account">My Account</a> portal and go to <b>Associated Account</b>  by clicking  <b>View details</b>.</li>
 					<li><code>subjectUri</code>: When configuring the federated authenticator, select the attribute in the subject identifier under the service providers section in the UI. This is used as the username of the SMSOTP authenticator.</li>
 					<li>
 						<p><code>userAttribute </code>: The name of the  federated authenticator's user attribute. That is the local username that is contained in a federated user's attribute. When using this, add the following parameter under the  <code>[authentication.authenticator.sms_otp.parameters]</code> section in the <code>deployment.toml</code> file and put the value, e.g., <code>email</code>, <code>screen_name</code>, <code>id</code>.</p>
 						
-						<code>[authentication.authenticator.sms_otp.parameters]</code></br>
+						<code>[authentication.authenticator.sms_otp.parameters]</code><br/>
 				                <code>userAttribute = "email"</code>
 					</li>
 				</ul>    


### PR DESCRIPTION
## Purpose
The below SMS OTP advanced configs are missing in docs. This PR adds them.
```
usecase = "local"
secondaryUserstore = "primary"
sendOTPToFederatedMobileAttribute = false
federatedMobileAttributeKey = "mobile"
```