### PR TITLE
Update OIDC DCR /register/{client_id} endpoint 404 response to 401

### DIFF
--- a/en/identity-server/6.0.0/docs/apis/restapis/oauth-dcr.yaml
+++ b/en/identity-server/6.0.0/docs/apis/restapis/oauth-dcr.yaml
@@ -148,8 +148,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/application'
-        404:
-          description: Not Found
+        401:
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -252,8 +252,8 @@ paths:
         204:
           description: Successfully deleted
           content: {}
-        404:
-          description: Not Found
+        401:
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/en/identity-server/6.1.0/docs/apis/restapis/oauth-dcr.yaml
+++ b/en/identity-server/6.1.0/docs/apis/restapis/oauth-dcr.yaml
@@ -148,8 +148,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/application'
-        404:
-          description: Not Found
+        401:
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -252,8 +252,8 @@ paths:
         204:
           description: Successfully deleted
           content: {}
-        404:
-          description: Not Found
+        401:
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/en/identity-server/next/docs/apis/restapis/oauth-dcr.yaml
+++ b/en/identity-server/next/docs/apis/restapis/oauth-dcr.yaml
@@ -187,8 +187,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/application'
-        404:
-          description: Not Found
+        401:
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -319,8 +319,8 @@ paths:
         204:
           description: Successfully deleted
           content: {}
-        404:
-          description: Not Found
+        401:
+          description: Unauthorized
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Purpose
These endpoints doesn't return 404 responses and according to the specification we can't return 404 responses as well [1]. However the documentation states 404 responses are returned. This should be fixed

[1] - https://openid.net/specs/openid-connect-registration-1_0.html#ReadError