### PR TITLE
Remove clientId, issuer attribute support from application listing API.

### DIFF
--- a/en/docs/apis/restapis/application.yaml
+++ b/en/docs/apis/restapis/application.yaml
@@ -2172,15 +2172,12 @@ components:
       name: filter
       required: false
       description: |
-        Condition to filter the retrieval of records.
-        Supports 'sw', 'co', 'ew', and 'eq' operations with 'and', 'or' logical operators.
-        Note that 'and' and 'or' operators in filters follow the general precedence of logical operators.
-        For example, A and B or C and D = (A and B) or (C and D)).
-        Currently supports only filtering based on the 'name', the 'clientId', and the 'issuer' attributes.
+        Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations.
+        Currently supports only filtering based on the 'name' attribute.
 
         /applications?filter=name+eq+user_portal
         <br>
-        /applications?filter=name+co+prod+or+clientId+co+123
+        /applications?filter=name+co+user
       schema:
         type: string
     sortOrderQueryParam:
@@ -2210,9 +2207,9 @@ components:
       required: false
       description: |
         Specifies the required parameters in the response.
-        Only 'advancedConfigurations', 'templateId', 'clientId', and 'issuer' attributes are supported currently.
+        Only 'advancedConfigurations' and 'templateId' attributes are supported currently.
         
-        /applications?attributes=advancedConfigurations,templateId,clientId,issuer
+        /applications?attributes=advancedConfigurations,templateId
       schema:
         type: string
     exportSecretsQueryParam:
@@ -2306,12 +2303,6 @@ components:
         accessUrl:
           type: string
           example: 'https://example.com/app/login'
-        clientId:
-          type: string
-          example: 'SmrrDNXRYf1lMmDlnleeHTuXx_Ea'
-        issuer:
-          type: string
-          example: 'http://idp.example.com/metadata.php'
         access:
           type: string
           enum:
@@ -2388,12 +2379,6 @@ components:
         accessUrl:
           type: string
           example: 'https://example.com/login'
-        clientId:
-          type: string
-          example: 'SmrrDNXRYf1lMmDlnleeHTuXx_Ea'
-        issuer:
-          type: string
-          example: 'http://idp.example.com/metadata.php'
         templateId:
           type: string
           example: "adwefi2429asdfdf94444rraf44"


### PR DESCRIPTION
## Purpose
> Remove clientId, issuer attribute support (filtering with and requesting as required attributes) from application listing API doc because that feature is fully delivered in IS 6.1.