### PR TITLE
Add excludeSystemPortals query param for applications GET

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
@@ -352,7 +352,7 @@ components:
       required: false
       description: |
         Specifies whether to exclude system portals in the response. 
-         If not provided, the default is false, meaning system portals will be excluded.
+         If not provided, the default is false, meaning system portals will be included.
 
         /applications?excludeSystemPortals=true
       schema:

--- a/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
@@ -351,7 +351,7 @@ components:
       name: excludeSystemPortals
       required: false
       description: |
-        Specifies whether to include or exclude system portals in the response. 
+        Specifies whether to exclude system portals in the response. 
          If not provided, the default is false, meaning system portals will be excluded.
 
         /applications?excludeSystemPortals=true

--- a/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
@@ -24,6 +24,7 @@ paths:
         - $ref: '#/components/parameters/sortOrderQueryParam'
         - $ref: '#/components/parameters/sortByQueryParam'
         - $ref: '#/components/parameters/attributesQueryParam'
+        - $ref: '#/components/parameters/excludeSystemPortalsQueryParam'
       responses:
         '200':
           description: OK
@@ -345,6 +346,17 @@ components:
         /applications?attributes=advancedConfigurations,templateId,clientId,issuer
       schema:
         type: string
+    excludeSystemPortalsQueryParam:
+      in: query
+      name: excludeSystemPortals
+      required: false
+      description: |
+        Specifies whether to include or exclude system portals in the response. 
+        Default will be treated as false if parameter is not preset in the request.
+
+        /applications?excludeSystemPortals=true
+      schema:
+        type: boolean
     exportSecretsQueryParam:
       in: query
       name: exportSecrets

--- a/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
@@ -352,7 +352,7 @@ components:
       required: false
       description: |
         Specifies whether to include or exclude system portals in the response. 
-        Default will be treated as false if parameter is not preset in the request.
+        The default value is false.
 
         /applications?excludeSystemPortals=true
       schema:

--- a/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
@@ -352,7 +352,7 @@ components:
       required: false
       description: |
         Specifies whether to include or exclude system portals in the response. 
-        The default value is false.
+         If not provided, the default is false, meaning system portals will be excluded.
 
         /applications?excludeSystemPortals=true
       schema:

--- a/en/identity-server/next/docs/apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/restapis/application.yaml
@@ -3938,7 +3938,7 @@ components:
       required: false
       description: |
         Specifies whether to include or exclude system portals in the response. 
-        Default will be treated as false if parameter is not preset in the request.
+        If not provided, the default is false, meaning system portals will be excluded.
 
         /applications?excludeSystemPortals=true
       schema:

--- a/en/identity-server/next/docs/apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/restapis/application.yaml
@@ -3937,7 +3937,7 @@ components:
       name: excludeSystemPortals
       required: false
       description: |
-        Specifies whether to include or exclude system portals in the response. 
+        Specifies whether to exclude system portals in the response. 
         If not provided, the default is false, meaning system portals will be excluded.
 
         /applications?excludeSystemPortals=true

--- a/en/identity-server/next/docs/apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/restapis/application.yaml
@@ -3938,7 +3938,7 @@ components:
       required: false
       description: |
         Specifies whether to exclude system portals in the response. 
-        If not provided, the default is false, meaning system portals will be excluded.
+        If not provided, the default is false, meaning system portals will be included.
 
         /applications?excludeSystemPortals=true
       schema:

--- a/en/identity-server/next/docs/apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/restapis/application.yaml
@@ -26,6 +26,7 @@ paths:
         - $ref: '#/components/parameters/sortOrderQueryParam'
         - $ref: '#/components/parameters/sortByQueryParam'
         - $ref: '#/components/parameters/attributesQueryParam'
+        - $ref: '#/components/parameters/excludeSystemPortalsQueryParam'
       responses:
         '200':
           description: OK
@@ -3931,6 +3932,17 @@ components:
         /applications?attributes=advancedConfigurations,templateId,templateVersion,clientId,issuer
       schema:
         type: string
+    excludeSystemPortalsQueryParam:
+      in: query
+      name: excludeSystemPortals
+      required: false
+      description: |
+        Specifies whether to include or exclude system portals in the response. 
+        Default will be treated as false if parameter is not preset in the request.
+
+        /applications?excludeSystemPortals=true
+      schema:
+        type: boolean
     exportSecretsQueryParam:
       in: query
       name: exportSecrets


### PR DESCRIPTION
## Purpose

Adding the new query param excludeSystemPortals introduced through [1] to the spec. This is added for IS next and asgardeo. 

[1] https://github.com/wso2/identity-api-server/pull/711