### PR TITLE
[7.0.0][next] Remove `primary` field and conflicting `type` fields for user emails

### DIFF
--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/group-management.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/group-management.yaml
@@ -490,9 +490,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/user-management.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/user-management.yaml
@@ -168,9 +168,7 @@ paths:
             "password": "MyPa33w@rd",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -358,9 +356,7 @@ paths:
             "userName": "kim",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -514,9 +510,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -578,9 +572,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -626,9 +618,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/7.0.0/docs/apis/restapis/scim2-me.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/scim2-me.yaml
@@ -109,9 +109,7 @@ paths:
             "userName": "kim",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -195,9 +193,7 @@ paths:
             "password": "MyPa33w@rd",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -334,9 +330,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -398,9 +392,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -446,9 +438,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -536,9 +526,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/7.0.0/docs/apis/restapis/scim2-users.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/scim2-users.yaml
@@ -167,9 +167,7 @@ paths:
             "password": "MyPa33w@rd",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -355,9 +353,7 @@ paths:
             "userName": "kim",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -509,9 +505,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -573,9 +567,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -621,9 +613,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/7.0.0/docs/apis/scim2-batch-operations.md
+++ b/en/identity-server/7.0.0/docs/apis/scim2-batch-operations.md
@@ -51,9 +51,7 @@ Given below is an example request payload to manage users in bulk. This request 
                "password": "smith123",
                "emails": [
                    {
-                       "type": "home",
                        "value": "smith@gmail.com",
-                       "primary": true
                    },
                    {
                        "type": "work",

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/group-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/group-management.yaml
@@ -490,9 +490,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/user-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/user-management.yaml
@@ -168,9 +168,7 @@ paths:
             "password": "MyPa33w@rd",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -358,9 +356,7 @@ paths:
             "userName": "kim",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -514,9 +510,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -578,9 +572,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -626,9 +618,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/next/docs/apis/restapis/scim2-me.yaml
+++ b/en/identity-server/next/docs/apis/restapis/scim2-me.yaml
@@ -109,9 +109,7 @@ paths:
             "userName": "kim",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -195,9 +193,7 @@ paths:
             "password": "MyPa33w@rd",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -334,9 +330,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -398,9 +392,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -446,9 +438,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -536,9 +526,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/next/docs/apis/restapis/scim2-users.yaml
+++ b/en/identity-server/next/docs/apis/restapis/scim2-users.yaml
@@ -167,9 +167,7 @@ paths:
             "password": "MyPa33w@rd",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -355,9 +353,7 @@ paths:
             "userName": "kim",
             "emails": [
               {
-                "type": "home",
                 "value": "kim@gmail.com",
-                "primary": true
               },
               {
                 "type": "work",
@@ -509,9 +505,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -573,9 +567,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:
@@ -621,9 +613,7 @@ components:
         emails:
           type: array
           example:
-            - type: home
-              value: kim@gmail.com
-              primary: true
+            - value: kim@gmail.com
             - type: work
               value: kim@wso2.com
           items:

--- a/en/identity-server/next/docs/apis/scim2-batch-operations.md
+++ b/en/identity-server/next/docs/apis/scim2-batch-operations.md
@@ -51,9 +51,7 @@ Given below is an example request payload to manage users in bulk. This request 
                "password": "smith123",
                "emails": [
                    {
-                       "type": "home",
                        "value": "smith@gmail.com",
-                       "primary": true
                    },
                    {
                        "type": "work",


### PR DESCRIPTION
## Purpose
- When `type` field is available, email is not set as primary email.
- `primary` email does not have an effect when setting as a primary email
- Hence, This PR removes `primary` field and have example emails without `type` field as well.
- 
### Before

<img width="1351" alt="Screenshot 2024-04-29 at 14 22 35" src="https://github.com/wso2/docs-is/assets/59327626/f4545ae6-bdd6-4b8a-95a5-da1e1f745df9">


### After 

<img width="1351" alt="Screenshot 2024-04-29 at 15 02 54" src="https://github.com/wso2/docs-is/assets/59327626/3479250d-6ef7-4ac7-8307-e69ae0517a36">



