### PR TITLE
[Docs][API][IS] Fix Incorrect Base Path in Shared Roles API Example (Organization API)

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -671,7 +671,8 @@ components:
               rolesRef:
                 type: string
                 description: URL reference to retrieve paginated roles for the shared user in this organization
-                example: "/api/server/v1/users/{userId}/shared-roles?orgId=b028ca17-8f89-449c-ae27-fa955e66465d&after=&before=&limit=2&filter=&recursive=false"
+                example: "/o/api/server/v1/users/{userId}/shared-roles?orgId=b028ca17-8f89-449c-ae27-fa955e66465d
+                &after=&before=&limit=2&filter=&recursive=false"
 
     UserSharedRolesResponse:
       type: object


### PR DESCRIPTION
## Purpose
Correct the base path in the shared roles API example to align with the organization API structure.

## Goals
Update the example URL to include the `/o` segment for proper request routing.

## Approach
Changed the example path from `/api/server/v1/users/{userId}/shared-roles?orgId=...` to `/o/api/server/v1/users/{userId}/shared-roles?orgId=...`

---

## Related Issue

[[Docs][API] Introduce User Sharing from Parent Org to Sub-Org #22823](https://github.com/wso2/product-is/issues/22823)