### PR TITLE
Change external links to open in new tab

### DIFF
--- a/en/asgardeo/docs/references/rate-limits.md
+++ b/en/asgardeo/docs/references/rate-limits.md
@@ -4,7 +4,7 @@ Asgardeo endpoints are subjected to rate limits to maintain smooth and reliable 
 
 Rate limits are calculated on a per IP address basis. For example, if the rate limit for an endpoint is 200, it means that the maximum number of requests you can make to this endpoint from a single IP address is 200 per minute.
 
-Exceeding the rate limit results in a [429 Too Many Requests error code](https://datatracker.ietf.org/doc/html/rfc6585#section-4).
+Exceeding the rate limit results in a [429 Too Many Requests error code](https://datatracker.ietf.org/doc/html/rfc6585#section-4){:target="_blank"}.
 
 Listed below are the endpoints and the rate limits that apply to each endpoint.
 

--- a/en/identity-server/6.0.0/docs/guides/login/oauth-app-config-advanced.md
+++ b/en/identity-server/6.0.0/docs/guides/login/oauth-app-config-advanced.md
@@ -49,7 +49,7 @@ This is the exact location in the service provider's application where an access
 ---
 
 ??? note "Click for information on configuring loopback callback URLs"
-     From IS 6.0.0 onwards, to comply with [RFC 8252 section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3), the callback URL in the authorization request does not need to have an exact port match to the callback URL registered here if it is a loopback callback IP address.
+     From IS 6.0.0 onwards, to comply with [RFC 8252 section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3){:target="_blank"}, the callback URL in the authorization request does not need to have an exact port match to the callback URL registered here if it is a loopback callback IP address.
      Exact port matches are not required if you use loopback IP addresses (`127.0.0.1` and `[::1]`) only. 
 
 

--- a/en/identity-server/6.0.0/docs/guides/login/oidc-auth-code-pkce-public-clients.md
+++ b/en/identity-server/6.0.0/docs/guides/login/oidc-auth-code-pkce-public-clients.md
@@ -4,7 +4,7 @@ This guide gives you instructions on how to implement login with OpenID Connect 
 
 Single-page applications and native mobile applications are some examples of public clients.
 
-For public clients, it is recommended to use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) along with the authorization code grant to mitigate [code interception attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-authorization-code-interception-attacks/).
+For public clients, it is recommended to use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636){:target="_blank"} along with the authorization code grant to mitigate [code interception attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-authorization-code-interception-attacks/).
 
 ## Register a service provider
 

--- a/en/identity-server/6.1.0/docs/guides/login/oauth-app-config-advanced.md
+++ b/en/identity-server/6.1.0/docs/guides/login/oauth-app-config-advanced.md
@@ -49,7 +49,7 @@ This is the exact location in the service provider's application where an access
 ---
 
 ??? note "Click for information on configuring loopback callback URLs"
-     From IS 6.0.0 onwards, to comply with [RFC 8252 section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3), the callback URL in the authorization request does not need to have an exact port match to the callback URL registered here if it is a loopback callback IP address.
+     From IS 6.0.0 onwards, to comply with [RFC 8252 section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3){:target="_blank"}, the callback URL in the authorization request does not need to have an exact port match to the callback URL registered here if it is a loopback callback IP address.
      Exact port matches are not required if you use loopback IP addresses (`127.0.0.1` and `[::1]`) only. 
 
 

--- a/en/identity-server/6.1.0/docs/guides/login/oidc-auth-code-pkce-public-clients.md
+++ b/en/identity-server/6.1.0/docs/guides/login/oidc-auth-code-pkce-public-clients.md
@@ -4,7 +4,7 @@ This guide gives you instructions on how to implement login with OpenID Connect 
 
 Single-page applications and native mobile applications are some examples of public clients.
 
-For public clients, it is recommended to use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) along with the authorization code grant to mitigate [code interception attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-authorization-code-interception-attacks/).
+For public clients, it is recommended to use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636){:target="_blank"} along with the authorization code grant to mitigate [code interception attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-authorization-code-interception-attacks/).
 
 ## Register a service provider
 

--- a/en/identity-server/6.1.0/docs/guides/login/oidc-auth-code-pkce.md
+++ b/en/identity-server/6.1.0/docs/guides/login/oidc-auth-code-pkce.md
@@ -4,7 +4,7 @@ This guide gives you instructions on how to implement login with OpenID Connect 
 
 Single-page applications and native mobile applications are some examples of public clients.
 
-For public clients, it is recommended to use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) along with the authorization code grant to mitigate [code interception attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-authorization-code-interception-attacks/).
+For public clients, it is recommended to use [PKCE](https://datatracker.ietf.org/doc/html/rfc7636){:target="_blank"} along with the authorization code grant to mitigate [code interception attacks]({{base_path}}/deploy/mitigate-attacks/mitigate-authorization-code-interception-attacks/).
 
 ## Register a service provider
 

--- a/en/includes/guides/authentication/add-login-to-single-page-app.md
+++ b/en/includes/guides/authentication/add-login-to-single-page-app.md
@@ -2,7 +2,7 @@
 
 Single-page apps (SPAs) by design run with the source code exposed in the browser, which means that they cannot maintain any secrets. These kinds of applications are called public clients.
 
-Based on the [OAuth 2.0 best practices for browser-based apps](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps-08), {{ product_name }} recommends securing your SPAs using the OpenID Connect Authorization Code Flow for public clients with the PKCE ([Proof Key for Code Exchange](https://datatracker.ietf.org/doc/html/rfc7636)) extension.
+Based on the [OAuth 2.0 best practices for browser-based apps](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps-08){:target="_blank"}, {{ product_name }} recommends securing your SPAs using the OpenID Connect Authorization Code Flow for public clients with the PKCE ([Proof Key for Code Exchange](https://datatracker.ietf.org/doc/html/rfc7636){:target="_blank"}) extension.
 
 See the guides given below to add login to your SPAs with {{ product_name }}.
 

--- a/en/includes/references/app-settings/oidc-settings-for-app.md
+++ b/en/includes/references/app-settings/oidc-settings-for-app.md
@@ -92,7 +92,7 @@ This section elaborates on the advanced settings available for OIDC applications
 
 ### Proof Key for Code Exchange(PKCE)
 
-When using [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) along with the [authorization code flow]({{base_path}}/guides/authentication/oidc/implement-auth-code-with-pkce/#get-tokens){:target="_blank"} grant, the application sends a `code challenge` in the authorization request and subsequently, sends the corresponding `code verifier` in the token request.
+When using [PKCE](https://datatracker.ietf.org/doc/html/rfc7636){:target="_blank"} along with the [authorization code flow]({{base_path}}/guides/authentication/oidc/implement-auth-code-with-pkce/#get-tokens) grant, the application sends a `code challenge` in the authorization request and subsequently, sends the corresponding `code verifier` in the token request.
 
 PKCE ensures that the authorization code is sent to the same client making the request and no malicious application has intercepted the code during the delivery process. {{product_name}} supports the following options for PKCE:
 


### PR DESCRIPTION
## Purpose
$subject

- Updated links that goes to `https://datatracker.ietf.org` site.


Partially fixes https://github.com/wso2/product-is/issues/20144