### PR TITLE
Update the docs to reflect default callback URL regex issue fix

### DIFF
--- a/en/docs/deploy/security/product-level-security-guidelines.md
+++ b/en/docs/deploy/security/product-level-security-guidelines.md
@@ -340,7 +340,7 @@ Follow the steps below to change the default credentials.
     
 ## Callback URL Regular Expressions
 
-For the scenarios listed below, you can define a regular expression to validate the callback URL. The default configuration allows any callback URL. Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
+Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
 
 - [Password Recovery](../../../guides/password-mgt/recover-password/#enable-password-recovery-via-email)
 - [Username Recovery](../../../guides/identity-lifecycles/recover-username/#enable-username-recovery)

--- a/en/docs/deploy/security/product-level-security-guidelines.md
+++ b/en/docs/deploy/security/product-level-security-guidelines.md
@@ -340,7 +340,7 @@ Follow the steps below to change the default credentials.
     
 ## Callback URL Regular Expressions
 
-Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
+Note that if you are using these scenarios, we highly recommend you define the regular expression that validates and only allows access to specific callback URLs.
 
 - [Password Recovery](../../../guides/password-mgt/recover-password/#enable-password-recovery-via-email)
 - [Username Recovery](../../../guides/identity-lifecycles/recover-username/#enable-username-recovery)


### PR DESCRIPTION
### Purpose
This removes the section in the document which states that the users are required to change the default callback URL regex.

### Related Issues
https://github.com/wso2/product-is/issues/15773