### PR TITLE
[6.1.0] Updated copyrights

### DIFF
--- a/en/theme/material/partials/footer.html
+++ b/en/theme/material/partials/footer.html
@@ -66,7 +66,7 @@
         {% endif %}
         <div class="md-footer-copyright__content">
           <div>
-              Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC 2023
+              Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC (2023-2024)
           </div>
           <div>
               Content licensed under <a href="https://creativecommons.org/licenses/by/4.0">CC By 4.0.</a> | Sample code licensed under <a href="http://www.apache.org/licenses/">Apache 2.0</a>.


### PR DESCRIPTION
## Purpose
- fixes https://github.com/wso2/product-is/issues/18917
- Updated the year mentioned in the copyrights statement.
     WSO2 generally follows the standard of adding the year of the copyrights based on the initial year the documentation was created to the current year (e.g., [1]). Therefore, I updated the copyrights year in this manner as opposed to just mentioning 2024.

[1] https://is.docs.wso2.com/en/5.11.0/

## Related to
https://github.com/wso2/product-is/issues/18917

## Reviewer
@himeshsiriwardana

## Assignee
@Mariangela 
