### PR TITLE
Removed `attributeSyncMethod` from idp.yaml

### DIFF
--- a/en/docs/apis/restapis/idp.yaml
+++ b/en/docs/apis/restapis/idp.yaml
@@ -2382,13 +2382,6 @@ components:
           type: boolean
           default: false
           example: true
-        attributeSyncMethod:
-          type: string
-          enum:
-            - OVERRIDE_ALL
-            - NONE
-            - PRESERVE_LOCAL
-          default: OVERRIDE_ALL
     ConnectedApps:
       type: object
       properties:


### PR DESCRIPTION
## Purpose
>$subject

`attributeSyncMethod` feature is not available for 6.1.0 release.

Related issue: