### PR TITLE
Adding permission for resend-code endpoint at toml level

### DIFF
--- a/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -13,7 +13,6 @@ The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is511/selfregist
 
 To do so, add the following configurations to the `deployment.toml` file
 
-Update the default permission for the resend-code endpoint in the Self-Sign-up API to utilize identity management permissions prior to production deployment.
 
 ```toml
 [resource.access_control]

--- a/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -9,6 +9,10 @@
 
 ## Enhance the default permission for the resend-code endpoint.
 
+The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is511/selfregister-v5.11.0/#!/operations#SelfRegister#meResendCodePost) of the self sign-up rest APIs is used to resend the confirmation code to an authenticated user. While no scopes are required to invoke this API by default, we recommend limiting permissions to this endpoint using scopes, prior to production deployment.
+
+To do so, add the following configurations to the `deployment.toml` file
+
 Update the default permission for the resend-code endpoint in the Self-Sign-up API to utilize identity management permissions prior to production deployment.
 
 Add the following properties to the `deployment.toml` file.

--- a/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -15,7 +15,6 @@ To do so, add the following configurations to the `deployment.toml` file
 
 Update the default permission for the resend-code endpoint in the Self-Sign-up API to utilize identity management permissions prior to production deployment.
 
-
 ```toml
 [resource.access_control]
 context = "(.*)/api/identity/user/v1.0/resend-code(.*)"

--- a/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -15,7 +15,6 @@ To do so, add the following configurations to the `deployment.toml` file
 
 Update the default permission for the resend-code endpoint in the Self-Sign-up API to utilize identity management permissions prior to production deployment.
 
-Add the following properties to the `deployment.toml` file.
 
 ```toml
 [resource.access_control]

--- a/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.11.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -6,3 +6,18 @@
 
 !!! info "Related Links" 
     For information on self-registration via the UI instead, see [Self-Registration and Account Confirmation](../../learn/self-registration-and-account-confirmation).
+
+## Enhance the default permission for the resend-code endpoint.
+
+Update the default permission for the resend-code endpoint in the Self-Sign-up API to utilize identity management permissions prior to production deployment.
+
+Add the following properties to the `deployment.toml` file.
+
+```toml
+[resource.access_control]
+context = "(.*)/api/identity/user/v1.0/resend-code(.*)"
+secure = "true"
+http_method = "all"
+permissions=["/permission/admin/manage/identity/identitymgt"]
+scopes=["internal_identity_mgt_view","internal_identity_mgt_update","internal_identity_mgt_create","internal_identity_mgt_delete"]
+```


### PR DESCRIPTION
## Purpose
Provide instructions for upgrading the permission level of the resend-code endpoint in IS 5.11.0.

## Goals
Upgrade the permission level following the documented instructions to ensure the stability of the existing system.
