### PR TITLE
Update username recovery documentation for non-unique users

### DIFF
--- a/en/identity-server/next/docs/guides/account-configurations/account-recovery/username-recovery.md
+++ b/en/identity-server/next/docs/guides/account-configurations/account-recovery/username-recovery.md
@@ -12,3 +12,14 @@ To enable username recovery, take the following steps:
 
 ![Username Recovery Configuration]({{base_path}}/assets/img/guides/account-configurations/username-recovery.png){: width="900" style="display: block; margin: 0;"}
 
+!!! note
+    Once users enter their details on the username recovery page, such as their first name, email, or mobile number, if the system can verify a unique user based on the provided information, an email will be sent to their registered email address. If the system is unable to identify a unique user, no recovery information will be sent by default.
+
+    If you want to enable username recovery for non-unique users, you can configure it by adding the following configuration to the `deployment.toml` file located in the `<IS_HOME>/repository/conf` directory.
+
+    ``` toml
+    [identity_mgt.username_recovery.non_unique_user]
+    enabled = true
+    ```
+
+    When this configuration is enabled, the system will send **multiple recovery notifications** with all usernames associated with the identified users.


### PR DESCRIPTION
## Purpose
> This pull request includes an update to the username recovery documentation for the Identity Server. The change adds a note explaining how to enable username recovery for non-unique users by modifying the `deployment.toml` file.

## Approach
> Added a note to `en/identity-server/7.0.0/docs/guides/account-configurations/account-recovery/username-recovery.md` on how to configure the system to send recovery notifications for non-unique users by updating the `deployment.toml`