### PR TITLE
added message on whitespace validation in passwords

### DIFF
--- a/en/identity-server/7.0.0/docs/guides/account-configurations/login-security/password-validation.md
+++ b/en/identity-server/7.0.0/docs/guides/account-configurations/login-security/password-validation.md
@@ -8,28 +8,30 @@ To configure password validation rules, follow the steps below:
 
 1. On the {{product_name}} Console, go to **Login & Registration** > **Login Security** > **Password Validation**.
 2. Adjust the settings according to your security requirements.
+
+    ![Password Validation Configuration]({{base_path}}/assets/img/guides/account-configurations/password-validation.png){: width="600" style="display: block; margin: 0;"}
+
+    <table>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td><code>Password Expiration</code></td>
+      <td>Defines the number of days after which a password must be changed.</td>
+    </tr>
+    <tr>
+      <td><code>Password History Count</code></td>
+      <td>Specifies the number of unique new passwords a user must use before an old password can be reused.</td>
+    </tr>
+    <tr>
+      <td><code>Password Input Validation</code></td>
+      <td>Sets requirements for password complexity, including length and character types.</td>
+    </tr>
+    </table>
+
 3. Click **Update** to save the changes.
 
-![Password Validation Configuration]({{base_path}}/assets/img/guides/account-configurations/password-validation.png){: width="800" style="display: block; margin: 0;"}
+!!! note "Validation for whitespace in passwords"
 
-## Parameters
-
-<table>
-  <tr>
-    <th>Parameter</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td><code>Password Expiration</code></td>
-    <td>Defines the number of days after which a password must be changed.</td>
-  </tr>
-  <tr>
-    <td><code>Password History Count</code></td>
-    <td>Specifies the number of unique new passwords a user must use before an old password can be reused.</td>
-  </tr>
-  <tr>
-    <td><code>Password Input Validation</code></td>
-    <td>Sets requirements for password complexity, including length and character types.</td>
-  </tr>
-</table>
-
+    {{product_name}} automatically trims leading and trailing whitespace from passwords when creating, updating, or when entering passwords to login.

--- a/en/includes/guides/user-accounts/account-security/password-validation.md
+++ b/en/includes/guides/user-accounts/account-security/password-validation.md
@@ -121,4 +121,4 @@ Configure the following parameters to enforce input validation.
 
 !!! note "Validation for whitespace in passwords"
 
-    {{product_name}} automatically trims leading and trailing whitespace from passwords when creating, updating, or when entering passwords to login. This behavior is enforced for interactions through the UI and the API.
+    {{product_name}} automatically trims leading and trailing whitespace from passwords when creating, updating, or when entering passwords to login.

--- a/en/includes/guides/user-accounts/account-security/password-validation.md
+++ b/en/includes/guides/user-accounts/account-security/password-validation.md
@@ -118,3 +118,7 @@ Configure the following parameters to enforce input validation.
         <td><code>[Optional]</code>This field identifies the number of characters that can be repeated consecutively in a user password. <br> <b> Example: </b> If you assign <code>1</code> as the number of repeated characters, the password cannot contain any repeated characters consecutively. <br> The password <code>aa1@Znlq</code> is incorrect as it has the character <code>a</code> appearing consecutively.</td>
     </tr>
 </table>
+
+!!! note "Validation for whitespace in passwords"
+
+    {{product_name}} automatically trims leading and trailing whitespace from passwords when creating, updating, or when entering passwords to login. This behavior is enforced for interactions through the UI and the API.


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/wso2/product-is/issues/21083

The content was added to /guides/user-accounts/account-security/password-validation/

IS:

![screencapture-localhost-8000-en-7-0-0-guides-account-configurations-login-security-password-validation-2024-09-11-14_19_32](https://github.com/user-attachments/assets/371a9ad4-6af6-4af5-9498-fd985535bb88)


Asgardeo:

![screencapture-localhost-8000-asgardeo-docs-guides-user-accounts-account-security-password-validation-2024-09-11-14_23_46](https://github.com/user-attachments/assets/b610251e-de53-4aee-933f-0c229804d590)





