### PR TITLE
Updated the export bulk user tool

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/exporting-user-data-from-wso2-is.md
+++ b/en/identity-server/5.10.0/docs/learn/exporting-user-data-from-wso2-is.md
@@ -1,10 +1,7 @@
-#Exporting User Data from WSO2 Identity Server
+# Exporting User Data from WSO2 Identity Server
 
-1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.3.2/scim.bulk.user.export.tool-4.3.2.zip).
-    
-    !!! note 
-        The SCIM2 Users endpoint used by the scim-bulk-user-export-tool mentioned above, does not support pagination and can only be used with smaller user bases.
-        
+1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.5.6/scim.bulk.user.export.tool-4.5.6.zip).
+
 2. Extract the downloaded .zip file.
 3. Run the `start.sh` script inside the extracted directory.
 
@@ -13,7 +10,7 @@
 4. Provide the host address of the WSO2 Identity Server instance.
 
     !!! Note
-        
+
         If you are getting data from the super-tenant, you only need to provide the host address of the instance 
         
         (E.g. For a local instance `https://localhost:9443`). 
@@ -21,11 +18,21 @@
         If you are getting data from a tenant, you need to append `t/<tenant-domain>` to the host address. 
         
         (E.g. For a local instance `https://localhost:9443/t/wso2`).
-    
+
 5. Provide the user credentials of a user with the required permissions to call SCIM 2.0 `users` endpoint.
-6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default, 
+
+6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default,
 the tool will create `users.csv` in the tool directory.
+
 7. Select the attributes that need to be filtered. Only the chosen attributes will be specified in the CSV file.
 This is also an **optional** input.
-8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in 
-the CSV file. This is also an **optional** input.
+
+8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in the CSV file. This is also an **optional** input.
+
+9. Provide the userstore domain to be filtered to have users from the specified userstore in the created CSV file. This is an **optional** input.
+
+10. Provide the start index to retrieve the users. The default is set to 1.
+
+11. Provide the batch count to retrieve the users. The default is set to 100.
+
+12. Provide the maximum count of users to be retrieved. The default is set to unlimited.

--- a/en/identity-server/5.11.0/docs/learn/exporting-user-data-from-wso2-is.md
+++ b/en/identity-server/5.11.0/docs/learn/exporting-user-data-from-wso2-is.md
@@ -1,10 +1,7 @@
-#Exporting User Data from WSO2 Identity Server
+# Exporting User Data from WSO2 Identity Server
 
-1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.3.2/scim.bulk.user.export.tool-4.3.2.zip).
+1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.5.6/scim.bulk.user.export.tool-4.5.6.zip).
 
-    !!! note 
-        The SCIM2 Users endpoint used by the scim-bulk-user-export-tool mentioned above, does not support pagination and can only be used with smaller user bases.
-        
 2. Extract the downloaded .zip file.
 3. Run the `start.sh` script inside the extracted directory.
 
@@ -13,7 +10,7 @@
 4. Provide the host address of the WSO2 Identity Server instance.
 
     !!! Note
-        
+
         If you are getting data from the super-tenant, you only need to provide the host address of the instance 
         
         (E.g. For a local instance `https://localhost:9443`). 
@@ -21,11 +18,21 @@
         If you are getting data from a tenant, you need to append `t/<tenant-domain>` to the host address. 
         
         (E.g. For a local instance `https://localhost:9443/t/wso2`).
-    
+
 5. Provide the user credentials of a user with the required permissions to call SCIM 2.0 `users` endpoint.
-6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default, 
+
+6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default,
 the tool will create `users.csv` in the tool directory.
+
 7. Select the attributes that need to be filtered. Only the chosen attributes will be specified in the CSV file.
 This is also an **optional** input.
-8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in 
-the CSV file. This is also an **optional** input.
+
+8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in the CSV file. This is also an **optional** input.
+
+9. Provide the userstore domain to be filtered to have users from the specified userstore in the created CSV file. This is an **optional** input.
+
+10. Provide the start index to retrieve the users. The default is set to 1.
+
+11. Provide the batch count to retrieve the users. The default is set to 100.
+
+12. Provide the maximum count of users to be retrieved. The default is set to unlimited.

--- a/en/identity-server/6.0.0/docs/guides/identity-lifecycles/sync-account-overview.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-lifecycles/sync-account-overview.md
@@ -1,6 +1,7 @@
 # Exporting User Data from WSO2 Identity Server
 
-1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.3.2/scim.bulk.user.export.tool-4.3.2.zip).
+1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.5.6/scim.bulk.user.export.tool-4.5.6.zip).
+
 2. Extract the downloaded .zip file.
 3. Run the `start.sh` script inside the extracted directory.
 
@@ -9,7 +10,7 @@
 4. Provide the host address of the WSO2 Identity Server instance.
 
     !!! Note
-        
+
         If you are getting data from the super-tenant, you only need to provide the host address of the instance 
         
         (E.g. For a local instance `https://localhost:9443`). 
@@ -17,11 +18,21 @@
         If you are getting data from a tenant, you need to append `t/<tenant-domain>` to the host address. 
         
         (E.g. For a local instance `https://localhost:9443/t/wso2`).
-    
+
 5. Provide the user credentials of a user with the required permissions to call SCIM 2.0 `users` endpoint.
-6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default, 
+
+6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default,
 the tool will create `users.csv` in the tool directory.
+
 7. Select the attributes that need to be filtered. Only the chosen attributes will be specified in the CSV file.
 This is also an **optional** input.
-8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in 
-the CSV file. This is also an **optional** input.
+
+8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in the CSV file. This is also an **optional** input.
+
+9. Provide the userstore domain to be filtered to have users from the specified userstore in the created CSV file. This is an **optional** input.
+
+10. Provide the start index to retrieve the users. The default is set to 1.
+
+11. Provide the batch count to retrieve the users. The default is set to 100.
+
+12. Provide the maximum count of users to be retrieved. The default is set to unlimited.

--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/sync-account-overview.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/sync-account-overview.md
@@ -1,6 +1,7 @@
 # Exporting User Data from WSO2 Identity Server
 
-1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.3.2/scim.bulk.user.export.tool-4.3.2.zip).
+1. Download **scim-bulk-user-export-tool** from [here](https://maven.wso2.org/nexus/content/groups/public/org/wso2/samples/is/scim.bulk.user.export.tool/4.5.6/scim.bulk.user.export.tool-4.5.6.zip).
+
 2. Extract the downloaded .zip file.
 3. Run the `start.sh` script inside the extracted directory.
 
@@ -9,7 +10,7 @@
 4. Provide the host address of the WSO2 Identity Server instance.
 
     !!! Note
-        
+
         If you are getting data from the super-tenant, you only need to provide the host address of the instance 
         
         (E.g. For a local instance `https://localhost:9443`). 
@@ -17,11 +18,21 @@
         If you are getting data from a tenant, you need to append `t/<tenant-domain>` to the host address. 
         
         (E.g. For a local instance `https://localhost:9443/t/wso2`).
-    
+
 5. Provide the user credentials of a user with the required permissions to call SCIM 2.0 `users` endpoint.
-6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default, 
+
+6. Provide the location of the CSV file you need to create. This is an **optional** parameter and by default,
 the tool will create `users.csv` in the tool directory.
+
 7. Select the attributes that need to be filtered. Only the chosen attributes will be specified in the CSV file.
 This is also an **optional** input.
-8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in 
-the CSV file. This is also an **optional** input.
+
+8. Provide the attributes that you need to exclude when creating the CSV file. These attributes will not be included in the CSV file. This is also an **optional** input.
+
+9. Provide the userstore domain to be filtered to have users from the specified userstore in the created CSV file. This is an **optional** input.
+
+10. Provide the start index to retrieve the users. The default is set to 1.
+
+11. Provide the batch count to retrieve the users. The default is set to 100.
+
+12. Provide the maximum count of users to be retrieved. The default is set to unlimited.


### PR DESCRIPTION
## Purpose

 **scim-bulk-user-export-tool** was updated to 4.5.6 [1] in IS documentation versions 5.10, 5.11, 6.0.0 and 6.1.0.

>Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/1159#issuecomment-1876779661

[1] https://github.com/wso2/samples-is/tree/v4.5.6/bulk-user-export-tool