### PR TITLE
Adding a note to clarify customizable fields in branding preferences

### DIFF
--- a/en/includes/guides/branding/configure-ui-branding.md
+++ b/en/includes/guides/branding/configure-ui-branding.md
@@ -675,4 +675,4 @@ Listed below are the text branding preferences you can apply to the screens in y
 </table>
 
 !!! note
-    You can only customize the provided fields. Adding custom fields to the branding preference texts is not supported.
+    Adding custom fields to the text preferences is not supported.

--- a/en/includes/guides/branding/configure-ui-branding.md
+++ b/en/includes/guides/branding/configure-ui-branding.md
@@ -673,3 +673,6 @@ Listed below are the text branding preferences you can apply to the screens in y
       <td>This is the main heading of the sign-up box, providing a brief introduction to the registration page within your organization.</td>
    </tr>
 </table>
+
+!!! note
+    You can only customize the provided fields. Adding custom fields to the branding preference texts is not supported.


### PR DESCRIPTION
## Purpose
Adding a note to clarify adding Customizable Fields in Branding Preferences is not supported.

Related issue: https://github.com/wso2/product-is/issues/20593

