### PR TITLE
Rename passivests WReply URL

### DIFF
--- a/en/identity-server/6.0.0/docs/guides/login/configure-ws-federation-single-sign-on.md
+++ b/en/identity-server/6.0.0/docs/guides/login/configure-ws-federation-single-sign-on.md
@@ -139,7 +139,7 @@ The next step is to configure the service provider.
 
     -   **Passive STS Realm** :`               PassiveSTSSampleApp             `
 
-    -   **Assertion Consumer URL** :`http://localhost:8080/PassiveSTSSampleApp/index.jsp`
+    -   **Passive STS WReply URL** :`http://localhost:8080/PassiveSTSSampleApp/index.jsp`
                  
     Click Yes, in the message that appears.
 

--- a/en/identity-server/6.0.0/docs/guides/login/webapp-ws-federation.md
+++ b/en/identity-server/6.0.0/docs/guides/login/webapp-ws-federation.md
@@ -69,7 +69,7 @@ To configure additional properties for the sample application:
     | Field name | Value | Description  |
     |------------|-------|--------------|
     | **Passive STS Realm** | `PassiveSTSSampleApp`  | This should be a unique identifier for the web app. Provide the same realm name given to the web app you are configuring WS-Federation for. |
-    | **Assertion Consumer URL**    | `http://localhost:8080/PassiveSTSSampleApp/index.jsp`    | Provide the URL of the web app you are configuring WS-Federation for. This endpoint URL will handle the token response. |
+    | **Passive STS WReply URL**    | `http://localhost:8080/PassiveSTSSampleApp/index.jsp`    | Provide the URL of the web app you are configuring WS-Federation for. This endpoint URL will handle the token response. |
 
 4. Expand **Claim Configuration** and click **Add Claim URI** next to **Requested Claims**, and add the following claims:
 

--- a/en/identity-server/6.1.0/docs/guides/login/configure-ws-federation-single-sign-on.md
+++ b/en/identity-server/6.1.0/docs/guides/login/configure-ws-federation-single-sign-on.md
@@ -139,7 +139,7 @@ The next step is to configure the service provider.
 
     -   **Passive STS Realm** :`               PassiveSTSSampleApp             `
 
-    -   **Assertion Consumer URL** :`http://localhost:8080/PassiveSTSSampleApp/index.jsp`
+    -   **Passive STS WReply URL** :`http://localhost:8080/PassiveSTSSampleApp/index.jsp`
                  
     Click Yes, in the message that appears.
 

--- a/en/identity-server/6.1.0/docs/guides/login/webapp-ws-federation.md
+++ b/en/identity-server/6.1.0/docs/guides/login/webapp-ws-federation.md
@@ -69,7 +69,7 @@ To configure additional properties for the sample application:
     | Field name | Value | Description  |
     |------------|-------|--------------|
     | **Passive STS Realm** | `PassiveSTSSampleApp`  | This should be a unique identifier for the web app. Provide the same realm name given to the web app you are configuring WS-Federation for. |
-    | **Assertion Consumer URL**    | `http://localhost:8080/PassiveSTSSampleApp/index.jsp`    | Provide the URL of the web app you are configuring WS-Federation for. This endpoint URL will handle the token response. |
+    | **Passive STS WReply URL**    | `http://localhost:8080/PassiveSTSSampleApp/index.jsp`    | Provide the URL of the web app you are configuring WS-Federation for. This endpoint URL will handle the token response. |
 
 4. Expand **Claim Configuration** and click **Add Claim URI** next to **Requested Claims**, and add the following claims:
 


### PR DESCRIPTION
PassiveSTS connector does not have a Assertion Consumer URL but WReply URL. Therefore it should be corrected. 