### PR TITLE
[6.1.0] Add resident IDP config step to react app integration guide

### DIFF
--- a/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
+++ b/en/docs/sdks/start-integrating-apps/integrate-a-react-app.md
@@ -54,6 +54,18 @@ To add CORS configurations:
     !!! note
         Make a note of the **OAuth Client Key** and **OAuth Client Secret** that appear, as they will be used to configure the sample application.
 
+## Configure the resident identity provider
+
+Follow this step, only if you are running the WSO2 Identity Server on a custom domain/port.
+
+1. On the WSO2 Identity Server management console (`https://<IS_HOST>:<PORT>/carbon`), go to **Main** > **Identity** > **Identity Providers**.
+2. Click **Resident** and expand **Inbound Authentication Configuration**.
+3. Expand **OAuth2 / OpenID Connect Configuration** and update **Identity Provider Entity ID** value to match with your custom domain/port.
+
+    Eg: if you are running the WSO2 Identity Server on port 9500, the updated **Identity Provider Entity ID** value should be `https://localhost:9500/oauth2/token`.
+
+4. Click **Update** to complete the configuration.
+
 ## Download the sample
 Download the latest release of the [sample react application](https://github.com/asgardeo/asgardeo-auth-react-sdk/releases/latest/download/asgardeo-react-app.zip).
 


### PR DESCRIPTION
## Purpose
> The doc for integrating React app with WSO2 IS is missing a step to follow when the IS is running on a custom domain / port. This PR to add that step to the doc.

## Related issues

- fixes https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/196