### PR TITLE
[Docs][API][IS] Fix Incorrect API Base Path in User Sharing API Specification

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -3,7 +3,7 @@ info:
   version: "v1"
   title: 'User Sharing API Definition'
   description: |-
-    This document specifies the **User Sharing RESTful API** for **WSO2 Identity Server**. This API enables organization administrators to share user access across child organizations, manage shared access, revoke access, and retrieve shared organizations and roles.
+    This document specifies the **User Sharing RESTful API of Organizations** for **WSO2 Identity Server**. This API enables organization administrators to share user access across child organizations, manage shared access, revoke access, and retrieve shared organizations and roles.
 
 security:
   - OAuth2: []

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -9,7 +9,7 @@ security:
   - OAuth2: []
 
 servers:
-  - url: 'https://{server-url}/t/{tenant-domain}/api/server/v1'
+  - url: 'https://{server-url}/t/{tenant-domain}/o/api/server/v1'
     variables:
       tenant-domain:
         default: "carbon.super"


### PR DESCRIPTION
## Purpose
Correct the API base path by adding the missing `/o` segment to ensure proper request routing.

## Goals
- Fix the incorrect base path in the `servers` section.
- Ensure API requests are routed correctly under `/o/api/server/v1`.

## Approach

- Updated `servers.url` from `https://{server-url}/t/{tenant-domain}/api/server/v1` to `https://{server-url}/t/{tenant-domain}/o/api/server/v1`

---

## Related Issue

[[Docs][API] Introduce User Sharing from Parent Org to Sub-Org #22823](https://github.com/wso2/product-is/issues/22823).