### PR TITLE
[6.0.0] Update `username` recovery request with `password`

### DIFF
--- a/en/docs/guides/identity-lifecycles/extend-username-and-password-recovery.md
+++ b/en/docs/guides/identity-lifecycles/extend-username-and-password-recovery.md
@@ -274,7 +274,7 @@ sms notification templates.
 
 ### With internal notification management
 
-1. Use the following command to create a username recovery request.
+1. Use the following command to create a password recovery request.
 
     !!! abstract ""
         **Request Format**
@@ -429,7 +429,7 @@ sms notification templates.
 
 ### With external notification management
 
-1. Use the following command to create a username recovery request.
+1. Use the following command to create a password recovery request.
 
     !!! abstract ""
         **Request Format**


### PR DESCRIPTION
## Purpose
Related issue: https://github.com/wso2/product-is/issues/16405

Doc [1] and [2] have text errors. Both sections mention `Use the following command to create a username recovery request.`. This PR updates it to `Use the following command to create a password recovery request.`

[1] https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/extend-username-and-password-recovery/#with-internal-notification-management
[2] https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/extend-username-and-password-recovery/#with-external-notification-management