### PR TITLE
Sub attribute and introspection response docs updated

### DIFF
--- a/en/includes/guides/authentication/oidc/token-validation-resource-server.md
+++ b/en/includes/guides/authentication/oidc/token-validation-resource-server.md
@@ -95,3 +95,32 @@ If the token you used is invalid, you will get the following response:
 ```
 
 <br>
+
+## Application Access Token Response
+
+Application Access Tokens are tokens obtained through grant types like the `client_credentials` grant. Unlike user-bound tokens, these tokens are not associated with any specific user, as they represent the application itself rather than an individual user.
+
+The introspection response for Application Access Tokens follows the format shown below:
+
+**Sample response**
+
+```json
+{
+  "nbf": 1629961093,
+  "scope": "openid profile",
+  "active": true,
+  "token_type": "Bearer",
+  "exp": 1629968693,
+  "iat": 1629961093,
+  "client_id": "Wsoq8t4nHW80gSnPfyDvRbiC__Eb"
+}
+```
+
+## Outdated Behavior (Optional)
+
+Previously, the `username` attribute was included in the introspection response, where its value represented the application owner's username. If your applications rely on this behavior, you are likely using an outdated version.
+
+!!! note
+    Before updating, ensure that any usages on the `username` attribute in the introspection response are removed. It is important to stop using this attribute if your applications rely on it.
+
+After updating the application, the `username` attribute will no longer be included in the introspection response.

--- a/en/includes/guides/authentication/user-attributes/enable-attributes-for-oidc-app.md
+++ b/en/includes/guides/authentication/user-attributes/enable-attributes-for-oidc-app.md
@@ -52,6 +52,17 @@ To define a different attribute as the subject:
 
 3. Click **Update**.
 
+#### Subject Attribute usage in Access tokens
+
+The subject attribute value configured here is sent in the `sub` attribute of both user access tokens and application access tokens.
+
+With the latest updates, the `sub` attribute for application access tokens will no longer be linked to the `subject attribute`. Instead, the `sub` attribute will now carry the `client_id` of the application.
+
+If you are still using the outdated behavior, please update your application to adopt the latest functionality.
+
+!!! note
+        Before updating, ensure that any usages on the `sub` attribute being used as the subject attribute for application tokens are removed.
+
 ### Define mandatory user attributes
 
 {% include "../../fragments/manage-app/manage-user-attributes/select-mandatory-attributes.md" %}


### PR DESCRIPTION
## Purpose
> With the https://github.com/wso2/product-is/issues/20917 changes,
- the subject attribute usage in sub claim of app tokens will be changed
- the username inclusion in introspection response for app tokens will be changed

This PR adds the relevant changes to the relevant sections.

## Related issues:
- https://github.com/wso2/product-is/issues/20917