### PR TITLE
Add Organizations /meta-attributes GET endpoint to docs

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
@@ -468,6 +468,12 @@ paths:
           $ref: '#/components/responses/ServerError'
         '501':
           $ref: '#/components/responses/NotImplemented'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://api.asgardeo.io/t/{organization-name}/o/api/server/v1/organizations/meta-attributes' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:

--- a/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
@@ -429,6 +429,45 @@ paths:
             curl --location 'https://api.asgardeo.io/t/{organization-name}/o/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
             -H 'Authorization: Bearer {bearer_token}'
+  /organizations/meta-attributes:
+    get:
+      tags:
+        - Organization Meta Attributes
+      description: |
+        This API facilitates the retrieval of organization meta attributes which matches the defined search criteria, if any.
+        
+        Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
+        
+        Multiple filters can be combined using the "and" operator.
+        
+        Example: filter=attributes+eq+Country
+        
+        <b>Scope(Permission) required:</b> `internal_org_organization_view`
+      summary: Get meta attributes of organizations with filter capabilities.
+      operationId: organizationsMetaAttributesGet
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetaAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 components:
   parameters:
     filterQueryParam:
@@ -478,8 +517,9 @@ components:
       in: query
       name: recursive
       required: false
-      description:
+      description: |
         Determines whether a recursive search should happen.
+        If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy.
       schema:
         type: boolean
         default: false
@@ -744,6 +784,30 @@ components:
           type: array
           items:
             type: string
+    MetaAttributesResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "next",
+              },  {
+                "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "previous",
+              }
+            ]
+        attributes:
+          type: array
+          items:
+            type: string
+            example:
+              - "Country"
+              - "Region"
     #-----------------------------------------------------
     # Organization Parent Object
     #-----------------------------------------------------

--- a/en/asgardeo/docs/apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/restapis/org-management.yaml
@@ -428,6 +428,45 @@ paths:
             curl --location 'https://api.asgardeo.io/t/{organization-name}/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
             -H 'Authorization: Bearer {bearer_token}'
+  /organizations/meta-attributes:
+    get:
+      tags:
+        - Organization Meta Attributes
+      description: |
+        This API facilitates the retrieval of organization meta attributes which matches the defined search criteria, if any.
+        
+        Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
+        
+        Multiple filters can be combined using the "and" operator.
+        
+        Example: filter=attributes+eq+Country
+        
+        <b>Scope(Permission) required:</b> `internal_organization_view`
+      summary: Get meta attributes of organizations with filter capabilities.
+      operationId: organizationsMetaAttributesGet
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetaAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 components:
   parameters:
     filterQueryParam:
@@ -477,8 +516,9 @@ components:
       in: query
       name: recursive
       required: false
-      description:
+      description: |
         Determines whether a recursive search should happen.
+        If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy.
       schema:
         type: boolean
         default: false
@@ -743,6 +783,30 @@ components:
           type: array
           items:
             type: string
+    MetaAttributesResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "next",
+              },  {
+                "href": "/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "previous",
+              }
+            ]
+        attributes:
+          type: array
+          items:
+            type: string
+            example:
+              - "Country"
+              - "Region"
     #-----------------------------------------------------
     # Organization Parent Object
     #-----------------------------------------------------

--- a/en/asgardeo/docs/apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/restapis/org-management.yaml
@@ -467,6 +467,12 @@ paths:
           $ref: '#/components/responses/ServerError'
         '501':
           $ref: '#/components/responses/NotImplemented'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://api.asgardeo.io/t/{organization-name}/api/server/v1/organizations/meta-attributes' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -424,6 +424,45 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4='
+  /organizations/meta-attributes:
+    get:
+      tags:
+        - Organization Meta Attributes
+      description: |
+        This API facilitates the retrieval of organization meta attributes which matches the defined search criteria, if any.
+        
+        Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
+        
+        Multiple filters can be combined using the "and" operator.
+        
+        Example: filter=attributes+eq+Country
+        
+        <b>Scope(Permission) required:</b> `internal_org_organization_view`
+      summary: Get meta attributes of organizations with filter capabilities.
+      operationId: organizationsMetaAttributesGet
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetaAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 components:
   parameters:
     filterQueryParam:
@@ -473,8 +512,9 @@ components:
       in: query
       name: recursive
       required: false
-      description:
+      description: |
         Determines whether a recursive search should happen.
+        If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy.
       schema:
         type: boolean
         default: false
@@ -739,6 +779,30 @@ components:
           type: array
           items:
             type: string
+    MetaAttributesResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "next",
+              },  {
+                "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "previous",
+              }
+            ]
+        attributes:
+          type: array
+          items:
+            type: string
+            example:
+              - "Country"
+              - "Region"
     #-----------------------------------------------------
     # Organization Parent Object
     #-----------------------------------------------------

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -463,6 +463,12 @@ paths:
           $ref: '#/components/responses/ServerError'
         '501':
           $ref: '#/components/responses/NotImplemented'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://localhost:9443/o/api/server/v1/organizations/meta-attributes' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
 components:
   parameters:
     filterQueryParam:

--- a/en/identity-server/next/docs/apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-management.yaml
@@ -428,6 +428,45 @@ paths:
             curl --location 'https://localhost:9443/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4='
+  /organizations/meta-attributes:
+    get:
+      tags:
+        - Organization Meta Attributes
+      description: |
+        This API facilitates the retrieval of organization meta attributes which matches the defined search criteria, if any.
+        
+        Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
+        
+        Multiple filters can be combined using the "and" operator.
+        
+        Example: filter=attributes+eq+Country
+        
+        <b>Scope(Permission) required:</b> `internal_organization_view`
+      summary: Get meta attributes of organizations with filter capabilities.
+      operationId: organizationsMetaAttributesGet
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetaAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 components:
   parameters:
     filterQueryParam:
@@ -477,8 +516,9 @@ components:
       in: query
       name: recursive
       required: false
-      description:
+      description: |
         Determines whether a recursive search should happen.
+        If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy.
       schema:
         type: boolean
         default: false
@@ -743,6 +783,30 @@ components:
           type: array
           items:
             type: string
+    MetaAttributesResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "next",
+              },  {
+                "href": "/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "previous",
+              }
+            ]
+        attributes:
+          type: array
+          items:
+            type: string
+            example:
+              - "Country"
+              - "Region"
     #-----------------------------------------------------
     # Organization Parent Object
     #-----------------------------------------------------

--- a/en/identity-server/next/docs/apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-management.yaml
@@ -467,6 +467,12 @@ paths:
           $ref: '#/components/responses/ServerError'
         '501':
           $ref: '#/components/responses/NotImplemented'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://localhost:9443/api/server/v1/organizations/meta-attributes' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
 components:
   parameters:
     filterQueryParam:


### PR DESCRIPTION
## Purpose
> Docs update for the new Organization Management GET API endpoint **_/meta-attributes_**. 
>To support the frontend implementation requiring backend API support to filter and return meta attributes belonging to a specific organizational hierarchy level.

## Related PRs
-  https://github.com/wso2/identity-api-server/pull/628

## Related Issues
- https://github.com/wso2/product-is/issues/20611