### PR TITLE
[Doc] Add OAuth grant types overview page and add grant level public client support configuration

### DIFF
--- a/en/docs/guides/access-delegation/oauth-2.0-grant-types.md
+++ b/en/docs/guides/access-delegation/oauth-2.0-grant-types.md
@@ -1,0 +1,57 @@
+# OAuth 2.0 Grant Types
+
+Grant types are used to authorize access to protected resources in
+different ways. This section lists out the main OAuth2 grant types
+supported by WSO2 Identity Server.
+
+-   [Authorization Code Grant]({{base_path}}/guides/access-delegation/auth-code-playground)
+-   [Client Credentials Grant]({{base_path}}/guides/access-delegation/client-credentials-playground)
+-   [Device Flow Grant]({{base_path}}/guides/access-delegation/try-device-flow)
+-   [Refresh Token Grant]({{base_path}}/guides/access-delegation/configure-refresh-token)
+-   [Implicit Grant]({{base_path}}/guides/access-delegation/implicit-playground/)
+-   [Password Grant]({{base_path}}/guides/access-delegation/password-playground)
+
+!!! note
+
+    WSO2 Identity Server provides more control over issuing id tokens and
+    user claims for client-credential grant type. To facilitate this, add the following configurations to the `deployment.toml` file found in the `<IS_HOME>/repository/conf` folder in order 
+    to register new `         ScopeHandlers        ` and
+    `         ScopeValidators        ` .
+    
+    ``` toml
+    [oauth.custom_scope_validator]
+    class = "org.fully.qualified.class.name.CustomScopeValidator"
+    ```
+    
+    Further, by configuring the `         <IdTokenAllowed>        ` property
+    to `         true        ` or `         false        ` along with the
+    above configuration, you can turn on or turn off the process of issuing
+    ID tokens for the grant types that have the `         openid        `
+    scope. By default, `         IdTokenAllowed        ` is set to
+    `         true        `, you can allow it to issue
+    `         id_tokens        ` for all grant types that have the
+    `         openid        ` scope. By configuring it to false, you can
+    stop issuing ID tokens.  
+    **Note:** You can not turn off the process of issuing ID tokens for the
+    `         authorization_code        ` grant type.
+    
+    By configuring the `         <IsRefreshTokenAllowed>        ` property
+    to `         true        ` or `         false        ` along with the
+    above configuration, you can turn on or turn on the process of issuing
+    refresh tokens. By default, `         IsRefreshTokenAllowed        ` is
+    set to `         true        `, and `        ` you can allow it to
+    issue refresh tokens for all grant types. By configuring it to
+    `         false        `, you can stop issuing refresh tokens.  
+    **Note:** By default, issuing ID token for
+    `         client_credentials        ` grant type is disabled as it is
+    logically invalid.
+
+    By configuring the `         <PublicClientAllowed>        ` property
+    to `        true        ` or `         false        ` along with the
+    above configuration, you can decide whether the grant type can be used
+    by public clients or not. By default, `         PublicClientAllowed        ` 
+    is set to `         true        `, and you can allow it to be used by
+    public clients. By configuring it to `         false        `, you can
+    stop using the grant type in public clients.   
+    **Note:** By default, using `         client_credentials        ` grant 
+    type for public clients is disabled as it is logically invalid.

--- a/en/docs/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type.md
+++ b/en/docs/references/extend/oauth2/write-a-custom-oauth-2.0-grant-type.md
@@ -50,6 +50,7 @@ Follow the steps given below to implement a new grant type.
     grant_validator="full qualified class name of grant validator"
     [oauth.custom_grant_type.properties]
     IdTokenAllowed=true
+    PublicClientAllowed=true
     ```
 
     !!! info 
@@ -57,7 +58,10 @@ Follow the steps given below to implement a new grant type.
         `            true           `, provides flexibility to control the
         issuing of IDtoken for each grant, and also allows the OIDC scope
         validator to validate the grant types that should support the openid
-        scope.
+        scope.   
+        Setting the `<PublicClientAllowed>` parameter
+        to `true`, provides the ability for the public
+        clients to use the grant type for public client authentication.
 
 4. Restart the server to apply changes.
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1470,8 +1470,8 @@ extra:
     - type: linkedin
       link: https://www.linkedin.com/company/wso2
   site_version: 6.1.0
-  #base_path: https://is.docs.wso2.com/en/next
-  base_path: http://127.0.0.1:8000/en/6.1.0
+  base_path: https://is.docs.wso2.com/en/next
+  #base_path: http://127.0.0.1:8000/en/6.1.0
 
   nav_list:
     - Home

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -201,6 +201,7 @@ nav:
       - Access Delegation:
         - Overview: guides/access-delegation/access-delegation.md
         - OAuth 2.0 Grant Types:
+          - Overview: guides/access-delegation/oauth-2.0-grant-types.md
           - Authorization Code Grant: guides/access-delegation/auth-code-playground.md
           - Client Credentials Grant: guides/access-delegation/client-credentials-playground.md
           - Device Flow Grant: guides/access-delegation/try-device-flow.md
@@ -1469,8 +1470,8 @@ extra:
     - type: linkedin
       link: https://www.linkedin.com/company/wso2
   site_version: 6.1.0
-  base_path: https://is.docs.wso2.com/en/next
-  #base_path: http://127.0.0.1:8000/en/6.1.0
+  #base_path: https://is.docs.wso2.com/en/next
+  base_path: http://127.0.0.1:8000/en/6.1.0
 
   nav_list:
     - Home


### PR DESCRIPTION
## Purpose
1. An overview page has been added to the OAuth2 grant types
3. Documented about a new configuration introduced to configure support for public clients for each grant types.

Screenshots:
![Screenshot 2023-10-05 at 13 46 50](https://github.com/wso2/docs-is/assets/50801227/b5cb9f37-cf90-421f-b76b-62443ea1bb61)
![Screenshot 2023-10-05 at 13 47 06](https://github.com/wso2/docs-is/assets/50801227/03f156ef-16b3-4884-bf79-df798958d803)
![Screenshot 2023-10-05 at 13 47 58](https://github.com/wso2/docs-is/assets/50801227/6c72442b-78c6-41f6-94db-7311860d46c1)
