### PR TITLE
Remove basic Auth from supported authorization mechanisms of organization level APIs

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/group-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/group-management.yaml
@@ -13,7 +13,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 paths:
   /Groups:
     get:
@@ -132,7 +131,7 @@ paths:
           content:
             application/scim+json:
               schema:
-                $ref: '#/components/schemas/ErroGroupAlreadyAvailable'
+                $ref: '#/components/schemas/ErrorGroupAlreadyAvailable'
       x-codeSamples:
         - lang: Curl
           source: |
@@ -869,7 +868,7 @@ components:
         scimType:
           type: string
           example: Forbidden
-    ErroGroupAlreadyAvailable:
+    ErrorGroupAlreadyAvailable:
       required:
         - detail
         - status
@@ -885,9 +884,6 @@ components:
           type: string
           example: 'Group with name: PRIMARY/manager already exists in the system.'
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/idp.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/idp.yaml
@@ -7,7 +7,6 @@ info:
   title: Identity Provider Management API
 security:
   - OAuth2: []
-  - BasicAuth: []
 paths:
   /identity-providers:
     get:
@@ -1858,9 +1857,6 @@ components:
           - text/xml
           - text/json
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/user-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/user-management.yaml
@@ -13,7 +13,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 paths:
   /Users:
     get:
@@ -769,9 +768,6 @@ components:
           type: string
           example: Internal Server Error.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:


### PR DESCRIPTION
## Purpose
Part of https://github.com/wso2/product-is/issues/16548

- Remove basic Auth from supported authorization mechanisms of organization level APIs
- Fix typo