### PR TITLE
Modify accessToken claims data type in preIssueAccessToken openAPI

### DIFF
--- a/en/asgardeo/docs/references/actions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
+++ b/en/asgardeo/docs/references/actions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
@@ -347,7 +347,13 @@ components:
         name:
           type: string
         value:
-          type: string
+          oneOf:
+            - type: string
+            - type: integer
+            - type: boolean
+            - type: array
+              items:
+                type: string
     Operations:
       type: object
       properties:

--- a/en/identity-server/next/docs/references/actions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
+++ b/en/identity-server/next/docs/references/actions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
@@ -353,7 +353,13 @@ components:
         name:
           type: string
         value:
-          type: string
+          oneOf:
+            - type: string
+            - type: integer
+            - type: boolean
+            - type: array
+              items:
+                type: string
     Operations:
       type: object
       properties:


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-is/issues/21312

Since we allow String, Integer, Boolean and String[] types for the value attribute of the claims object, need to properly mention that in the openAPI.

Before
<img width="816" alt="image" src="https://github.com/user-attachments/assets/03cada89-102d-4139-9f1e-53593feca05a">

Now
<img width="744" alt="image" src="https://github.com/user-attachments/assets/903accc1-f4ed-4bb7-ae32-bbb28a82691f">
