### PR TITLE
Add instructions for mapping `username` and `userid` claims for LDAP based user stores

### DIFF
--- a/en/identity-server/6.0.0/docs/deploy/configure-a-read-only-ldap-user-store.md
+++ b/en/identity-server/6.0.0/docs/deploy/configure-a-read-only-ldap-user-store.md
@@ -94,6 +94,10 @@ connection_password = "admin"
 ```
 Apart from the properties mentioned above, WSO2 Identity Server also supports advanced LDAP configurations.
 
+!!! note
+    It is important to map the `Username` and `User ID` claims correctly to the values used for `Username Attribute` and `User ID Attribute` properties in the userstore configuration for user authentication to work properly.<br />
+    Claim mappings can be done through the management console as explained in [edit claim mapping]({{base_path}}/guides/dialects/edit-claim-mapping).
+
 ---
 
 ## Properties used in read-only LDAP userstore manager

--- a/en/identity-server/6.0.0/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/identity-server/6.0.0/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -113,6 +113,7 @@ since SCIM is enabled by default from the WSO2 Identity Server 5.10.0 onwards.
 
 !!! note
     It is required to edit the claim mappings in WSO2 IS according to the user claims of the Active Directory version you have configured.<br />
+    Additioanlly the `Username` and `User ID` claims need to be mapped correctly to the values used for `Username Attribute` and `User ID Attribute` properties in the userstore configuration for authentication to work properly.<br /><br />
     Before starting the server, edit the `<IS_HOME>/repository/conf/claim-config.xml` configuration file and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims to `whenCreated` and `whenChanged` respectively.
     Start the server and edit the rest of the required claim mappings through the management console as explained in [edit claim mapping]({{base_path}}/guides/dialects/edit-claim-mapping).
 

--- a/en/identity-server/6.0.0/docs/deploy/configure-a-read-write-ldap-user-store.md
+++ b/en/identity-server/6.0.0/docs/deploy/configure-a-read-write-ldap-user-store.md
@@ -92,6 +92,11 @@ connection_password = "admin"
 ```
 Apart from above properties, WSO2 Identity Server also supports advanced LDAP configurations.
 
+!!! note
+    It is important to map the `Username` and `User ID` claims correctly to the values used for `Username Attribute` and `User ID Attribute` properties in the userstore configuration for user authentication to work properly.<br />
+    Claim mappings can be done through the management console as explained in [edit claim mapping]({{base_path}}/guides/dialects/edit-claim-mapping).
+
+
 ---
 
 ## Properties used in Read-write LDAP userstore manager

--- a/en/identity-server/6.1.0/docs/deploy/configure-a-read-only-ldap-user-store.md
+++ b/en/identity-server/6.1.0/docs/deploy/configure-a-read-only-ldap-user-store.md
@@ -94,6 +94,10 @@ connection_password = "admin"
 ```
 Apart from the properties mentioned above, WSO2 Identity Server also supports advanced LDAP configurations.
 
+!!! note
+    It is important to map the `Username` and `User ID` claims correctly to the values used for `Username Attribute` and `User ID Attribute` properties in the userstore configuration for user authentication to work properly.<br />
+    Claim mappings can be done through the management console as explained in [edit claim mapping]({{base_path}}/guides/dialects/edit-claim-mapping).
+
 ---
 
 ## Properties used in read-only LDAP userstore manager

--- a/en/identity-server/6.1.0/docs/deploy/configure-a-read-write-active-directory-user-store.md
+++ b/en/identity-server/6.1.0/docs/deploy/configure-a-read-write-active-directory-user-store.md
@@ -113,6 +113,7 @@ since SCIM is enabled by default from the WSO2 Identity Server 5.10.0 onwards.
 
 !!! note
     It is required to edit the claim mappings in WSO2 IS according to the user claims of the Active Directory version you have configured.<br />
+    Additioanlly the `Username` and `User ID` claims need to be mapped correctly to the values used for `Username Attribute` and `User ID Attribute` properties in the userstore configuration for authentication to work properly.<br /><br />
     Before starting the server, edit the `<IS_HOME>/repository/conf/claim-config.xml` configuration file and change the `AttributeID` of the `Created Time` and `Last Modified Time` claims to `whenCreated` and `whenChanged` respectively.
     Start the server and edit the rest of the required claim mappings through the management console as explained in [edit claim mapping]({{base_path}}/guides/dialects/edit-claim-mapping).
 

--- a/en/identity-server/6.1.0/docs/deploy/configure-a-read-write-ldap-user-store.md
+++ b/en/identity-server/6.1.0/docs/deploy/configure-a-read-write-ldap-user-store.md
@@ -92,6 +92,10 @@ connection_password = "admin"
 ```
 Apart from above properties, WSO2 Identity Server also supports advanced LDAP configurations.
 
+!!! note
+    It is important to map the `Username` and `User ID` claims correctly to the values used for `Username Attribute` and `User ID Attribute` properties in the userstore configuration for user authentication to work properly.<br />
+    Claim mappings can be done through the management console as explained in [edit claim mapping]({{base_path}}/guides/dialects/edit-claim-mapping).
+
 ---
 
 ## Properties used in Read-write LDAP userstore manager

--- a/en/identity-server/7.0.0/docs/guides/users/user-stores/primary-user-store/configure-a-read-only-ldap-user-store.md
+++ b/en/identity-server/7.0.0/docs/guides/users/user-stores/primary-user-store/configure-a-read-only-ldap-user-store.md
@@ -39,6 +39,8 @@ If you are configuring a server that has not been started yet, you need to updat
     For `created` and `modified` claims, it is recommended to use the `createTimestamp` and `modifyTimestamp` 
     operational attributes.
 
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
+
 ### Updating configuration for existing servers
 
 !!! warning
@@ -60,6 +62,8 @@ configurations.
     Refer to the [Update Attributes]({{base_path}}/guides/users/attributes/manage-attributes/#update-attributes) 
     to learn more on updating attribute mappings. For `created` and `modified` attributes, it is recommended to use the 
     `createTimestamp` and `modifyTimestamp` operational attributes.
+
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
 
     !!! Warning
         If you have more than one tenant, you need to change the attributes mappings for each tenant before adding the 

--- a/en/identity-server/7.0.0/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-active-directory-user-store.md
+++ b/en/identity-server/7.0.0/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-active-directory-user-store.md
@@ -58,6 +58,8 @@ If you are configuring a server that has not been started yet, you need to updat
     For `created` and `modified` claims, it is recommended to use the `whenCreated` and `whenChanged` 
     operational attributes.
 
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
+
 ### Updating configuration for existing servers
 
 !!! warning
@@ -79,6 +81,8 @@ configurations.
     Refer to the [Update Attributes]({{base_path}}/guides/users/attributes/manage-attributes/#update-attributes) 
     to learn more on updating attribute mappings.  For `created` and `modified` claims, it is recommended to use the 
     `whenCreated` and `whenChanged` operational attributes.
+
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
 
     !!! Warning
         If you have more than one tenant, you need to change the claim mappings for each tenant before adding the 

--- a/en/identity-server/7.0.0/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-ldap-user-store.md
+++ b/en/identity-server/7.0.0/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-ldap-user-store.md
@@ -41,6 +41,8 @@ If you are configuring a server that has not been started yet, you need to updat
     For `created` and `modified` claims, it is recommended to use the `createTimestamp` and `modifyTimestamp` 
     operational attributes.
 
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
+
 ### Updating configuration for existing servers
 
 !!! warning
@@ -62,6 +64,8 @@ configurations.
     Refer to the [Update Attributes]({{base_path}}/guides/users/attributes/manage-attributes/#update-attributes) 
     to learn more on updating attribute mappings.  For `created` and `modified` claims, it is recommended to use the 
     `createTimestamp` and `modifyTimestamp` operational attributes.
+
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
 
     !!! Warning
         If you have more than one tenant, you need to change the claim mappings for each tenant before adding the 

--- a/en/identity-server/next/docs/guides/users/user-stores/primary-user-store/configure-a-read-only-ldap-user-store.md
+++ b/en/identity-server/next/docs/guides/users/user-stores/primary-user-store/configure-a-read-only-ldap-user-store.md
@@ -39,6 +39,8 @@ If you are configuring a server that has not been started yet, you need to updat
     For `created` and `modified` claims, it is recommended to use the `createTimestamp` and `modifyTimestamp` 
     operational attributes.
 
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
+
 ### Updating configuration for existing servers
 
 !!! warning
@@ -60,6 +62,8 @@ configurations.
     Refer to the [Update Attributes]({{base_path}}/guides/users/attributes/manage-attributes/#update-attributes) 
     to learn more on updating attribute mappings. For `created` and `modified` attributes, it is recommended to use the 
     `createTimestamp` and `modifyTimestamp` operational attributes.
+
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
 
     !!! Warning
         If you have more than one tenant, you need to change the attributes mappings for each tenant before adding the 

--- a/en/identity-server/next/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-active-directory-user-store.md
+++ b/en/identity-server/next/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-active-directory-user-store.md
@@ -58,6 +58,8 @@ If you are configuring a server that has not been started yet, you need to updat
     For `created` and `modified` claims, it is recommended to use the `whenCreated` and `whenChanged` 
     operational attributes.
 
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
+
 ### Updating configuration for existing servers
 
 !!! warning
@@ -79,6 +81,8 @@ configurations.
     Refer to the [Update Attributes]({{base_path}}/guides/users/attributes/manage-attributes/#update-attributes) 
     to learn more on updating attribute mappings.  For `created` and `modified` claims, it is recommended to use the 
     `whenCreated` and `whenChanged` operational attributes.
+
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
 
     !!! Warning
         If you have more than one tenant, you need to change the claim mappings for each tenant before adding the 

--- a/en/identity-server/next/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-ldap-user-store.md
+++ b/en/identity-server/next/docs/guides/users/user-stores/primary-user-store/configure-a-read-write-ldap-user-store.md
@@ -41,6 +41,8 @@ If you are configuring a server that has not been started yet, you need to updat
     For `created` and `modified` claims, it is recommended to use the `createTimestamp` and `modifyTimestamp` 
     operational attributes.
 
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
+
 ### Updating configuration for existing servers
 
 !!! warning
@@ -62,6 +64,8 @@ configurations.
     Refer to the [Update Attributes]({{base_path}}/guides/users/attributes/manage-attributes/#update-attributes) 
     to learn more on updating attribute mappings.  For `created` and `modified` claims, it is recommended to use the 
     `createTimestamp` and `modifyTimestamp` operational attributes.
+
+    For `username` and `userid` claims, the `Username Attribute` and `User ID Attribute` properties configured in the User Store configuration should be used to ensure proper user authentication.
 
     !!! Warning
         If you have more than one tenant, you need to change the claim mappings for each tenant before adding the 


### PR DESCRIPTION
## Purpose
- `Username` and `User ID` claims need to be mapped to the values of `Username Attribute` and `User ID Attribute` from user store configuration for a proper authentication flow.
- This PR documents the instructions and the necessity. 

## Related Issue
- https://github.com/wso2/product-is/issues/20558