### PR TITLE
Remove the non unique user support docs.

### DIFF
--- a/en/identity-server/next/docs/guides/account-configurations/account-recovery/username-recovery.md
+++ b/en/identity-server/next/docs/guides/account-configurations/account-recovery/username-recovery.md
@@ -13,15 +13,3 @@ To enable username recovery, take the following steps:
 3. Click **Update** to save the changes.
 
 ![Username Recovery Configuration]({{base_path}}/assets/img/guides/account-configurations/username-recovery.png){: width="900" style="display: block; margin: 0;"}
-
-!!! note
-    Once users enter their details on the username recovery page, such as their first name, email, or mobile number, if the system can verify a unique user based on the provided information, an email will be sent to their registered email address. If the system is unable to identify a unique user, no recovery information will be sent by default.
-
-    If you want to enable username recovery for non-unique users, you can configure it by adding the following configuration to the `deployment.toml` file located in the `<IS_HOME>/repository/conf` directory.
-
-    ``` toml
-    [identity_mgt.username_recovery.non_unique_user]
-    enabled = true
-    ```
-
-    When this configuration is enabled, the system will send **multiple recovery notifications** with all usernames associated with the identified users.


### PR DESCRIPTION
## Purpose
- With the new multiple channel support for the username recovery, non unique users will not be support as we updating the api from v0.9 to v2.

## Related issues
- https://github.com/wso2/product-is/issues/21407
- https://github.com/wso2/product-is/issues/21180

## Current view
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/162d2353-f6aa-4860-9474-87348aa1c47b">


## Updated view
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/c57dc2a6-4331-4f1a-b7f2-73bfe20da8eb">
