### PR TITLE
Fix documentation_link for Auth React SDK docs

### DIFF
--- a/en/base.yml
+++ b/en/base.yml
@@ -105,7 +105,7 @@ extra:
     - name: Auth React SDK
       icon: assets/img/logo/react-logo.svg
       description: An SDK to integrate {{ config.extra.product_name }} into React applications
-      documentation_link: get-started/try-your-own-app/javascript/
+      documentation_link: get-started/try-your-own-app/react/
       download_link: https://github.com/asgardeo/asgardeo-auth-react-sdk/releases/latest/download/asgardeo-react-app.zip
       source_link: https://github.com/asgardeo/asgardeo-auth-react-sdk
     - name: Auth SPA SDK


### PR DESCRIPTION
## Purpose
> Resolve the issue in the integration section where clicking on the "Auth React SDK" documentation link redirects to the "Auth SPA SDK" documentation instead.

## Approach
> Updated the documentation link in the integration section of `base.yml` to correctly redirect to the Auth React SDK documentation path (`/react`) instead of the Auth SPA SDK docs.