### PR TITLE
Modify doc with new commands to enable PQC TLS

### DIFF
--- a/en/includes/deploy/security/configure-post-quantum-tls.md
+++ b/en/includes/deploy/security/configure-post-quantum-tls.md
@@ -120,13 +120,13 @@ The following dependencies are required during build-time.
     In Debian-based Linux:
 
     ```bash
-    apt-get install make cmake wget tar gcc
+    apt-get install make cmake wget tar gcc git python3 autoconf libtool-bin
     ```
 
     In Red Hat Linux distributions:
 
     ```bash
-    yum install make cmake wget tar gcc perl
+    yum install make cmake wget tar gcc perl git python3 autoconf libtool
     ```
 
 === "MacOS"
@@ -134,7 +134,7 @@ The following dependencies are required during build-time.
     On macOS, you can use Homebrew to install dependencies.
 
     ```bash
-    brew install wget cmake
+    brew install wget cmake git python3 autoconf libtool
     ```
 
 #### Runtime dependencies


### PR DESCRIPTION
## Purpose
As mentioned in issue [https://github.com/wso2/product-is/issues/22563](https://github.com/wso2/product-is/issues/22563), configuring post-quantum TLS in IS with Method 2: Using self-contained libraries encountered problems due to a download link being incorrect.

This issue was addressed with [https://github.com/wso2/product-is/pull/22825](https://github.com/wso2/product-is/pull/22825), by modifying the download link and relevant installation method.

However, this required additional packages installed, and it should be mentioned in the documentation.

Resolves [https://github.com/wso2/product-is/issues/22840](https://github.com/wso2/product-is/issues/22840)

## Goals
This will update the documentation with the necessary commands to install the required packages in both Linux and MacOS environments.

## Documentation
[https://is.docs.wso2.com/en/next/deploy/security/configure-post-quantum-tls/](https://is.docs.wso2.com/en/next/deploy/security/configure-post-quantum-tls/)
