### PR TITLE
Rewording Configure Transport Level Security doc

### DIFF
--- a/en/identity-server/next/docs/deploy/security/configure-transport-level-security.md
+++ b/en/identity-server/next/docs/deploy/security/configure-transport-level-security.md
@@ -6,7 +6,7 @@ Given below are the various transport-level security configurations that are req
 
 Follow the instructions given below to configure SSL/TLS protocols in the WSO2 Identity Server.
 
-1. You can configure multiple TLS versions or a single TLS version according to your preference. Add the following configuration to the `<IS_HOME>/repository/conf/deployment.toml` file. Note that the list of protocols needs to be seperated by `+` sign.
+1. You can configure multiple TLS versions or a single TLS version by adding the following configuration to the `<IS_HOME>/repository/conf/deployment.toml` file. Note that the list of protocols needs to be seperated by `+` sign.
 
     ```toml
     [transport.https.sslHostConfig.properties]

--- a/en/identity-server/next/docs/deploy/security/configure-transport-level-security.md
+++ b/en/identity-server/next/docs/deploy/security/configure-transport-level-security.md
@@ -2,19 +2,18 @@
 
 Given below are the various transport-level security configurations that are required for the WSO2 Identity Server.
 
-## Enabling SSL protocols in the WSO2 IS
+## Configuring SSL/TLS protocols in the WSO2 IS
 
-Follow the instructions given below to enable SSL protocols in the WSO2 Identity Server.
+Follow the instructions given below to configure SSL/TLS protocols in the WSO2 Identity Server.
 
-1. Add the following configurations in the `<IS_HOME>/repository/conf/deployment.toml` file.
+1. You can configure multiple TLS versions or a single TLS version according to your preference. Add the following configuration to the `<IS_HOME>/repository/conf/deployment.toml` file. Note that the list of protocols needs to be seperated by `+` sign.
 
     ```toml
     [transport.https.sslHostConfig.properties]
-    protocols="+TLSv1, +TLSv1.1, +TLSv1.2, +TLSv1.3"
+    protocols="TLSv1+TLSv1.1+TLSv1.2+TLSv1.3"
     ```
 
-    You can configure multiple TLS versions or a single TLS version according to your preference.
-    To achieve high security, use the latest TLS version by removing `+TLSv1`, `+TLSv1.1`, and `+TLSv1.2` from the `protocols` property of the configuration.
+    To achieve higher level of security, use only the latest TLS version by removing `TLSv1`, `TLSv1.1`, and `TLSv1.2` from the `protocols` property of the configuration.
 
 2. Restart the server.
 


### PR DESCRIPTION
## Purpose
Although the title of the section is `Enabling SSL protocols`, the list of protocols mentioned in the doc is enabled by default. (After https://github.com/wso2/product-is/issues/18465 enables TLS 1.3 by default)

<img width="999" alt="Screenshot 2024-02-08 at 10 54 38" src="https://github.com/wso2/docs-is/assets/46132469/380de20a-7764-48fd-8833-017ad1a34ae7">

Therefore I am suggesting to reword the section as following.

<img width="1026" alt="Screenshot 2024-02-08 at 11 18 44" src="https://github.com/wso2/docs-is/assets/46132469/ff9c33c0-c102-4736-8492-96de4cfe0917">


