### PR TITLE
Remove the order note from the content.

### DIFF
--- a/en/identity-server/6.1.0/docs/guides/mfa/x509.md
+++ b/en/identity-server/6.1.0/docs/guides/mfa/x509.md
@@ -162,14 +162,12 @@ Once you have done the above steps, you have the keystore (`localcrt.jks`), trus
 
     !!! note
     
-        1.   To function properly, this connector should come first in the order. Otherwise, when mutual SSL takes place, the already existing connector (9443) will be picked up and the certificate will not be retrieved correctly.
-
-        2.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
+        1.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
             -   `true` : valid client certificate required for a connection to succeed
             -   `want` : use a certificate if available, but still connect if no certificate is available
             -   `false` : no client certificate is required or validated
     
-        3.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
+        2.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
 
 ---
 

--- a/en/identity-server/7.0.0/docs/guides/authentication/mfa/add-x509-login.md
+++ b/en/identity-server/7.0.0/docs/guides/authentication/mfa/add-x509-login.md
@@ -172,14 +172,12 @@ that you need to use later on in this guide.
 
     !!! note
     
-        1.   To function properly, this connector should come first in the order. Otherwise, when mutual SSL takes place, the already existing connector (9443) will be picked up and the certificate will not be retrieved correctly.
-
-        2.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
+        1.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
             -   `true` : valid client certificate required for a connection to succeed
             -   `want` : use a certificate if available, but still connect if no certificate is available
             -   `false` : no client certificate is required or validated
     
-        3.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
+        2.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
 
 ## Disable certificate validation
 

--- a/en/identity-server/next/docs/guides/authentication/mfa/add-x509-login.md
+++ b/en/identity-server/next/docs/guides/authentication/mfa/add-x509-login.md
@@ -172,14 +172,12 @@ that you need to use later on in this guide.
 
     !!! note
     
-        1.   To function properly, this connector should come first in the order. Otherwise, when mutual SSL takes place, the already existing connector (9443) will be picked up and the certificate will not be retrieved correctly.
-
-        2.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
+        1.  The `clientAuth` attribute causes the Tomcat to require the client with providing a certificate that can be configured as follows.
             -   `true` : valid client certificate required for a connection to succeed
             -   `want` : use a certificate if available, but still connect if no certificate is available
             -   `false` : no client certificate is required or validated
     
-        3.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
+        2.   The `truststoreFile` attributes specifies the location of the truststore that contains the trusted certificate issuers.
 
 ## Disable certificate validation
 


### PR DESCRIPTION
## Purpose
- $subject

## Goals
- Removing the order note since from IS 6.1.0 order is not an issue for x509 authenticator.

## Related issues
- https://github.com/wso2/product-is/issues/22144