### PR TITLE
Update applcation management API's `{application-id}/inbound-protocols/oidc` endpoint

### DIFF
--- a/en/identity-server/next/docs/apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/restapis/application.yaml
@@ -1744,8 +1744,6 @@ paths:
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
             -d '{
-            "clientId": "string",
-            "clientSecret": "string",
             "grantTypes": [
               "authorization_code",
               "password"


### PR DESCRIPTION
## Purpose
> $subject

The clientID and clientSecret cannot be updated using the APIs, therefore removed it from API docs