### PR TITLE
Added new API for claim management export/import

### DIFF
--- a/en/docs/apis/restapis/claim-management.yaml
+++ b/en/docs/apis/restapis/claim-management.yaml
@@ -802,6 +802,105 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       x-wso2-curl: ""
+  /claim-dialects/{dialect-id}/export:
+    get:
+      tags:
+        - management
+      summary: Export a claim dialect with claims.
+      description: This API provides the capability to retrieve a claim dialect for a given dialect ID along with all 
+        related claims as a XML, YAML, or JSON file. 
+        <br><b>Permission required:</b> <br>
+        * /permission/admin/manage/identity/claimmgt/metadata/view <br>
+        <b>Scope required:</b> <br>
+        * internal_claim_meta_view
+      operationId: exportClaimDialectToFile
+      parameters:
+        - $ref: '#/components/parameters/dialectIdPathParam'
+        - $ref: '#/components/parameters/fileTypeHeaderParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 'Sample claim dialect configurations in the requested format'
+            application/xml:
+              schema:
+                type: string
+              example: 'Sample claim dialect configurations in the requested format'
+            application/yaml:
+              schema:
+                type: string
+              example: 'Sample claim dialect configurations in the requested format'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /claim-dialects/import:
+    put:
+      tags:
+        - management
+      summary: Update a claim dialect with claims.
+      description: This API provides the capability to update a claim dialect and all related claims from a file 
+        in XML, YAML, or JSON format. 
+        <br><b>Permission required:</b> <br>
+        * /permission/admin/manage/identity/claimmgt/metadata/create <br>
+        <b>Scope required:</b> <br>
+        * internal_claim_meta_create
+      operationId: updateClaimDialectFromFile
+      parameters:
+        - $ref: '#/components/parameters/preserveClaimsParam'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUpload'
+      responses:
+        '201':
+          $ref: '#/components/responses/Created'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      tags:
+        - management
+      summary: Import an external claim dialect with claims.
+      description: This API provides the capability to import a external claim dialect with related claims from a file 
+        in XML, YAML, or JSON format. 
+        <br><b>Permission required:</b> <br>
+        * /permission/admin/manage/identity/claimmgt/metadata/create <br>
+        <b>Scope required:</b> <br>
+        * internal_claim_meta_create
+      operationId: importClaimDialectFromFile
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUpload'
+      responses:
+        '201':
+          $ref: '#/components/responses/Created'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   schemas:
     LocalClaimReq:
@@ -1027,6 +1126,13 @@ components:
         traceId:
           type: string
           example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+    FileUpload:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+          description: This file represents the claim dialect.
   responses:
     Conflict:
       description: Element Already Exists.
@@ -1126,6 +1232,30 @@ components:
       required: true
       schema:
         type: string
+    fileTypeHeaderParam:
+      name: Accept
+      in: header
+      description: Content type of the file.
+      required: false
+      schema:
+        type: string
+        default: application/yaml
+        enum:
+          - application/json
+          - application/xml
+          - application/yaml
+          - application/x-yaml
+          - text/yaml
+          - text/xml
+          - text/json
+    preserveClaimsParam:
+      name: preserveClaims
+      in: query
+      description: Specify whether to merge and preserve the claims or completely replace the existing claims set.
+      required: false
+      schema:
+        type: boolean
+        default: false
   securitySchemes:
     BasicAuth:
       type: http


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15461

Add support for claim configurations to export/import in XML, YAML, and JSON file formats.

## Goals
When the required file type is given, this API will export/import/update Claims in either XML, YAML, or JSON file formats.

## Approach
The following APIs are added:
Export:
**GET /claim-dialects/{dialect-id}/export** - Exports the claim configurations of the provided claim ID of the dialect.

Import:
**POST /claim-dialects/import** - Creates a new local or external claim from the given file configurations.
**PUT /claim-dialects/import** - Modifies the existing claim with the given file configurations.

## Related PRs
https://github.com/wso2/identity-api-server/pull/449
https://github.com/wso2-extensions/identity-tools-cli/pull/22