### PR TITLE
[5.11.0] Fix typo

### DIFF
--- a/en/docs/learn/lite-user-registration.md
+++ b/en/docs/learn/lite-user-registration.md
@@ -55,7 +55,7 @@ Execute the following cURL command to create a user using the email address alon
 
 ```curl 
 curl -X POST -H "Authorization: Basic [Base64encode(Username>:<Password>)]=" -H "Content-Type: application/json" -d '{"email
-": "<regsiter_email>","realm": "PRIMARY","preferedChannel":"Email","claims":[], "properties": []}' "https://localhost:9443/api/identity/user/v1.0/lite"
+": "<regsiter_email>","realm": "PRIMARY","preferredChannel":"Email","claims":[], "properties": []}' "https://localhost:9443/api/identity/user/v1.0/lite"
 ```
 
 This will also trigger an email with a confirmation code. `LiteUserEmailConfirmation` is the email template used. Modifications can be performed on the template if required. `ResendLiteUserEmailConfrimation` is the email template used for resending the code. 


### PR DESCRIPTION
The property name "preferedChannel" in the payload of the curl command was changed to "preferredChannel" as per the implementation.

Related Issues
https://github.com/wso2/product-is/issues/16409