### PR TITLE
[6.0.0] Remove google fonts

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -2,7 +2,7 @@
 template: templates/single-column.html 
 ---
 
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+<link href="https://wso2.cachefly.net/wso2/sites/all/fonts/docs/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2" rel="stylesheet" />
 <div>
     <header>
         <h1>Welcome to the WSO2 Identity Server Documentation!</h1>

--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -2,7 +2,31 @@
 template: templates/single-column.html 
 ---
 
-<link href="https://wso2.cachefly.net/wso2/sites/all/fonts/docs/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2" rel="stylesheet" />
+<style>
+    @font-face {
+    font-family: 'Material Icons';
+    font-style: normal;
+    font-weight: 400;
+    src: url(https://wso2.cachefly.net/wso2/sites/all/fonts/docs/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2) format('woff2');
+    }
+
+    .material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+    }
+</style>
+
 <div>
     <header>
         <h1>Welcome to the WSO2 Identity Server Documentation!</h1>


### PR DESCRIPTION
## Purpose
This PR removes the Google fonts and replaces them with fonts hosted on the WSO2 CDN.

Related issue: https://github.com/wso2/product-is/issues/16264