### PR TITLE
Update workflow to avoid a python version issue when installing depen…

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Purpose

There are some dependencies that still do not support python 3.13 which is used by default in the workflow. This change should fallback the python version to 3.12 and successfully install dependencies.

Example:
https://github.com/wso2/docs-is/actions/runs/13045866072