### PR TITLE
[7.0][next] Prevent RAR Content from Displaying in IS 7.0.0

### DIFF
--- a/en/includes/guides/authorization/index.md
+++ b/en/includes/guides/authorization/index.md
@@ -10,6 +10,8 @@ Role Based Access Control (RBAC) lets organizations grant limited access to its 
 
 User impersonation involves granting temporary access to another user's account. Learn how to implement it in [User impersonation]({{base_path}}/guides/authorization/user-impersonation/).
 
+{% if product_name == "WSO2 Identity Server" and is_version != "7.0.0" %}
 ## Rich authorization requests
 
 Rich Authorization Requests (RAR) (RFC 9396) enhance authorization mechanisms by allowing clients to specify fine-grained authorization details. Learn how to use it in [Rich Authorization Requests]({{base_path}}/guides/authorization/rich-authorization-requests/).
+{% endif %}


### PR DESCRIPTION
## Purpose
Currently, RAR-related content is being displayed for IS 7.0.0, whereas it should only be visible for IS 7.1.0. This PR introduces a conditional check to ensure that RAR content is displayed only when the version is not 7.0.0, preventing incorrect visibility in earlier versions.
