### PR TITLE
Added the recommended regex pattern to the docs

### DIFF
--- a/en/identity-server/5.10.0/docs/administer/product-level-security-guidelines.md
+++ b/en/identity-server/5.10.0/docs/administer/product-level-security-guidelines.md
@@ -355,6 +355,9 @@ When configuring intermediate certificate validation for REST APIs, it is recomm
 
 For the scenarios listed below, you can define a regular expression to validate the callback URL. The default configuration allows any callback URL. Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
 
+!!! note
+    The recommended **callback URL regex** to use when testing the product is `^https:\/\/localhost:9443\/.*`. However, users should modify it to meet their requirements when they deploy the product. You can find the specific instructions through following sections.
+
 - [Password Recovery](../../learn/password-recovery)
 - [Username Recovery](../../learn/username-recovery)
 - [Self User Registration](../../learn/self-registration-and-account-confirmation/#configuring-self-registration)

--- a/en/identity-server/5.11.0/docs/administer/product-level-security-guidelines.md
+++ b/en/identity-server/5.11.0/docs/administer/product-level-security-guidelines.md
@@ -199,6 +199,10 @@ By default, XSS attacks are prevented in the latest WSO2 Identity Server version
 
 For the scenarios listed below, you can define a regular expression to validate the callback URL. The default configuration allows any callback URL. Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
 
+!!! note
+
+    The recommended **callback URL regex** to use when testing the product is `^https:\/\/localhost:9443\/.*`. However, users should modify it to meet their requirements when they deploy the product. You can find the specific instructions through following sections.
+
 - [Password Recovery](../../learn/password-recovery)
 - [Username Recovery](../../learn/username-recovery)
 - [Self User Registration](../../learn/self-registration-and-account-confirmation/#configuring-self-registration)

--- a/en/identity-server/5.11.0/docs/administer/product-level-security-guidelines.md
+++ b/en/identity-server/5.11.0/docs/administer/product-level-security-guidelines.md
@@ -200,7 +200,6 @@ By default, XSS attacks are prevented in the latest WSO2 Identity Server version
 For the scenarios listed below, you can define a regular expression to validate the callback URL. The default configuration allows any callback URL. Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
 
 !!! note
-
     The recommended **callback URL regex** to use when testing the product is `^https:\/\/localhost:9443\/.*`. However, users should modify it to meet their requirements when they deploy the product. You can find the specific instructions through following sections.
 
 - [Password Recovery](../../learn/password-recovery)

--- a/en/identity-server/6.0.0/docs/deploy/security/product-level-security-guidelines.md
+++ b/en/identity-server/6.0.0/docs/deploy/security/product-level-security-guidelines.md
@@ -360,6 +360,9 @@ Follow the steps below to change the default credentials.
 
 For the scenarios listed below, you can define a regular expression to validate the callback URL. The default configuration allows any callback URL. Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
 
+!!! note
+        The recommended **callback URL regex** to use when testing the product is `^https:\/\/localhost:9443\/.*`. However, users should modify it to meet their requirements when they deploy the product. You can find the specific instructions through following sections.
+
 - [Password Recovery](../../../guides/password-mgt/recover-password/#enable-password-recovery-via-email)
 - [Username Recovery](../../../guides/identity-lifecycles/recover-username/#enable-username-recovery)
 - [Self User Registration](../../../guides/identity-lifecycles/self-registration-workflow/)

--- a/en/identity-server/6.1.0/docs/deploy/security/product-level-security-guidelines.md
+++ b/en/identity-server/6.1.0/docs/deploy/security/product-level-security-guidelines.md
@@ -360,6 +360,9 @@ Follow the steps below to change the default credentials.
 
 For the scenarios listed below, you can define a regular expression to validate the callback URL. The default configuration allows any callback URL. Note that if you are using these scenarios, it is highly recommended to define the regular expression that validates and only allows access to specific callback URLs.
 
+!!! note
+        The recommended **callback URL regex** to use when testing the product is `^https:\/\/localhost:9443\/.*`. However, users should modify it to meet their requirements when they deploy the product. You can find the specific instructions through following sections.
+
 - [Password Recovery](../../../guides/password-mgt/recover-password/#enable-password-recovery-via-email)
 - [Username Recovery](../../../guides/identity-lifecycles/recover-username/#enable-username-recovery)
 - [Self User Registration](../../../guides/identity-lifecycles/self-registration-workflow/)


### PR DESCRIPTION
This pull request includes updates to the product-level security guidelines documentation for multiple versions of the WSO2 Identity Server. The changes introduce a recommended regular expression for validating callback URLs during testing.

Documentation updates:

* [`en/identity-server/5.10.0/docs/administer/product-level-security-guidelines.md`](diffhunk://#diff-dc6f7cf4ca2243583c589876aa9d9ba57f967e6a16216615646934f4dc08d917R358-R360): Added a note recommending the callback URL regex `^https:\/\/localhost:9443\/.*` for testing purposes.
* [`en/identity-server/5.11.0/docs/administer/product-level-security-guidelines.md`](diffhunk://#diff-fe9e72b3970d4bdbefa9bebc1990c88d3670d188b6a8f63855a341ce9fcef66eR202-R205): Added a note recommending the callback URL regex `^https:\/\/localhost:9443\/.*` for testing purposes.
* [`en/identity-server/6.0.0/docs/deploy/security/product-level-security-guidelines.md`](diffhunk://#diff-4e5d6f1172d7bd8a542a3eb7e2c5cbf66e581531bff530b480efcf3a2d0255c0R363-R365): Added a note recommending the callback URL regex `^https:\/\/localhost:9443\/.*` for testing purposes.
* [`en/identity-server/6.1.0/docs/deploy/security/product-level-security-guidelines.md`](diffhunk://#diff-4e5d6f1172d7bd8a542a3eb7e2c5cbf66e581531bff530b480efcf3a2d0255c0R363-R365): Added a note recommending the callback URL regex `^https:\/\/localhost:9443\/.*` for testing purposes.

<img width="719" alt="unnamed" src="https://github.com/user-attachments/assets/90b71275-72fa-4813-9f82-663dbf7381c0" />
