### PR TITLE
Update new keystore migration note

### DIFF
--- a/en/includes/deploy/security/keystores/configure-keystores.md
+++ b/en/includes/deploy/security/keystores/configure-keystores.md
@@ -93,7 +93,7 @@ In production environments, it is recommended to use distinct keystores for each
 ### Configure the internal keystore
 
 !!! warning
-    Adding a new keystore for internal data encryption for an existing deployment will make already encrypted data unusable. In such cases, an appropriate data migration effort is needed.
+    Adding a new keystore for internal data encryption for an existing deployment will make already encrypted data unusable. If asymmetric key encryption or symmetric key encryption with a new secret is used, an appropriate data migration effort is needed.
 
 
 To configure the new internal keystore, add the following configuration block to the `keystore.internal` tag of the `deployment.toml` file found in the `<IS_HOME>/repository/conf` folder.

--- a/en/includes/deploy/security/keystores/configure-keystores.md
+++ b/en/includes/deploy/security/keystores/configure-keystores.md
@@ -93,7 +93,7 @@ In production environments, it is recommended to use distinct keystores for each
 ### Configure the internal keystore
 
 !!! warning
-    Adding a new keystore for internal data encryption for an existing deployment will make already encrypted data unusable. If asymmetric key encryption or symmetric key encryption with a new secret is used, an appropriate data migration effort is needed.
+    If [asymmetric encryption]({{base_path}}/deploy/security/asymmetric-encryption) is used, adding a new keystore for internal data encryption for an existing deployment will make already encrypted data unusable. In such cases, an appropriate data migration effort is needed.
 
 
 To configure the new internal keystore, add the following configuration block to the `keystore.internal` tag of the `deployment.toml` file found in the `<IS_HOME>/repository/conf` folder.


### PR DESCRIPTION
## Purpose
This PR updates the note included in the new keystore generating guide. According to the encryption method used, the migration effort is different.

> 1. Symmetric encryption + old secret -> Migration NOT needed.

> 2. Symmetric encryption + new secret -> Migration needed.

> 3. Asymmetric encryption -> Migration needed.