### PR TITLE
Scim scim2 inbound provisioining coexisting issue

### DIFF
--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/outbound-provisioning-with-scim.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/outbound-provisioning-with-scim.md
@@ -20,6 +20,18 @@ configuration user interface of WSO2 Identity Server.
 
 WSO2 Identity Server supports outbound provisioning with both SCIM 1.1 and SCIM 2.0 standards. This topic provides instructions  on how to configure SCIM 1.1 or SCIM 2.0 connectors to provision users from the WSO2 IS. 
 
+!!! Note
+    If another Identity Server instance is being used as the secondary Identity Provider, please note the below.
+
+    Identity server does not support SCIM1.1 and SCIM 2.0 inbound provisioning to work at the same time. Therefore we have disabled SCIM1.1 listeners by default. If you have a requirement to enable SCIM1.1.1 connector, add the below configuration to the deployment.toml file.
+
+    ```toml
+    [event.default_listener.scim2]
+    enable=false
+
+    [event.default_listener.scim]
+    enable=true 
+    ```
 ---
 
 ## Configure an identity provider


### PR DESCRIPTION
## Purpose
> Identity Server SCIM 1.1 and SCIM 2 inbound provisioning at the same time. Therefore we need sufficient documentation to mention that the user need to disable one of the listeners to get the other worked.

- 7.0 does not contain any documentation related to scim1. Hence not adding the note there.

Resolves https://github.com/wso2/product-is/issues/21904

<img width="709" alt="Screenshot 2024-12-16 at 17 46 53" src="https://github.com/user-attachments/assets/a825741d-6c0b-421e-ad39-dc5f31104b1f" />
