### PR TITLE
[Docs][API][IS] Update User Sharing API Documentation for WSO2 IS 7.1 (Version v1 & Path Refactor)

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 1.0.2
+  version: v1
   title: 'User Sharing API Definition'
   description: |-
     This API provides organization administrators with the ability to manage user access across child organizations. It supports operations to share users with specific or all child organizations, retrieve shared access details, and remove shared access as needed. The API also includes features for paginated retrieval of organizations and roles associated with shared users.

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 1.0.2
+  version: v1
   title: 'User Sharing API Definition'
   description: |-
     This API provides organization administrators with the ability to manage user access across child organizations. It supports operations to share users with specific or all child organizations, retrieve shared access details, and remove shared access as needed. The API also includes features for paginated retrieval of organizations and roles associated with shared users.

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -871,7 +871,7 @@ nav:
         - SCIM 2.0 Users API: apis/organization-apis/scim2/scim2-org-user-mgt.md
         - SCIM 2.0 Groups API: apis/organization-apis/scim2/scim2-org-group-mgt.md
         - SCIM 2.0 Bulk API: apis/organization-apis/scim2/scim2-org-bulk-mgt.md
-      - User sharing management API: apis/organization-apis/organization-user-share-rest-api.md
+      - User sharing management API: apis/organization-apis/organization-user-share.md
       - User store management API: apis/organization-apis/user-store.md
     - End User APIs:
         - FIDO API: apis/fido-rest-api.md


### PR DESCRIPTION
## Purpose
This PR addresses an issue in the previous documentation ([[Docs][API][IS] Introduce User Sharing API Documentation for WSO2 IS 7.1 #5025](https://github.com/wso2/docs-is/pull/5025)) where:
- The API version was not correctly specified. This PR updates the API version to v1.
- The path of the User Sharing API in `Organization APIs` nav was incorrect. This PR refactors the path to its correct location.

## Goals

- Update the API version to v1 in the documentation.
- Correct the path of the User Sharing API in `Organization APIs` nav.
- Maintain consistency with WSO2 documentation standards. 

## Approach

- Updated all relevant API references to version v1.
- Refactored the User Sharing API path to its correct location.