### PR TITLE
Update Branding Management API Definition to Include `restrictToPublished` Query Paramater

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/branding-management.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/branding-management.yaml
@@ -469,7 +469,7 @@ components:
       name: restrictToPublished
       required: false
       description: |
-        Specifies whether to use only published branding preferences for resolving.
+        Specifies whether to limit resolving to published branding preferences.
         If set to true, branding preference will be resolved only using published branding preferences.
         If set to false, branding preference will be resolved using both published and unpublished branding preferences.
       schema:

--- a/en/asgardeo/docs/apis/organization-apis/restapis/branding-management.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/branding-management.yaml
@@ -216,6 +216,7 @@ paths:
         - $ref: '#/components/parameters/typeQueryParam'
         - $ref: '#/components/parameters/nameQueryParam'
         - $ref: '#/components/parameters/localeQueryParam'
+        - $ref: '#/components/parameters/restrictToPublishedQueryParam'
       responses:
         '200':
           description: OK
@@ -463,6 +464,18 @@ components:
       schema:
         type: string
       example: "login"
+    restrictToPublishedQueryParam:
+      in: query
+      name: restrictToPublished
+      required: false
+      description: |
+        Specifies whether to use only published branding preferences for resolving.
+        If set to true, branding preference will be resolved only using published branding preferences.
+        If set to false, branding preference will be resolved using both published and unpublished branding preferences.
+      schema:
+        type: boolean
+        default: false
+      example: true
 
   schemas:
     BrandingPreferenceModel:

--- a/en/asgardeo/docs/apis/restapis/branding-preference.yaml
+++ b/en/asgardeo/docs/apis/restapis/branding-preference.yaml
@@ -255,6 +255,7 @@ paths:
         - $ref: '#/components/parameters/typeQueryParam'
         - $ref: '#/components/parameters/nameQueryParam'
         - $ref: '#/components/parameters/localeQueryParam'
+        - $ref: '#/components/parameters/restrictToPublishedQueryParam'
       responses:
         '200':
           description: OK
@@ -537,6 +538,18 @@ components:
       schema:
         type: string
       example: "login"
+    restrictToPublishedQueryParam:
+      in: query
+      name: restrictToPublished
+      required: false
+      description: |
+        Specifies whether to use only published branding preferences for resolving.
+        If set to true, branding preference will be resolved only using published branding preferences.
+        If set to false, branding preference will be resolved using both published and unpublished branding preferences.
+      schema:
+        type: boolean
+        default: false
+      example: true
 
   schemas:
     BrandingPreferenceModel:

--- a/en/asgardeo/docs/apis/restapis/branding-preference.yaml
+++ b/en/asgardeo/docs/apis/restapis/branding-preference.yaml
@@ -543,7 +543,7 @@ components:
       name: restrictToPublished
       required: false
       description: |
-        Specifies whether to use only published branding preferences for resolving.
+        Specifies whether to limit resolving to published branding preferences.
         If set to true, branding preference will be resolved only using published branding preferences.
         If set to false, branding preference will be resolved using both published and unpublished branding preferences.
       schema:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/branding-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/branding-management.yaml
@@ -220,6 +220,7 @@ paths:
         - $ref: '#/components/parameters/typeQueryParam'
         - $ref: '#/components/parameters/nameQueryParam'
         - $ref: '#/components/parameters/localeQueryParam'
+        - $ref: '#/components/parameters/restrictToPublishedQueryParam'
       responses:
         '200':
           description: OK
@@ -467,6 +468,18 @@ components:
       schema:
         type: string
       example: "login"
+    restrictToPublishedQueryParam:
+      in: query
+      name: restrictToPublished
+      required: false
+      description: |
+        Specifies whether to use only published branding preferences for resolving.
+        If set to true, branding preference will be resolved only using published branding preferences.
+        If set to false, branding preference will be resolved using both published and unpublished branding preferences.
+      schema:
+        type: boolean
+        default: false
+      example: true
 
   schemas:
     BrandingPreferenceModel:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/branding-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/branding-management.yaml
@@ -473,7 +473,7 @@ components:
       name: restrictToPublished
       required: false
       description: |
-        Specifies whether to use only published branding preferences for resolving.
+        Specifies whether to limit resolving to published branding preferences.
         If set to true, branding preference will be resolved only using published branding preferences.
         If set to false, branding preference will be resolved using both published and unpublished branding preferences.
       schema:

--- a/en/identity-server/next/docs/apis/restapis/branding-preference.yaml
+++ b/en/identity-server/next/docs/apis/restapis/branding-preference.yaml
@@ -259,6 +259,7 @@ paths:
         - $ref: '#/components/parameters/typeQueryParam'
         - $ref: '#/components/parameters/nameQueryParam'
         - $ref: '#/components/parameters/localeQueryParam'
+        - $ref: '#/components/parameters/restrictToPublishedQueryParam'
       responses:
         '200':
           description: OK
@@ -541,6 +542,18 @@ components:
       schema:
         type: string
       example: "login"
+    restrictToPublishedQueryParam:
+      in: query
+      name: restrictToPublished
+      required: false
+      description: |
+        Specifies whether to use only published branding preferences for resolving.
+        If set to true, branding preference will be resolved only using published branding preferences.
+        If set to false, branding preference will be resolved using both published and unpublished branding preferences.
+      schema:
+        type: boolean
+        default: false
+      example: true
 
   schemas:
     BrandingPreferenceModel:

--- a/en/identity-server/next/docs/apis/restapis/branding-preference.yaml
+++ b/en/identity-server/next/docs/apis/restapis/branding-preference.yaml
@@ -547,7 +547,7 @@ components:
       name: restrictToPublished
       required: false
       description: |
-        Specifies whether to use only published branding preferences for resolving.
+        Specifies whether to limit resolving to published branding preferences.
         If set to true, branding preference will be resolved only using published branding preferences.
         If set to false, branding preference will be resolved using both published and unpublished branding preferences.
       schema:


### PR DESCRIPTION
## Purpose
> A new query parameter (`restrictToPublished`) to the branding preference resolve GET endpoint is introduced, in order to enable the resolution of branding preferences using only published preferences. The purpose of this PR is to add this newly introduced query parameter into branding management API docs.

> By adding the `restrictToPublished` query parameter, users can specify whether to retrieve branding preferences only from published sources or from both published and unpublished preferences.

### Example Usage:
```
curl --location '{base-url}/api/server/v1/branding-preference/resolve?locale={locale}&name={name}&type={branding-type}&restrictToPublished={true/false}' 
```
#### EX:
```
curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/branding-preference/resolve?locale=en-US&name=e3548660-6ff9-4a39-acd6-d4071d6a6e69&type=APP&restrictToPublished=true' 
```

### Parameter Behavior of restrictToPublished
- `true`: Returns resolved branding preferences considering only published preferences.
- `false`: Returns resolved branding preferences considering both published and unpublished preferences.
- `Not set`: Defaults to false, considering both published and unpublished preferences.

## Related Issues
- https://github.com/wso2/product-is/issues/20769

## Related PRs
- https://github.com/wso2-extensions/identity-branding-preference-management/pull/43
- https://github.com/wso2/identity-api-server/pull/637
- https://github.com/wso2/carbon-identity-framework/pull/5820
- https://github.com/wso2/product-is/pull/20889/
