### PR TITLE
Update the base_path to next release version

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1467,7 +1467,7 @@ extra:
     - type: linkedin
       link: https://www.linkedin.com/company/wso2
   site_version: 6.1.0
-  base_path: https://is.docs.wso2.com/en/6.1.0
+  base_path: https://is.docs.wso2.com/en/next
   #base_path: http://127.0.0.1:8000/en/6.1.0
 
   nav_list:


### PR DESCRIPTION
## Purpose
Since the base_path is configured for `https://is.docs.wso2.com/en/6.1.0` images are loaded from 6.1.0. So if there is a new doc added, images will not be loaded in the page.