### PR TITLE
Add meta attribute filtering to organization GET API docs

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
@@ -79,11 +79,15 @@ paths:
       description: |
         This API is used to search and retrieve organizations created for this tenant.
         
-        Organizations can be filtered by id, name, description, created, lastModified, status, and parentId attributes. 
+        Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
         
         Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
         
-        example: filter=name+eq+ABC Builders
+        Multiple attributes can be combined using the "and" operator.
+
+        Examples:
+          - filter=name+eq+ABC Builders
+          - filter=attributes.Country+eq+Sri Lanka
         
         <b>Scope(Permission) required:</b> `internal_org_organization_view`
       summary:
@@ -658,6 +662,10 @@ components:
         ref:
           type: string
           example: '/o/api/server/v1/organizations/06c1f4e2-3339-44e4-a825-96585e3653b1'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
     OrganizationResponse:
       type: object
       required:

--- a/en/asgardeo/docs/apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/restapis/org-management.yaml
@@ -78,11 +78,15 @@ paths:
       description: |
         This API is used to search and retrieve organizations created for this tenant.
         
-        Organizations can be filtered by id, name, description, created, lastModified, status, and parentId attributes. 
+        Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
         
         Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
         
-        example: filter=name+eq+ABC Builders
+        Multiple attributes can be combined using the "and" operator.
+
+        Examples:
+          - filter=name+eq+ABC Builders
+          - filter=attributes.Country+eq+Sri Lanka
         
         <b>Scope(Permission) required:</b> `internal_organization_view`
       summary:
@@ -657,6 +661,10 @@ components:
         ref:
           type: string
           example: '/api/server/v1/organizations/06c1f4e2-3339-44e4-a825-96585e3653b1'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
     OrganizationResponse:
       type: object
       required:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -74,11 +74,15 @@ paths:
       description: |
         This API is used to search and retrieve organizations created for this tenant.
         
-        Organizations can be filtered by id, name, description, created, lastModified, status, and parentId attributes. 
+        Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
         
         Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
         
-        example: filter=name+eq+ABC Builders
+        Multiple attributes can be combined using the "and" operator.
+
+        Examples:
+          - filter=name+eq+ABC Builders
+          - filter=attributes.Country+eq+Sri Lanka
         
         <b>Scope(Permission) required:</b> `internal_org_organization_view`
       summary:
@@ -653,6 +657,10 @@ components:
         ref:
           type: string
           example: '/o/api/server/v1/organizations/06c1f4e2-3339-44e4-a825-96585e3653b1'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
     OrganizationResponse:
       type: object
       required:

--- a/en/identity-server/next/docs/apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-management.yaml
@@ -78,11 +78,15 @@ paths:
       description: |
         This API is used to search and retrieve organizations created for this tenant.
         
-        Organizations can be filtered by id, name, description, created, lastModified, status, and parentId attributes. 
+        Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
         
         Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
         
-        example: filter=name+eq+ABC Builders
+        Multiple attributes can be combined using the "and" operator.
+
+        Examples:
+          - filter=name+eq+ABC Builders
+          - filter=attributes.Country+eq+Sri Lanka
         
         <b>Scope(Permission) required:</b> `internal_organization_view`
       summary:
@@ -657,6 +661,10 @@ components:
         ref:
           type: string
           example: '/api/server/v1/organizations/06c1f4e2-3339-44e4-a825-96585e3653b1'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
     OrganizationResponse:
       type: object
       required:


### PR DESCRIPTION
## Purpose
> Docs update for the new feature of extending the current organization filtering to metadata attributes.

## Related PRs
> https://github.com/wso2/identity-api-server/pull/624

## Related Issues
> https://github.com/wso2/product-is/issues/20611