### PR TITLE
Add to JIT provisioning configurations

### DIFF
--- a/en/includes/guides/authentication/jit-user-provisioning.md
+++ b/en/includes/guides/authentication/jit-user-provisioning.md
@@ -57,6 +57,8 @@ If you wish to change this default behavior and preserve the locally added claim
 [authentication.jit_provisioning]
 preserve_locally_added_claims = "true"
 ```
+
+However, if the `provisioning.jit.attributeSyncMethod` property is set for the identity provider, it will take precedence over the above configuration.
 {% endif %}
 
 ## Troubleshoot sign-in flow errors

--- a/en/includes/guides/authentication/jit-user-provisioning.md
+++ b/en/includes/guides/authentication/jit-user-provisioning.md
@@ -58,7 +58,8 @@ If you wish to change this default behavior and preserve the locally added claim
 preserve_locally_added_claims = "true"
 ```
 
-However, if the `provisioning.jit.attributeSyncMethod` property is set for the identity provider, it will take precedence over the above configuration.
+!!! note
+    If an identity provider is created using the [Identity Provider REST APIs]({{base_path}}/apis/idp/) with the `provisioning.jit.attributeSyncMethod` property set, this will take precedence over the above configuration.
 {% endif %}
 
 ## Troubleshoot sign-in flow errors


### PR DESCRIPTION
### Purpose

Mention the IdP level config `provisioning.jit.attributeSyncMethod` takes precedence over the server level config `authentication.jit_provisioning.preserve_locally_added_claims` for attribute syncing in federated user login flow with JIT provisioning.

### Related Issues

- https://github.com/wso2-enterprise/wso2-iam-internal/issues/1738
- https://github.com/wso2/product-is/issues/16281
