### PR TITLE
Update redirect url definition for wildcard url allowed app types

### DIFF
--- a/en/identity-server/7.0.0/docs/guides/applications/register-standard-based-app.md
+++ b/en/identity-server/7.0.0/docs/guides/applications/register-standard-based-app.md
@@ -50,6 +50,13 @@ To register an application:
             </tr>
         </table>
 
+    !!! note
+        If you are planning to enable the Authorization Code grant type for standard-based applications, please note the following when adding the authorized redirect URL. The authorized redirect URL should be defined based on the type of application you are using:
+        
+        - Web-based applications: Use exact URLs or implement logic to dynamically register specific redirect URIs as needed.
+        
+        - Mobile apps with deep links: Wildcard support may be acceptable, but it must be implemented securely and restricted to well-defined patterns to limit its scope.
+
 ## What's Next?
 
 - [Configuring an OIDC application]({{base_path}}/references/app-settings/oidc-settings-for-app/)

--- a/en/identity-server/next/docs/guides/applications/register-standard-based-app.md
+++ b/en/identity-server/next/docs/guides/applications/register-standard-based-app.md
@@ -50,6 +50,13 @@ To register an application:
             </tr>
         </table>
 
+    !!! note
+        If you are planning to enable the Authorization Code grant type for standard-based applications, please note the following when adding the authorized redirect URL. The authorized redirect URL should be defined based on the type of application you are using:
+        
+        - Web-based applications: Use exact URLs or implement logic to dynamically register specific redirect URIs as needed.
+        
+        - Mobile apps with deep links: Wildcard support may be acceptable, but it must be implemented securely and restricted to well-defined patterns to limit its scope.
+
 ## What's Next?
 
 - [Configuring an OIDC application]({{base_path}}/references/app-settings/oidc-settings-for-app/)

--- a/en/includes/guides/applications/register-mobile-app.md
+++ b/en/includes/guides/applications/register-mobile-app.md
@@ -29,7 +29,7 @@ To register the app:
         </tr>
         <tr>
             <td>Authorized redirect URLs</td>
-            <td>The URL to which the authorization code is sent to upon user authentication and where the user is redirected to upon logout.</td>
+            <td>The URL to which the authorization code is sent to upon user authentication and where the user is redirected to upon logout. If wildcard support is necessary, ensure it is limited to well-defined patterns and implemented securely to meet your specific requirements.</td>
         </tr>
         <tr>
             <td>Allow sharing with organizations</td>

--- a/en/includes/guides/applications/register-standard-based-app.md
+++ b/en/includes/guides/applications/register-standard-based-app.md
@@ -50,6 +50,13 @@ To register an application:
             </tr>
         </table>
 
+    !!! note
+        If you are planning to enable the Authorization Code grant type for standard-based applications, please note the following when adding the authorized redirect URL. The authorized redirect URL should be defined based on the type of application you are using:
+        
+        - Web-based applications: Use exact URLs or implement logic to dynamically register specific redirect URIs as needed.
+        
+        - Mobile apps with deep links: Wildcard support may be acceptable, but it must be implemented securely and restricted to well-defined patterns to limit its scope.
+
 ## What's Next?
 
 - [Configuring an OIDC application]({{base_path}}/references/app-settings/oidc-settings-for-app/)


### PR DESCRIPTION
## Purpose

This PR contains the improvement for the below explanation.

> The support for wild card in sub domains looks intentional to support use cases such as mobile apps requiring dynamic URL handling or tenanted URL handling.
> 
> However, its usage for general web-based redirect URIs may not align with [OAuth 2.0 best practices](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.1).
> 
> ```
> When comparing client redirect URIs against pre-registered URIs, authorization servers MUST utilize exact string matching except for port numbers in localhost redirection URIs of native apps.
> ```
> 
> Regarding the customer recommendation,
> AFAIK, Standard based templates used for clients (mobile or web-based) using standard protocols. But its recommended > to follow best practises,
> 
> - For web-based applications, customers should use exact URLs or implement logic to dynamically register specific redirect URIs as needed.
> 
> - For mobile apps leveraging deep links, wildcard support may be acceptable, but it must be implemented securely and limited in scope.

