### PR TITLE
[5.11.0] Remove note about using XML configurations

### DIFF
--- a/en/docs/references/new-configuration-model.md
+++ b/en/docs/references/new-configuration-model.md
@@ -33,4 +33,3 @@ With the **new configuration model** in WSO2 Identity Server 5.9.0, configuratio
 
 !!! info
 	For more information about the new configuration model, see [Simplifying Configuration with WSO2 Identity Server](https://wso2.com/blogs/thesource/2019/10/simplifying-configuration-with-WSO2-identity-server).
-

--- a/en/docs/references/new-configuration-model.md
+++ b/en/docs/references/new-configuration-model.md
@@ -26,7 +26,7 @@ With the **new configuration model** in WSO2 Identity Server 5.9.0, configuratio
 -	Configurations are well-grouped and consistently named.
 
 !!! warning
-	If you are familiar with the previous configuration model, note that the `deployment.toml` gets precedence over the old `.xml` configuration files—it is expected to reset changes in `.xml` configuration files unless these configurations are now represented in `deployment.toml` file. If you require to use the old configuration model, remove the `deployment.toml` file from the `<IS_HOME>/repository/conf/` directory.
+	If you are familiar with the previous configuration model, note that the `deployment.toml` gets precedence over the old `.xml` configuration files—it is expected to reset changes in `.xml` configuration files unless these configurations are now represented in `deployment.toml` file.
 
 !!! tip
 	For TOML configurations pertaining to a particular feature, see the respective document section.


### PR DESCRIPTION
Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/407