### PR TITLE
Add passkey note: Ensure federated users are provisioned

### DIFF
--- a/en/includes/guides/authentication/mfa/add-passkey-login.md
+++ b/en/includes/guides/authentication/mfa/add-passkey-login.md
@@ -73,3 +73,6 @@ In this section, let’s try out the scenario where Passkey progressive enrollme
     ![Rename passkey in {{ product_name }}]({{base_path}}/assets/img/guides/passwordless/passkey/rename-passkey.png){: width="300" style="border: 0.3px solid lightgrey;"}
 
 8. Click **Submit** to complete the enrollment. You'll be authenticated in the application.
+
+!!! note
+    To ensure Passkey work with federated authenticators such as Google, Facebook, etc., it is necessary for the federated user to be previously provisioned to {{ product_name }}. Failure to do so will result in the user being redirected to an error page.

--- a/en/includes/guides/authentication/mfa/add-passkey-login.md
+++ b/en/includes/guides/authentication/mfa/add-passkey-login.md
@@ -75,4 +75,4 @@ In this section, let’s try out the scenario where Passkey progressive enrollme
 8. Click **Submit** to complete the enrollment. You'll be authenticated in the application.
 
 !!! note
-    To ensure Passkey work with federated authenticators such as Google, Facebook, etc., it is necessary for the federated user to be previously provisioned to {{ product_name }}. Failure to do so will result in the user being redirected to an error page.
+    For passkeys to function as a second factor alongside federated authenticators, users should have their external accounts already provisioned in {{product_name}}. If, for example, an external user logs in with Google using an account not provisioned in {{product_name}}, attempting a Passkey login will result in an error and the login flow fails.

--- a/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-passkey.md
+++ b/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-passkey.md
@@ -150,4 +150,4 @@ Follow the steps below to use an enrolled passkey to sign in to an application.
     ![Sign In with passkey browser prompt {{ product_name }}]({{base_path}}/assets/img/guides/passwordless/passkey/sign-in-with-passkey-browser-prompt.png){: width="300" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
 !!! note
-    To ensure Passkey work with federated authenticators such as Google, Facebook, etc., it is necessary for the federated user to be previously provisioned to {{ product_name }}. Failure to do so will result in the user being redirected to an error page. 
+    During passkey progressive enrollment, if a user wishes to use a federated authenticator, they should have their external accounts already provisioned within {{product_name}}. If, for example, a user logs in with Google using an account not provisioned in {{product_name}}, passkey enrolment results in an error and the login flow fails.

--- a/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-passkey.md
+++ b/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-passkey.md
@@ -148,3 +148,6 @@ Follow the steps below to use an enrolled passkey to sign in to an application.
 5. Follow the browser/device instructions to log in with a passkey.
 
     ![Sign In with passkey browser prompt {{ product_name }}]({{base_path}}/assets/img/guides/passwordless/passkey/sign-in-with-passkey-browser-prompt.png){: width="300" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
+
+!!! note
+    To ensure Passkey work with federated authenticators such as Google, Facebook, etc., it is necessary for the federated user to be previously provisioned to {{ product_name }}. Failure to do so will result in the user being redirected to an error page. 


### PR DESCRIPTION
## Purpose

- $Subject
- For Passkey to work with federated authenticators such as Google, Facebook, etc., it is necessary for the federated user to be previously provisioned to Identity Server/ Asgardeo prior to the use of Passkey Authenticator. Failure to do so will result in the user being redirected to the following error page.

![image](https://github.com/wso2/docs-is/assets/47135592/50344be6-a79c-4a4e-a34b-85b6b5db28ca)
