### PR TITLE
[5.11.0][6.0.0][6.1.0] Remove primary field and conflicting type fields for user emails

### DIFF
--- a/en/identity-server/5.11.0/docs/develop/scim2-batch-operations.md
+++ b/en/identity-server/5.11.0/docs/develop/scim2-batch-operations.md
@@ -82,9 +82,7 @@ Given below is an example request payload to manage users in bulk. This request 
                "password": "smith123",
                "emails": [
                    {
-                       "type": "home",
                        "value": "smith@gmail.com",
-                       "primary": true
                    },
                    {
                        "type": "work",

--- a/en/identity-server/6.0.0/docs/apis/restapis/scim2.yaml
+++ b/en/identity-server/6.0.0/docs/apis/restapis/scim2.yaml
@@ -1308,9 +1308,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:
@@ -1372,9 +1370,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:
@@ -1420,9 +1416,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:
@@ -1510,9 +1504,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:

--- a/en/identity-server/6.0.0/docs/apis/scim2-batch-operations.md
+++ b/en/identity-server/6.0.0/docs/apis/scim2-batch-operations.md
@@ -51,9 +51,7 @@ Given below is an example request payload to manage users in bulk. This request 
                "password": "smith123",
                "emails": [
                    {
-                       "type": "home",
                        "value": "smith@gmail.com",
-                       "primary": true
                    },
                    {
                        "type": "work",

--- a/en/identity-server/6.1.0/docs/apis/restapis/scim2.yaml
+++ b/en/identity-server/6.1.0/docs/apis/restapis/scim2.yaml
@@ -1308,9 +1308,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:
@@ -1372,9 +1370,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:
@@ -1420,9 +1416,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:
@@ -1510,9 +1504,7 @@ components:
         emails:
           type: array
           example:
-          - type: home
-            value: kim@gmail.com
-            primary: true
+          - value: kim@gmail.com
           - type: work
             value: kim@wso2.com
           items:

--- a/en/identity-server/6.1.0/docs/apis/scim2-batch-operations.md
+++ b/en/identity-server/6.1.0/docs/apis/scim2-batch-operations.md
@@ -51,9 +51,7 @@ Given below is an example request payload to manage users in bulk. This request 
                "password": "smith123",
                "emails": [
                    {
-                       "type": "home",
                        "value": "smith@gmail.com",
-                       "primary": true
                    },
                    {
                        "type": "work",


### PR DESCRIPTION
### Purpose
- When `type` field is available, email is not set as primary email.
- `primary` email does not have an effect when setting as a primary email
- Hence, This PR removes `primary` field and have example emails without `type` field as well.

### Related Issue
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/1476