### PR TITLE
Fix formatting in doc link

### DIFF
--- a/en/docs/references/extend/provisioning/add-scim2-custom-user-schema-support.md
+++ b/en/docs/references/extend/provisioning/add-scim2-custom-user-schema-support.md
@@ -1,6 +1,6 @@
 # Adding SCIM2 Custom User Schema Support
 
-WSO2 Identity Server allows adding custom attributes into user objects through [Enterprise User Extension](({{base_path}}/references/extend/provisioning/extend-scim2-user-schemas). From 6.0.0 onwards, you can use this custom schema to add custom attributes of the user.
+WSO2 Identity Server allows adding custom attributes into user objects through [Enterprise User Extension]({{base_path}}/references/extend/provisioning/extend-scim2-user-schemas). From 6.0.0 onwards, you can use this custom schema to add custom attributes of the user.
 
 !!! Note
     **Reasons why we introduced custom schema to add custom attributes:**


### PR DESCRIPTION
## Purpose
Description of the doc https://is.docs.wso2.com/en/latest/references/extend/provisioning/add-scim2-custom-user-schema-support/#add-custom-schema-dialect has a doc link which is not properly formatted.


This PR fixes the issue.

<img width="1132" alt="Screenshot 2023-10-11 at 00 23 04" src="https://github.com/wso2/docs-is/assets/25483865/647575fd-cd08-4941-a188-65768b0b1631">
