### PR TITLE
[Doc] [5.11] Add grant level public client support configuration to the documentation

### DIFF
--- a/en/docs/learn/oauth-2.0-grant-types.md
+++ b/en/docs/learn/oauth-2.0-grant-types.md
@@ -53,6 +53,6 @@ supported by WSO2 Identity Server.
     by public clients or not. By default, `         PublicClientAllowed        ` 
     is set to `         true        `, and you can allow it to be used by
     public clients. By configuring it to `         false        `, you can
-    stop using the grant type by public clients.   
+    stop using the grant type in public clients.   
     **Note:** By default, using `         client_credentials        ` grant 
     type for public clients is disabled as it is logically invalid.

--- a/en/docs/learn/oauth-2.0-grant-types.md
+++ b/en/docs/learn/oauth-2.0-grant-types.md
@@ -46,3 +46,13 @@ supported by WSO2 Identity Server.
     **Note:** By default, issuing ID token for
     `         client_credentials        ` grant type is disabled as it is
     logically invalid.
+
+    By configuring the `         <PublicClientAllowed>        ` property
+    to `        true        ` or `         false        ` along with the
+    above configuration, you can decide whether the grant type can be used
+    by public clients or not. By default, `         PublicClientAllowed        ` 
+    is set to `         true        `, and you can allow it to be used by
+    public clients. By configuring it to `         false        `, you can
+    stop using the grant type by public clients.   
+    **Note:** By default, using `         client_credentials        ` grant 
+    type for public clients is disabled as it is logically invalid.

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -58,7 +58,7 @@ implement a new grant type.
 
     !!! info 
         - Setting the `<IdTokenAllowed>` parameter to
-        `            true           `, provides flexibility to control the
+        `true`, provides flexibility to control the
         issuing of IDtoken for each grant, and also allows the OIDC scope
         validator to validate the grant types that should support the openid
         scope.   

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -53,6 +53,7 @@ implement a new grant type.
     grant_validator="full qualified class name of grant validator"
     [oauth.custom_grant_type.properties]
     IdTokenAllowed=true
+    PublicClientAllowed=true
     ```
 
     !!! info 
@@ -60,7 +61,10 @@ implement a new grant type.
         `            true           `, provides flexibility to control the
         issuing of IDtoken for each grant, and also allows the OIDC scope
         validator to validate the grant types that should support the openid
-        scope.
+        scope.   
+        Setting the `            <PublicClientAllowed>           ` parameter 
+        to `            true           `, provides the ability for the public
+        clients to use the grant type for public client authentication.
 
     To test this out, follow the instructions below to implement a
     custom-grant type sample.

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -57,7 +57,7 @@ implement a new grant type.
     ```
 
     !!! info 
-        - Setting the `<IdTokenAllowed>` parameter to
+        Setting the `<IdTokenAllowed>` parameter to
         `true`, provides flexibility to control the
         issuing of IDtoken for each grant, and also allows the OIDC scope
         validator to validate the grant types that should support the openid

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -57,7 +57,7 @@ implement a new grant type.
     ```
 
     !!! info 
-        Setting the `            <IdTokenAllowed>           ` parameter to
+        - Setting the `<IdTokenAllowed>` parameter to
         `            true           `, provides flexibility to control the
         issuing of IDtoken for each grant, and also allows the OIDC scope
         validator to validate the grant types that should support the openid

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -66,7 +66,6 @@ implement a new grant type.
         to `            true           `, provides the ability for the public
         clients to use the grant type for public client authentication.
 
-    To test this out, follow the instructions below to implement a
 
 ------------------------------------------------------------------------
 

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -63,7 +63,7 @@ implement a new grant type.
         validator to validate the grant types that should support the openid
         scope.   
         Setting the `            <PublicClientAllowed>           ` parameter 
-        to `            true           `, provides the ability for the public
+        to `true`, provides the ability for the public
         clients to use the grant type for public client authentication.
 
 

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -62,7 +62,7 @@ implement a new grant type.
         issuing of IDtoken for each grant, and also allows the OIDC scope
         validator to validate the grant types that should support the openid
         scope.   
-        Setting the `            <PublicClientAllowed>           ` parameter 
+        Setting the `<PublicClientAllowed>` parameter 
         to `true`, provides the ability for the public
         clients to use the grant type for public client authentication.
 

--- a/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/learn/writing-a-custom-oauth-2.0-grant-type.md
@@ -67,7 +67,6 @@ implement a new grant type.
         clients to use the grant type for public client authentication.
 
     To test this out, follow the instructions below to implement a
-    custom-grant type sample.
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose
With this PR, we will document about a new configuration introduced to configure support for public clients for each grant types.

Changes made to the documentation:
<img width="1511" alt="Screenshot 2023-09-25 at 09 29 59" src="https://github.com/wso2/docs-is/assets/50801227/01332786-5fa2-492e-8a4e-c6084160af4f">
<img width="1511" alt="Screenshot 2023-09-25 at 09 31 07" src="https://github.com/wso2/docs-is/assets/50801227/01389800-2ae0-4206-a20e-da6412b8b4af">


