### PR TITLE
[7.0.0] Add Documentation for Userstore export and import rest apis

### DIFF
--- a/en/identity-server/next/docs/apis/restapis/user-store.yaml
+++ b/en/identity-server/next/docs/apis/restapis/user-store.yaml
@@ -24,7 +24,8 @@ paths:
 
           To retrieve the available user store classes/types, use the **api/server/v1/userstores/meta/types** API.
 
-         <b>Permission required:</b> `/permission/admin`
+         <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/create` <br>
+         <b>Scope Required:</b> `internal_userstore_create`
       responses:
         '201':
           description: Successful response
@@ -76,11 +77,12 @@ paths:
     get:
       tags:
         - User Store
-      summary: Retrieve or list the configured secondary user stores
+      summary: Retrieve the list of secondary user stores
       operationId: getSecondaryUserStores
       description: >
-        This API provides the capability to list the configured secondary user stores.
-        <br><b>Permission required:</b> `/permission/admin`
+        This API provides the capability to list the configured secondary user stores.<br>
+        <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+        <b>Scope required:</b> `internal_userstore_view`
       parameters:
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
@@ -110,8 +112,55 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/t/carbon.super/api/server/v1/userstores' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='            
-  '/userstores/primary':
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='  
+  /userstores/import:
+    post:
+      tags:
+        - User Store
+      summary: |
+        Import a secondary user store from a file
+      description: >
+        This API provides the capability to import a user store from
+        the configurations provided as a `YAML`, `JSON`, or `XML` file.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/userstore/config/create <br>
+          <b>Scope required:</b> <br>
+              * internal_userstore_create
+      operationId: importUserStoreFromFile
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUpload'
+        description: This represents the user store to be created.
+      responses:
+        '201':
+          description: Successful response
+          headers:
+            Location:
+              description: >-
+                Location of the newly created secondary userstore. userstore id is generated as base-64-url-encoded(domain-name) value.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      x-codeSample:
+        - lang: Curl
+          source: |
+            curl -X 'POST' \
+            'https://localhost:9443/t/carbon.super/api/server/v1/userstores/import' \
+            -H 'accept: */*' \
+            -H 'Content-Type: multipart/form-data' \
+            -F 'file=@file-name.xml;type=text/xml'
+  /userstores/primary:
     get:
       tags:
         - User Store
@@ -119,10 +168,10 @@ paths:
         Retrieve the configurations of primary user store
       operationId: getPrimaryUserStore
       description: >
-        This API provides the capability to retrieve the configurations of
-        primary user store.
+        This API provides the capability to retrieve the configurations of the primary user store.
 
-          <b>Permission required:</b> `/permission/admin`
+          <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+          <b>Scopes Required:</b> `internal_userstore_view`
       responses:
         '200':
           description: Successful response.
@@ -151,10 +200,10 @@ paths:
         Retrieve the configurations of secondary user store based on its domain id
       operationId: getUserStoreByDomainId
       description: >
-        This API provides the capability to retrieve the configurations of
-        secondary user store based on its domain id.
+        This API provides the capability to retrieve the configurations of a secondary user store based on its domain id. <br>
 
-          <b>Permission required:</b> `/permission/admin`
+          <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+          <b>Scope required:</b> `internal_userstore_view`
       parameters:
         - $ref: '#/components/parameters/domainNamePathParam'
       responses:
@@ -183,10 +232,10 @@ paths:
       summary: Delete a secondary user store
       operationId: deleteUserStore
       description: >
-        This API provides the capability to delete a secondary user store
-        matching to the given user store domain id.
+        This API provides the capability to delete a secondary user store based on the given user store domain id.<br>
 
-         <b>Permission required:</b> `/permission/admin`
+         <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/delete` <br>
+         <b>Scope required:</b> `internal_userstore_delete`
       parameters:
         - $ref: '#/components/parameters/domainNamePathParam'
       responses:
@@ -211,10 +260,10 @@ paths:
       summary: Update a user store by its domain id
       operationId: updateUserStore
       description: >
-        This API provides the capability to edit a user store based on its
-        domain id.
+        This API provides the capability to edit a user store based on its domain id. <br>
 
-         <b>Permission required:</b> `/permission/admin`
+         <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/update` <br>
+         <b>Permission required:</b> `internal_userstore_update`
       parameters:
         - in: path
           name: userstore-domain-id
@@ -318,6 +367,117 @@ paths:
             schema:
               $ref: '#/components/schemas/PatchRequest'
         required: true
+  /userstores/{userstore-domain-id}/export:
+      get:
+        tags:
+          - User Store
+        summary: |
+          Export a secondary user store by its domain id
+        description: |
+          This API provides the capability to retrieve the configurations of a
+          secondary user store based on its domain id as an `XML`, `YAML`, or `JSON` file.<br>
+          <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+          <b>Scope required:</b> `internal_userstore_view`
+        operationId: exportUserStoreToFile
+        parameters:
+          - name: userstore-domain-id
+            in: path
+            description: ID of the user store domain.
+            required: true
+            schema:
+              type: string
+              example: SkRCQy1TRUNPTkRBUlk
+          - $ref: '#/components/parameters/fileTypeHeaderParam'
+        responses:
+          '200':
+            description: Successful response.
+            content:
+              application/json:
+                schema:
+                  type: string
+                example: 'Sample userstore configuration in the requested format'
+              application/yaml:
+                schema:
+                  type: string
+                example: 'Sample userstore configuration in the requested format'
+              application/xml:
+                schema:
+                  type: string
+                example: 'Sample userstore configuration in the requested format'
+              application/octet-stream:
+                schema:
+                  type: string
+                example: 'Sample userstore configuration in the requested format'
+          '400':
+            $ref: '#/components/responses/InvalidInput'
+          '401':
+            $ref: '#/components/responses/Unauthorized'
+          '403':
+            $ref: '#/components/responses/Forbidden'
+          '404':
+            $ref: '#/components/responses/NotFound'
+          '409':
+            $ref: '#/components/responses/Conflict'
+          '500':
+            $ref: '#/components/responses/ServerError'
+        x-codeSamples:
+          - lang: Curl
+            source: |
+              curl -X 'GET' \
+              'https://localhost:9443/t/carbon.super/api/server/v1/userstores/{domain-id}/export' \
+              -H 'accept: application/json' 
+  /userstores/{userstore-domain-id}/import:
+    put:
+      tags:
+        - User Store
+      summary: |
+        Update an existing user store by importing configs from a file
+      description: >
+        This API provides the capability to update an existing user store by importing
+        user store configurations provided as a YAML, JSON or XML file.<br>
+          <b>Permission required:</b> `permission/admin/manage/identity/userstore/config/update` <br>
+          <b>Scope required:</b> `internal_userstore_update`
+      operationId: updateUserStoreFromFile
+      parameters:
+        - name: userstore-domain-id
+          in: path
+          description: ID of the user store.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUpload'
+        description: This represents the user store to be updated.
+      responses:
+        '200':
+          description: Successfully Updated.
+          headers:
+            Location:
+              description: >-
+                Location of the updated userstore. userstore id is generated as base-64-url-encoded(domain-name) value.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl -X 'PUT' \
+            'https://localhost:9443/t/carbon.super/api/server/v1/userstores/{userstore-domain-id}/import' \
+            -H 'accept: */*' \
+            -H 'Content-Type: multipart/form-data' \
+            -F 'file=@file-name.xml;type=text/xml'
   /userstores/meta/types:
     get:
       tags:
@@ -325,10 +485,11 @@ paths:
       summary: Retrieve the available user store classes/types
       operationId: getAvailableUserStoreTypes
       description: >
-        This API provides the capability to retrieve the available user store
-        types.
+        This API provides the capability to retrieve the available user store types. <br>
 
-         <b>Permission required:</b> `/permission/admin`
+         <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+         <b>Scope required:</b> `internal_userstore_view`
+
       responses:
         '200':
           description: Successful Response.
@@ -357,10 +518,11 @@ paths:
         Retrieve the properties of secondary user store of a given user store type
       operationId: getUserStoreManagerProperties
       description: >
-        This API provides the capability to retrieve the properties of secondary
-        user store of a given class name.
+        This API provides the capability to retrieve the properties of secondary user store of a given class name. <br>
 
-         <b>Permission required:</b> `/permission/admin`
+         <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+         <b>Scope required:</b> `internal_userstore_view`
+
       parameters:
         - in: path
           name: type-id
@@ -400,9 +562,10 @@ paths:
       operationId: testRDBMSConnection
       description: >
         This API provides the capability to test the connection to the
-        datasource used by a JDBC user store manager.
+        datasource used by a JDBC user store manager. <br>
 
-          <b>Permission required:</b> `/permission/admin`
+          <b>Permission required:</b> `/permission/admin/manage/identity/userstore/config/view` <br>
+          <b>Permission required:</b> `internal_userstore_view`
       responses:
         '200':
           description: Successful response.
@@ -492,6 +655,23 @@ components:
       description: Define set of user store attributes (as comma separated) to be returned.
       schema:
         type: string
+    fileTypeHeaderParam:
+      in: header
+      name: Accept
+      required: false
+      description: |
+        Content type of the file.
+      schema:
+        type: string
+        default: application/yaml
+        enum:
+          - application/json
+          - application/xml
+          - application/yaml
+          - application/x-yaml
+          - text/yaml
+          - text/xml
+          - text/json        
   responses:
     NotFound:
       description: The specified resource is not found.
@@ -821,3 +1001,10 @@ components:
         value:
           type: string
           example: basic
+    FileUpload:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+          description: File uploaded during import.          


### PR DESCRIPTION
## Purpose
This PR adds documentation for the new secondary userstore export and import APIs.

3 new APIs are added:
Export - /userstores/{userstore-domain-id}/export- GET
Import - /userstores/import- POST
Update - /userstores/{userstore-domain-id}/import - PUT

Related Issue: https://github.com/wso2/product-is/issues/15891
Related PR: https://github.com/wso2/identity-api-server/pull/448

This PR also updates the permissions and scopes of userstore APIs according to the changes added by https://github.com/wso2/identity-api-server/pull/447

PR from master-deprecated: https://github.com/wso2/docs-is/pull/3745