### PR TITLE
Fix alignment issue in branding docs

### DIFF
--- a/en/includes/guides/branding/configure-ui-branding.md
+++ b/en/includes/guides/branding/configure-ui-branding.md
@@ -630,7 +630,7 @@ Listed below are the text branding preferences you can apply to the screens in y
 <table>
    <tr>
       <th>Screen</th>
-      <th>Field</th>
+      <th style="width: 200px;">Field</th>
       <th>Description</th>
    </tr>
    <tr>


### PR DESCRIPTION
## Purpose
<img width="1712" alt="Screenshot 2024-01-26 at 22 29 29" src="https://github.com/wso2/docs-is/assets/25483865/c1a521d8-49b0-4a92-a142-63f554a6565f">
<img width="1713" alt="Screenshot 2024-01-26 at 22 30 50" src="https://github.com/wso2/docs-is/assets/25483865/fdac9629-158e-485c-9fb9-eab6938a9217">

Fix https://github.com/wso2/product-is/issues/19218