### PR TITLE
remove CORS configuration from saml sample web apps

### DIFF
--- a/en/identity-server/5.11.0/docs/learn/deploying-the-sample-app.md
+++ b/en/identity-server/5.11.0/docs/learn/deploying-the-sample-app.md
@@ -360,32 +360,6 @@ For example,
     
 ### Configuring the service provider
 
-!!! note "Important"
-
-    SAML2 POST Binding requires CORS configs set up. Before configuring the service provider, make sure you add the following configurations to the `<IS_HOME>/repository/conf/deployment.toml` file to allow HTTP POST requests. 
-
-    ```toml
-    [cors]
-    allow_generic_http_requests = true
-    allow_any_origin = false
-    allowed_origins = [
-        "http://localhost:8080", "http://localhost.com:8080"
-    ]
-    allow_subdomains = false
-    supported_methods = [
-        "GET",
-        "POST",
-        "HEAD",
-        "OPTIONS"
-    ]
-    support_any_header = true
-    supported_headers = []
-    exposed_headers = []
-    supports_credentials = true
-    max_age = 3600
-    tag_requests = false
-    ```
-
 The next step is to configure the service provider.
 
 1.  Return to the WSO2 IS management console.

--- a/en/identity-server/6.0.0/docs/includes/pickup-dispatch-saml.md
+++ b/en/identity-server/6.0.0/docs/includes/pickup-dispatch-saml.md
@@ -14,12 +14,6 @@ To deploy the sample web app on a web container:
 
 ---
 
-### Add CORS configuration
-
-{!./includes/cors-config.md!}
-
----
-
 ### Register a service provider
 
 1. On the Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.

--- a/en/identity-server/6.1.0/docs/includes/pickup-dispatch-saml.md
+++ b/en/identity-server/6.1.0/docs/includes/pickup-dispatch-saml.md
@@ -14,12 +14,6 @@ To deploy the sample web app on a web container:
 
 ---
 
-### Add CORS configuration
-
-{!./includes/cors-config.md!}
-
----
-
 ### Register a service provider
 
 1. On the Management Console, go to **Main** > **Identity** > **Service Providers** and click **Add**.


### PR DESCRIPTION
## Purpose

With the improvements made in the PR https://github.com/wso2/product-is/issues/11078, there is no need to add CORS configurations when setting up SAML sample web apps. Therefore, the configurations have been removed from the documentation for IS 5.11, IS 6.0, and IS 6.1.


