### PR TITLE
[Docs] Update config management GET endpoints to have internal_config_view as the required scope

### DIFF
--- a/en/identity-server/next/docs/apis/restapis/configs.yaml
+++ b/en/identity-server/next/docs/apis/restapis/configs.yaml
@@ -17,7 +17,7 @@ paths:
       description: |
         Retrieve Server Configs
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -118,7 +118,7 @@ paths:
       description: |
         Retrieve Server Inbound SCIM Configs
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -216,7 +216,7 @@ paths:
       description: |
         List available local authenticators of the server
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - $ref: '#/components/parameters/typeQueryParam'
       responses:
@@ -270,7 +270,7 @@ paths:
       description: |
         By passing in the appropriate authenticator ID, you can retrieve authenticator details
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - name: authenticator-id
           in: path
@@ -323,7 +323,7 @@ paths:
       description: |
         Retrieve the tenant CORS configuration.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -565,7 +565,7 @@ paths:
       description: |
         Retrieve Schemas supported by Server.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -614,7 +614,7 @@ paths:
       description: |
         By passing in the appropriate schema ID, you can retrieve attributes of a schema supported by the Server.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - name: schema-id
           in: path
@@ -667,7 +667,7 @@ paths:
       description: |
         Retrieve Remote Logging Configurations
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -821,7 +821,7 @@ paths:
       description: |
         Retrieve Remote Logging Configurations by log type.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - name: log-type
           in: path
@@ -988,7 +988,7 @@ paths:
       description: |
         Retrieve server SAML2 inbound authentication configurations.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       operationId: getSAMLInboundAuthConfig
       responses:
         '200':
@@ -1088,7 +1088,7 @@ paths:
       description: |
         Retrieve WS Federation (Passive STS) inbound authentication configurations.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       operationId: getPassiveSTSInboundAuthConfig
       responses:
         '200':

--- a/en/identity-server/next/docs/apis/restapis/configs.yaml
+++ b/en/identity-server/next/docs/apis/restapis/configs.yaml
@@ -365,7 +365,10 @@ paths:
         - CORS
       summary: Patch the tenant CORS configuration.
       operationId: patchCORSConfiguration
-      description: A JSONPatch as defined by RFC 6902.
+      description: |
+        A JSONPatch as defined by RFC 6902.
+        
+        <b>Scope(Permission) required:</b> `internal_config_update`
       requestBody:
         content:
           application/json:
@@ -418,7 +421,10 @@ paths:
         - Private Key JWY validation Authenticators
       summary: Retrieve the tenant private key jwt authentication configuration
       operationId: getPrivatKeyJWTValidationConfiguration
-      description: Retrieve the tenant private key jwt authentication configuration.
+      description: |
+        Retrieve the tenant private key jwt authentication configuration.
+        
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response


### PR DESCRIPTION
## Purpose
The resource access control scopes of the config management api endpoints are updated with below PR. This PR is to update the docs to reflect those changes

- https://github.com/wso2/carbon-identity-framework/pull/5506

This PR should be merged after above PR is merged

## Related Issue

- https://github.com/wso2/product-is/issues/19481