### PR TITLE
[5.10] Adding permission for resend-code endpoint at toml level

### DIFF
--- a/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -9,7 +9,7 @@
 
 ## Enhance default permissions for the resend-code endpoint.
 
-The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is510/self-registration/#!/operations#SelfRegister#resendCodePost) of the self sign-up rest APIs is used to resend the confirmation code to an authenticated user. While no scopes are required to invoke this API by default, we recommend limiting permissions to this endpoint using scopes, prior to production deployment.
+The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is510/self-registration/#!/operations#SelfRegister#resendCodePost) of the self sign-up rest APIs is used to resend the confirmation code to an authenticated user. While no scopes are required to invoke this API by default, we recommend restricting access to this endpoint using scopes, before deploying to production.
 
 To do so, add the following configurations to the `<IS_HOME>/repository/conf/deployment.toml` file
 

--- a/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -11,7 +11,7 @@
 
 The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is510/self-registration/#!/operations#SelfRegister#resendCodePost) of the self sign-up rest APIs is used to resend the confirmation code to an authenticated user. While no scopes are required to invoke this API by default, we recommend limiting permissions to this endpoint using scopes, prior to production deployment.
 
-To do so, add the following configurations to the `<IS_HOME>/repository/conf/deployment.toml/deployment.toml` file
+To do so, add the following configurations to the `<IS_HOME>/repository/conf/deployment.toml` file
 
 
 ```toml

--- a/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -6,3 +6,19 @@
 
 !!! info "Related Links" 
     For information on self-registration via the UI instead, see [Self-Registration and Account Confirmation](../../learn/self-registration-and-account-confirmation).
+
+## Enhance default permissions for the resend-code endpoint.
+
+The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is510/self-registration/#!/operations#SelfRegister#resendCodePost) of the self sign-up rest APIs is used to resend the confirmation code to an authenticated user. While no scopes are required to invoke this API by default, we recommend limiting permissions to this endpoint using scopes, prior to production deployment.
+
+To do so, add the following configurations to the `deployment.toml` file
+
+
+```toml
+[resource.access_control]
+context = "(.*)/api/identity/user/v1.0/resend-code(.*)"
+secure = "true"
+http_method = "all"
+permissions=["/permission/admin/manage/identity/identitymgt"]
+scopes=["internal_identity_mgt_view","internal_identity_mgt_update","internal_identity_mgt_create","internal_identity_mgt_delete"]
+```

--- a/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
+++ b/en/identity-server/5.10.0/docs/develop/using-the-self-sign-up-rest-apis.md
@@ -11,7 +11,7 @@
 
 The [resend-code endpoint](https://api-docs.wso2.com/apidocs/is/is510/self-registration/#!/operations#SelfRegister#resendCodePost) of the self sign-up rest APIs is used to resend the confirmation code to an authenticated user. While no scopes are required to invoke this API by default, we recommend limiting permissions to this endpoint using scopes, prior to production deployment.
 
-To do so, add the following configurations to the `deployment.toml` file
+To do so, add the following configurations to the `<IS_HOME>/repository/conf/deployment.toml/deployment.toml` file
 
 
 ```toml


### PR DESCRIPTION
## Purpose
Provide instructions for upgrading the permission level of the resend-code endpoint in IS 5.10.0.

## Goals
Upgrade the permission level following the documented instructions to ensure the stability of the existing system.
