### PR TITLE
[6.0.0] Add docs regarding the configurations to preserve locally added claims of JIT provisioned users.

### DIFF
--- a/en/docs/guides/identity-federation/jit-workflow.md
+++ b/en/docs/guides/identity-federation/jit-workflow.md
@@ -89,6 +89,19 @@ With the JIT provisioned enhanced feature, the following capabilities will be av
 - Editing JIT-provisioned user’s attributes will not be allowed.
 - Ability to lock JIT provisioned user accounts based on social identity.
 
+## Preserve Locally Added Claims of JIT Provisioned Users
+
+Identity server deletes the existing local claims of JIT provisioned users that are not coming in the federated login after the provisioning.
+
+You can change this default behavior to keep locally added claims of JIT provisioned users by  avoiding deleting the attributes that are not coming in the federated login after the provisioning.
+
+To preserve locally added claims of JIT provisioned users, add the following configuration to deployment.toml in the `/conf` directory.
+
+``` toml
+[authentication.jit_provisioning]
+enable_enhanced_feature = "true"
+```
+
 
 ## Customize JIT Provisioning User Interfaces
 


### PR DESCRIPTION
## Purpose

Identity server deletes the existing local claims of JIT provisioned users that are not coming in the federated login after the provisioning. 

You can change this default behavior to keep locally added claims of JIT provisioned users by  avoiding deleting the attributes that are not coming in the federated login after the provisioning.

To preserve locally added claims of JIT provisioned users, add the following configuration in the deployment.toml file.

```
[authentication.jit_provisioning]
preserve_locally_added_claims = true
```

Note:
- This configuration is available in IS 6.0.0 product from the update level **6.0.0.92**
- This configuration is available in IS 6.1.0 product from the update level **6.1.0.44**


## Related Git Issue
- https://github.com/wso2/product-is/issues/16281
