### PR TITLE
[master] Add resident IDP config step to react app integration guide

### DIFF
--- a/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
+++ b/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
@@ -66,7 +66,7 @@ To add CORS configurations:
     !!! info
         For example, if you are running the WSO2 Identity Server on port 9500, the updated **Identity Provider Entity ID** value should be `https://localhost:9500/oauth2/token`.
 
-4. Scroll to the bottom and click **Update** to complete the configuration.
+4. Click **Update** to complete the configuration.
 
 ## Download the sample
 Download the latest release of the [sample react application](https://github.com/asgardeo/asgardeo-auth-react-sdk/releases/latest/download/asgardeo-react-app.zip).

--- a/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
+++ b/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
@@ -54,7 +54,7 @@ To add CORS configurations:
     !!! note
         Make a note of the **OAuth Client Key** and **OAuth Client Secret** that appear, as they will be used to configure the sample application.
 
-## Configure the Resident Identity Provider
+## Configure the resident identity provider
 
 !!! Note
     Follow this step, only if you are running the WSO2 Identity Server on a custom domain/port.

--- a/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
+++ b/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
@@ -56,15 +56,13 @@ To add CORS configurations:
 
 ## Configure the resident identity provider
 
-!!! Note
-    Follow this step, only if you are running the WSO2 Identity Server on a custom domain/port.
+Follow this step, only if you are running the WSO2 Identity Server on a custom domain/port.
 
 1. On the WSO2 Identity Server management console (`https://<IS_HOST>:<PORT>/carbon`), go to **Main** > **Identity** > **Identity Providers**.
 2. Click **Resident** and expand **Inbound Authentication Configuration**.
 3. Expand **OAuth2 / OpenID Connect Configuration** and update **Identity Provider Entity ID** value to match with your custom domain/port.
 
-    !!! info
-        For example, if you are running the WSO2 Identity Server on port 9500, the updated **Identity Provider Entity ID** value should be `https://localhost:9500/oauth2/token`.
+    Eg: if you are running the WSO2 Identity Server on port 9500, the updated **Identity Provider Entity ID** value should be `https://localhost:9500/oauth2/token`.
 
 4. Click **Update** to complete the configuration.
 

--- a/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
+++ b/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
@@ -54,6 +54,20 @@ To add CORS configurations:
     !!! note
         Make a note of the **OAuth Client Key** and **OAuth Client Secret** that appear, as they will be used to configure the sample application.
 
+## Configure the Resident Identity Provider
+
+!!! Note
+    Follow this step, only if you are running the WSO2 Identity Server on a custom domain/port.
+
+1. On the WSO2 Identity Server management console (`https://<IS_HOST>:<PORT>/carbon`), go to **Main** > **Identity** > **Identity Providers**.
+2. Click **Resident** and expand **Inbound Authentication Configuration**.
+3. Expand **OAuth2 / OpenID Connect Configuration** and update **Identity Provider Entity ID** value to match with your custom domain/port.
+
+    !!! info
+        For example, if you are running the WSO2 Identity Server on port 9500, the updated **Identity Provider Entity ID** value should be `https://localhost:9500/oauth2/token`.
+
+4. Scroll to the bottom and click **Update** to complete the configuration.
+
 ## Download the sample
 Download the latest release of the [sample react application](https://github.com/asgardeo/asgardeo-auth-react-sdk/releases/latest/download/asgardeo-react-app.zip).
 


### PR DESCRIPTION
## Purpose

The doc for integrating React app with WSO2 IS is missing a step to follow when the IS is running on a custom domain / port. This PR to add that step to the doc.

![Updated view](https://github.com/wso2/docs-is/assets/41533942/d6286270-d1df-400a-a868-818041ce912a)

## Related issues

- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/196