### PR TITLE
[master] Fix Incorrect configuration for `resend_code_validity`

### DIFF
--- a/en/docs/guides/identity-lifecycles/extend-username-and-password-recovery.md
+++ b/en/docs/guides/identity-lifecycles/extend-username-and-password-recovery.md
@@ -63,6 +63,8 @@ Follow the steps given below to recover a user in the super tenant (i.e., `carbo
     ``` toml
     [identity_mgt.notification_channel_recovery]
     recovery_code_validity=2
+   
+    [identity_mgt.resend_notification]
     resend_code_validity=5
     
     [identity_mgt.password_reset_sms]


### PR DESCRIPTION
## Purpose
The offical documentation at [1] instructs the users to use the following configuration to set the validity period of the recovery code given after initiating password recovery.

```
[identity_mgt.notification_channel_recovery]
recovery_code_validity=2
resend_code_validity=5
```
However, the above configuration is invalid because the parent tag is wrong hence it should be fixed with the following configuration which is the correct one. Related  identity.xml.j2 configurations for this configurations can be found out from here.[2]

```
[identity_mgt.notification_channel_recovery]
recovery_code_validity=2
    
[identity_mgt.resend_notification]
resend_code_validity=5
```

[1] - https://is.docs.wso2.com/en/5.11.0/learn/password-recovery-via-user-preferred-notification-channel/
[2] - https://github.com/wso2/carbon-identity-framework/blame/3288d9b9d60b56da7829892262e3cdba3910056c/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2#L1240-L1241
