### PR TITLE
Removing JDK 1.8 from recommended JDKs

### DIFF
--- a/en/identity-server/7.0.0/docs/deploy/deployment-guide.md
+++ b/en/identity-server/7.0.0/docs/deploy/deployment-guide.md
@@ -64,7 +64,7 @@ The above recommendations can change based on the expected concurrency and perfo
 </tr>
 <tr class="even">
 <th>Java</th>
-<td>Oracle JDK 1.8</td>
+<td>Open JDK 11</td>
 </tr>
 <tr class="odd">
 <th>Web browsers</th>

--- a/en/identity-server/7.0.0/docs/deploy/security/security-guidelines/product-level-security-guidelines.md
+++ b/en/identity-server/7.0.0/docs/deploy/security/security-guidelines/product-level-security-guidelines.md
@@ -227,7 +227,7 @@ Log forging can be prevented by appending a UUID to the log message.
 
 ## JVM parameters
 
-- The recommended JDK versions are JDK 1.8 and 11. For more information, see <a href="{{base_path}}/deploy/get-started/install/#prerequisites">Prerequisites</a>. 
+- The recommended JDK versions are JDK 11 and 17. For more information, see <a href="{{base_path}}/deploy/get-started/install/#prerequisites">Prerequisites</a>. 
 
     ```java
     -Xms512m -Xmx2048m 

--- a/en/identity-server/next/docs/deploy/deployment-guide.md
+++ b/en/identity-server/next/docs/deploy/deployment-guide.md
@@ -64,7 +64,7 @@ The above recommendations can change based on the expected concurrency and perfo
 </tr>
 <tr class="even">
 <th>Java</th>
-<td>Oracle JDK 1.8</td>
+<td>Open JDK 11</td>
 </tr>
 <tr class="odd">
 <th>Web browsers</th>

--- a/en/identity-server/next/docs/deploy/security/security-guidelines/product-level-security-guidelines.md
+++ b/en/identity-server/next/docs/deploy/security/security-guidelines/product-level-security-guidelines.md
@@ -227,7 +227,7 @@ Log forging can be prevented by appending a UUID to the log message.
 
 ## JVM parameters
 
-- The recommended JDK versions are JDK 1.8 and 11. For more information, see <a href="{{base_path}}/deploy/get-started/install/#prerequisites">Prerequisites</a>. 
+- The recommended JDK versions are JDK 11 and 17. For more information, see <a href="{{base_path}}/deploy/get-started/install/#prerequisites">Prerequisites</a>. 
 
     ```java
     -Xms512m -Xmx2048m 


### PR DESCRIPTION
## Purpose
Updating the recommended JDK versions.

Related Issue: 

- https://github.com/wso2/product-is/issues/21792