### PR TITLE
[6.1.0] Fix typo in account lock

### DIFF
--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/lock-accounts-by-failed-login-attempts.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/lock-accounts-by-failed-login-attempts.md
@@ -54,7 +54,7 @@ tenants.
 		of **Maximum failed login attempts**.
    
 		!!! note
-			WSO2 Identity Server has the **Internal/ki8system** role configured by
+			WSO2 Identity Server has the **Internal/system** role configured by
 			default. However, generally a new user is not assigned the
 			**Internal/system** role by default. Required roles can be assigned
 			to a user depending on the set of permission a user needs to have.


### PR DESCRIPTION
## Purpose
$
we only have **Internal/system** role not **Internal/ki8system** role.