### PR TITLE
Remove UMA db script references

### DIFF
--- a/en/identity-server/6.1.0/docs/deploy/change-to-ibm-db2.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-ibm-db2.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
 		Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
 		
 		- `<IS-HOME>/dbscripts/identity/db2.sql`
-		- `<IS-HOME>/dbscripts/identity/uma/db2.sql`
 		- `<IS-HOME>/dbscripts/consent/db2.sql`
 
 		!!! info 

--- a/en/identity-server/6.1.0/docs/deploy/change-to-mssql.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-mssql.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/mssql.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/mssql.sql`
         - `<IS-HOME>/dbscripts/consent/mssql.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/6.1.0/docs/deploy/change-to-mysql.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-mysql.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
         
         - `<IS-HOME>/dbscripts/identity/mysql.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/mysql.sql`
         - `<IS-HOME>/dbscripts/consent/mysql.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/6.1.0/docs/deploy/change-to-oracle-rac.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-oracle-rac.md
@@ -55,7 +55,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/oracle_rac.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/oracle_rac.sql`
         - `<IS-HOME>/dbscripts/consent/oracle_rac.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/6.1.0/docs/deploy/change-to-oracle.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-oracle.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
         
         - `<IS-HOME>/dbscripts/identity/oracle.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/oracle.sql`
         - `<IS-HOME>/dbscripts/consent/oracle.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/6.1.0/docs/deploy/change-to-postgresql.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-postgresql.md
@@ -44,7 +44,6 @@ A sample configuration is given below.
         Execute the scripts in the following files, against the database created.
         
         - `<IS-HOME>/dbscripts/identity/postgresql.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/postgresql.sql`
         - `<IS-HOME>/dbscripts/consent/postgresql.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/6.1.0/docs/deploy/change-to-remote-h2.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-remote-h2.md
@@ -90,7 +90,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/h2.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/h2.sql`
         - `<IS-HOME>/dbscripts/consent/h2.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
 		Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
 		
 		- `<IS-HOME>/dbscripts/identity/db2.sql`
-		- `<IS-HOME>/dbscripts/identity/uma/db2.sql`
 		- `<IS-HOME>/dbscripts/consent/db2.sql`
 
 		!!! info 

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/mssql.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/mssql.sql`
         - `<IS-HOME>/dbscripts/consent/mssql.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mysql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mysql.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
         
         - `<IS-HOME>/dbscripts/identity/mysql.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/mysql.sql`
         - `<IS-HOME>/dbscripts/consent/mysql.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle-rac.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle-rac.md
@@ -55,7 +55,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/oracle_rac.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/oracle_rac.sql`
         - `<IS-HOME>/dbscripts/consent/oracle_rac.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle.md
@@ -46,7 +46,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
         
         - `<IS-HOME>/dbscripts/identity/oracle.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/oracle.sql`
         - `<IS-HOME>/dbscripts/consent/oracle.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -44,7 +44,6 @@ A sample configuration is given below.
         Execute the scripts in the following files, against the database created.
         
         - `<IS-HOME>/dbscripts/identity/postgresql.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/postgresql.sql`
         - `<IS-HOME>/dbscripts/consent/postgresql.sql`
         
 2. `WSO2_SHARED_DB`

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-remote-h2.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-remote-h2.md
@@ -83,7 +83,6 @@ A sample configuration is given below.
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/h2.sql`
-        - `<IS-HOME>/dbscripts/identity/uma/h2.sql`
         - `<IS-HOME>/dbscripts/consent/h2.sql`
         
 2. `WSO2_SHARED_DB`


### PR DESCRIPTION
## Purpose
Related issue https://github.com/wso2/product-is/issues/16200

Since UMA is an optional feature which is not packed into IS from IS 6.1.0 the, references of the db scripts should be removed from the docs.

<img width="718" alt="Screenshot 2024-02-07 at 18 38 51" src="https://github.com/wso2/docs-is/assets/46132469/667f5821-8053-4109-af44-663b2751ef00">
