### PR TITLE
Add warnings for OIDC Hybrid Flow

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/openid-connect-hybrid-flow.md
+++ b/en/identity-server/5.10.0/docs/learn/openid-connect-hybrid-flow.md
@@ -10,6 +10,9 @@ in an authorization request selects the hybrid flow for authentication:
 -   [code id\_token](#code-id_token)
 -   [code id\_token token](#code-id_token-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 To configure WSO2 Identity Server to support the OpenID Connect hybrid
 flow for authentication, you need to add following to the
 `         <IS_HOME>/repository/conf/deployment.toml        ` file.

--- a/en/identity-server/5.11.0/docs/learn/openid-connect-hybrid-flow.md
+++ b/en/identity-server/5.11.0/docs/learn/openid-connect-hybrid-flow.md
@@ -10,6 +10,9 @@ in an authorization request selects the hybrid flow for authentication:
 -   [code id\_token](#code-id_token)
 -   [code id\_token token](#code-id_token-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 
 To understand how the `         response_type        ` value specified
 in an authorization request selects the hybrid flow to be the

--- a/en/identity-server/5.9.0/docs/learn/openid-connect-hybrid-flow.md
+++ b/en/identity-server/5.9.0/docs/learn/openid-connect-hybrid-flow.md
@@ -10,6 +10,9 @@ in an authorization request selects the hybrid flow for authentication:
 -   [code id\_token](#code-id_token)
 -   [code id\_token token](#code-id_token-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 To configure WSO2 Identity Server to support the OpenID Connect hybrid
 flow for authentication, you need to add following to the
 `         <IS_HOME>/repository/conf/deployment.toml        ` file.

--- a/en/identity-server/6.0.0/docs/guides/login/oidc-hybrid-flow.md
+++ b/en/identity-server/6.0.0/docs/guides/login/oidc-hybrid-flow.md
@@ -8,6 +8,9 @@ Specifying any of the following `response_type` values in an authorization reque
 - [code id\_token](#get-code-and-id-token)
 - [code id\_token token](#get-code-access-token-and-id-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 To understand how the `response_type` value specified in an authorization request selects the hybrid flow to be the authentication flow, let's take a look at the following `response_type` values in detail.
 
 -----

--- a/en/identity-server/6.0.0/docs/references/concepts/authentication/hybrid-client-profile.md
+++ b/en/identity-server/6.0.0/docs/references/concepts/authentication/hybrid-client-profile.md
@@ -7,6 +7,9 @@ in an authorization request selects the hybrid flow for authentication:
 - [code id_token](#code-id_token)
 - [code id_token token](#code-id_token-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 To understand how the ` response_type ` value specified
 in an authorization request selects the hybrid flow to be the
 authentication flow, let's take a look at the following

--- a/en/identity-server/6.1.0/docs/guides/login/oidc-hybrid-flow.md
+++ b/en/identity-server/6.1.0/docs/guides/login/oidc-hybrid-flow.md
@@ -8,6 +8,9 @@ Specifying any of the following `response_type` values in an authorization reque
 - [code id\_token](#get-code-and-id-token)
 - [code id\_token token](#get-code-access-token-and-id-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 To understand how the `response_type` value specified in an authorization request selects the hybrid flow to be the authentication flow, let's take a look at the following `response_type` values in detail.
 
 -----

--- a/en/identity-server/6.1.0/docs/references/concepts/authentication/hybrid-client-profile.md
+++ b/en/identity-server/6.1.0/docs/references/concepts/authentication/hybrid-client-profile.md
@@ -7,6 +7,9 @@ in an authorization request selects the hybrid flow for authentication:
 - [code id_token](#code-id_token)
 - [code id_token token](#code-id_token-token)
 
+!!! warning
+    It is not recommended to use `code token` and `code id_token token` response types as they do not adhere to best practices and may introduce security risks.
+
 To understand how the ` response_type ` value specified
 in an authorization request selects the hybrid flow to be the
 authentication flow, let's take a look at the following


### PR DESCRIPTION
## Purpose
- This PR adds warning to use `code token` and `code id_token token` response types due to best practises and potential security risks.