### PR TITLE
Change keystore type using a variable

### DIFF
--- a/en/identity-server/7.0.0/mkdocs.yml
+++ b/en/identity-server/7.0.0/mkdocs.yml
@@ -22,6 +22,8 @@ site_url: https://is.docs.wso2.com/en/7.0.0
 extra:
   base_path: /en/7.0.0
   is_version: 7.0.0
+  default_keystore_type: JKS
+  default_keystore_ext: jks
 
 hooks:
   - hooks.py

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -22,6 +22,8 @@ site_url: https://is.docs.wso2.com/en/next
 extra:
   base_path: /en/next
   is_version: next
+  default_keystore_type: PKCS12
+  default_keystore_ext: p12
 
 hooks:
   - hooks.py

--- a/en/includes/deploy/change-the-hostname.md
+++ b/en/includes/deploy/change-the-hostname.md
@@ -18,13 +18,19 @@ This section guides you through changing the hostname of the WSO2 Identity Serve
     === "Format"
 
         ``` java
-        keytool -genkey -alias <alias_name> -keyalg RSA -keysize 2048 -keystore <keystore_name>.jks -dname "CN=<hostname>, OU=<organizational_unit>,O=<organization>,L=<Locality>,S=<State/province>,C=<country_code>" -storepass <keystore_password> -keypass <confirm_keystore_password> -ext SAN=dns:localhost
+        keytool -genkey -alias <alias_name> -keyalg RSA -keysize 2048 -keystore <keystore_name> -storetype <keystore_type> -dname "CN=<hostname>, OU=<organizational_unit>,O=<organization>,L=<Locality>,S=<State/province>,C=<country_code>" -storepass <keystore_password> -keypass <confirm_keystore_password> -ext SAN=dns:localhost
         ```
 
-    === "Sample keytool command"
+    === "Sample command (JKS)"
 
         ``` java
         keytool -genkey -alias newcert -keyalg RSA -keysize 2048 -keystore newkeystore.jks -dname "CN=is.dev.wso2.com, OU=Is,O=Wso2,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword -ext SAN=dns:localhost
+        ```
+    
+    === "Sample command (PKCS12)"
+
+        ``` java
+        keytool -genkey -alias newcert -keyalg RSA -keysize 2048 -keystore newkeystore.p12 -storetype PKCS12 -dname "CN=is.dev.wso2.com, OU=Is,O=Wso2,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword -ext SAN=dns:localhost
         ```
 
     **Option 2**
@@ -42,61 +48,105 @@ This section guides you through changing the hostname of the WSO2 Identity Serve
     === "Format"
 
         ``` java
-        keytool -genkey -alias <alias_name> -keyalg RSA -keysize 2048 -keystore <keystore_name>.jks -dname "CN=<hostname>, OU=<organizational_unit>,O=<organization>,L=<Locality>,S=<State/province>,C=<country_code>" -storepass <keystore_password> -keypass <confirm_keystore_password>
+        keytool -genkey -alias <alias_name> -keyalg RSA -keysize 2048 -keystore <keystore_name> -storetype <keystore_type> -dname "CN=<hostname>, OU=<organizational_unit>,O=<organization>,L=<Locality>,S=<State/province>,C=<country_code>" -storepass <keystore_password> -keypass <confirm_keystore_password>
         ```
 
-    === "Sample keytool command"
+    === "Sample command (JKS)"
 
         ``` java
         keytool -genkey -alias newcert -keyalg RSA -keysize 2048 -keystore newkeystore.jks -dname "CN=is.dev.wso2.com, OU=Is,O=Wso2,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword
         ```
 
+    === "Sample command (PKCS12)"
+
+        ``` java
+        keytool -genkey -alias newcert -keyalg RSA -keysize 2048 -keystore newkeystore.p12 -storetype PKCS12 -dname "CN=is.dev.wso2.com, OU=Is,O=Wso2,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword
+        ```
+
 2. If the keystore name and password is changed, all the references to it within the WSO2 Identity Server must also be updated. Add the following configuration to the `deployment.toml` file in the `<IS_HOME>/repository/conf/` folder.
 
-    ``` toml
-    [keystore.primary]
-    file_name = "new-keystore.jks"
-    password = "new-keystore-password"
-    alias = "new-private-key-alias"
-    key_password = "new-private-key-password"
-    ```
+    === "JKS"
 
-3. Export the public key from your keystore .jks file using the following command.
+        ``` toml
+        [keystore.primary]
+        file_name = "new-keystore.jks"
+        password = "new-keystore-password"
+        alias = "new-private-key-alias"
+        key_password = "new-private-key-password"
+        type = "JKS"
+        ```
+
+    === "PKCS12"
+
+        ``` toml
+        [keystore.primary]
+        file_name = "new-keystore.p12"
+        password = "new-keystore-password"
+        alias = "new-private-key-alias"
+        key_password = "new-private-key-password"
+        type = "PKCS12"
+        ```
+
+3. Export the public key from your keystore file using the following command.
 
     === "Format"
 
         ``` java
-        keytool -export -alias <alias_name> -keystore <keystore_name>.jks -file <public_key_name>.pem
+        keytool -export -alias <alias_name> -keystore <keystore_name> -storetype <keystore_type> -file <public_key_name>.pem
         ```
 
-    === "Sample keytool command"
+    === "Sample command (JKS)"
 
         ``` java
         keytool -export -alias newcert -keystore newkeystore.jks -file pkn.pem
         ```
 
-4. Import the public key you extracted in the previous step to the `client-truststore.jks` file using the following command.
+    === "Sample command (PKCS12)"
+
+        ``` java
+        keytool -export -alias newcert -keystore newkeystore.p12 -storetype PKCS12 -file pkn.pem
+        ```
+
+4. Import the public key you extracted in the previous step to the `client-truststore.{{default_keystore_ext}}` file using the following command.
 
     === "Format"
 
         ``` java
-        keytool -import -alias <alias_name> -file <public_key_name>.pem -keystore client-truststore.jks -storepass <keystore_password>
+        keytool -import -alias <alias_name> -file <public_key_name>.pem -keystore <keystore_name> -storetype <keystore_type> -storepass <keystore_password>
         ```
 
-    === "Sample keytool command"
+    === "Sample command (JKS)"
 
         ``` java
         keytool -import -alias newcert -file pkn.pem -keystore client-truststore.jks -storepass wso2carbon
         ```
 
-    !!! note
-        If you create a new client truststore, in place of the default `client-truststore.jks`, place the new truststore in the `<IS_HOME>/repository/resources/security/` folder and add the following configuration to the `deployment.toml` file in the `<IS_HOME>/repository/conf/` folder.
+    === "Sample command (PKCS12)"
 
-        ```toml
-        [truststore]
-        file_name = "customer-truststore-name.jks" 
-        password = "password" 
+        ``` java
+        keytool -import -alias newcert -file pkn.pem -keystore client-truststore.p12 -storetype PKCS12 -storepass wso2carbon
         ```
+
+    !!! note
+        If you create a new client truststore, in place of the default `client-truststore.{{default_keystore_ext}}`, place the new truststore in the `<IS_HOME>/repository/resources/security/` folder and add the following configuration to the `deployment.toml` file in the `<IS_HOME>/repository/conf/` folder.
+
+        === "JKS"
+
+            ```toml
+            [truststore]
+            file_name = "customer-truststore-name.jks" 
+            password = "password" 
+            type = "JKS"
+            ```
+
+        === "PKCS12"
+
+            ```toml
+            [truststore]
+            file_name = "customer-truststore-name.p12"
+            password = "password"
+            type = "PKCS12"
+            ```
 
 5. Verify the hostname change by attempting to log in to My Account, getting a token from any grant type, etc.
 
@@ -106,7 +156,7 @@ This section guides you through changing the hostname of the WSO2 Identity Serve
     127.0.0.1       is.dev.wso2.com
     ```
 
-When you fully recreate the keystore, a new key-pair value is created. This means that any existing encrypted data (for example, users created before recreating the keystore) are still encrypted using the original keystore (`wso2carbon.jks`). Therefore, older users will not be able to log in to My Account and need to be migrated. You can use one of the following options in this situation.
+When you fully recreate the keystore, a new key-pair value is created. This means that any existing encrypted data (for example, users created before recreating the keystore) are still encrypted using the original keystore (`wso2carbon.{{default_keystore_ext}}`). Therefore, older users will not be able to log in to My Account and need to be migrated. You can use one of the following options in this situation.
 
 **Option 1**
 

--- a/en/includes/deploy/security/encrypt-passwords-with-cipher-tool.md
+++ b/en/includes/deploy/security/encrypt-passwords-with-cipher-tool.md
@@ -198,25 +198,25 @@ You can rotate encryption keys by switching between symmetric and asymmetric enc
 
     === "JKS"
 
-    ```toml
-    [keystore.internal]
-    file_name = "internal.jks"
-    type = "JKS"
-    alias = "new_alias"
-    password = "$secret{keystore_password}"
-    key_password = "$secret{keystore_password}"
-    ```
+        ```toml
+        [keystore.internal]
+        file_name = "internal.jks"
+        type = "JKS"
+        alias = "new_alias"
+        password = "$secret{keystore_password}"
+        key_password = "$secret{keystore_password}"
+        ```
 
     === "PKCS12"
 
-    ```toml
-    [keystore.internal]
-    file_name = "internal.p12"
-    type = "PKCS12"
-    alias = "new_alias"
-    password = "$secret{keystore_password}"
-    key_password = "$secret{keystore_password}"
-    ```
+        ```toml
+        [keystore.internal]
+        file_name = "internal.p12"
+        type = "PKCS12"
+        alias = "new_alias"
+        password = "$secret{keystore_password}"
+        key_password = "$secret{keystore_password}"
+        ```
 
 3. Navigate to the `<IS_HOME>/bin/` directory on the command prompt, where the cipher tool scripts reside.
 

--- a/en/includes/deploy/security/encrypt-passwords-with-cipher-tool.md
+++ b/en/includes/deploy/security/encrypt-passwords-with-cipher-tool.md
@@ -179,16 +179,35 @@ You can rotate encryption keys by switching between symmetric and asymmetric enc
     === "Symmetric encryption"
 
         ```bash
-        keytool -genseckey -alias new_alias -keyalg AES -keysize 256 -keystore internal.p12 -storepass password -keypass password
+        keytool -genseckey -alias new_alias -keyalg AES -keysize 256 -keystore internal.p12 -storetype PKCS12 -storepass password -keypass password
         ```
     
-    === "Asymmetric encryption"
+    === "Asymmetric encryption (JKS)"
 
         ```bash
         keytool -genkeypair -alias new_alias -keyalg RSA -keystore wso2carbon.jks -storepass password -keypass password
         ```
 
+    === "Asymmetric encryption (PKCS12)"
+
+        ```bash
+        keytool -genkeypair -alias new_alias -keyalg RSA -keystore wso2carbon.p12 -storetype PKCS12 -storepass password -keypass password
+        ```
+
 2. Update the `deployment.toml` file found in the `<IS_HOME>/repository/conf` directory to reflect the new key or secret alias:
+
+    === "JKS"
+
+    ```toml
+    [keystore.internal]
+    file_name = "internal.jks"
+    type = "JKS"
+    alias = "new_alias"
+    password = "$secret{keystore_password}"
+    key_password = "$secret{keystore_password}"
+    ```
+
+    === "PKCS12"
 
     ```toml
     [keystore.internal]

--- a/en/includes/deploy/security/keystores/configure-keystores.md
+++ b/en/includes/deploy/security/keystores/configure-keystores.md
@@ -11,17 +11,8 @@
 
 WSO2 Identity Server provides default keystore and truststore files:
 
-{% if is_version == "7.0.0" %}
-
-- `wso2carbon.jks`: The default keystore that includes a private key and a self-signed certificate.
-- `client-truststore.jks`: The default truststore containing Certificate Authority (CA) certificates and the self-signed certificate from wso2carbon.jks.
-
-{% else %}
-
-- `wso2carbon.p12`: The default keystore that includes a private key and a self-signed certificate.
-- `client-truststore.p12`: The default truststore containing Certificate Authority (CA) certificates and the self-signed certificate from wso2carbon.jks.
-
-{% endif %}
+- `wso2carbon.{{default_keystore_ext}}`: The default keystore that includes a private key and a self-signed certificate.
+- `client-truststore.{{default_keystore_ext}}`: The default truststore containing Certificate Authority (CA) certificates and the self-signed certificate from wso2carbon.{{default_keystore_ext}}.
 
 These files are originally located in the `<IS_HOME>/repository/resources/security` folder. The file settings can be configured by specifying them in the `deployment.toml` file found in the `<IS_HOME>/repository/conf` folder as follows.
 
@@ -162,44 +153,25 @@ To add a key,
     === "Format"
 
         ```bash
-        keytool -genkey -alias <PUBLIC_CERTIFICATE_ALIAS> -keyalg RSA -keysize 2048 -keystore <KEYSTORE_NAME> -dname "CN=<<Common Name>>,OU=<<Organization Unit>>,O=<<Organization>>,L=<<Locality>>,S=<<StateofProvice Name>>,C=<<Country Name>>"-storepass <KEYSTORE_PASSWORD> -keypass <PRIVATE_KEY_PASSWORD>
+        keytool -genkey -alias <public_certificate_alias> -keyalg RSA -keysize 2048 -keystore <keystore_name> -storetype <keystore_type> -dname "CN=<<Common Name>>,OU=<<Organization Unit>>,O=<<Organization>>,L=<<Locality>>,S=<<StateofProvice Name>>,C=<<Country Name>>"-storepass <keystore_password> -keypass <private_key_password>
         ```
 
-    === "Sample keytool command"
+    === "Sample command (JKS)"
 
         ``` bash
         keytool -genkey -alias newkey -keyalg RSA -keysize 2048 -keystore wso2carbon.jks -dname "CN=localhost, OU=IT,O={{base_path}},L=SL,S=WS,C=LK" -storepass wso2carbon -keypass wso2carbon
+        ```
+
+    === "Sample command (PKCS12)"
+
+        ``` bash
+        keytool -genkey -alias newkey -keyalg RSA -keysize 2048 -keystore wso2carbon.p12 -storetype PKCS12 -dname "CN=localhost, OU=IT,O={{base_path}},L=SL,S=WS,C=LK" -storepass wso2carbon -keypass wso2carbon
         ```
 
     !!! tip  
         If you are planning to delete the newly added keys in the future, it is recommended to maintain separate keystores for internal and external encryption purposes.
 
 This newly added key can be used for different purposes.
-
-!!! abstract ""
-    **Example**
-
-    Follow the instructions given below to set the newly added key as the primary encrypting and signing key:
-
-    1. Open the `deployment.toml` file in the `<IS_HOME>/repository/conf` directory.
-
-    {% if is_version == "7.0.0" %}
-
-    2. Update the `alias` parameter under the `[keystore.primary]` element with the new keystore `alias`.
-            
-        ```toml
-        [keystore.primary]
-        alias= "newKey"
-        ```
-    {% else %}
-
-    2. Update the `alias` parameter under the `[keystore.tls]` element with the new keystore `alias`.
-            
-        ```toml
-        [keystore.tls]
-        alias= "newKey"
-        ```
-    {% endif %}
 
 {% if not is_version == "7.0.0" %}
 

--- a/en/includes/deploy/security/keystores/index.md
+++ b/en/includes/deploy/security/keystores/index.md
@@ -67,7 +67,7 @@ Follow the recommendations given below when you set up your keystores.
 
 - The primary keystore used for admin passwords and other data encryption requirements can be a self-signed one. There is no value added by using a CA-signed keystore for this purpose as it is not used for any external communication.
 
-- The primary keystore's public key certificate must have the **Data Encipherment** key usage to allow direct encipherment of raw data using its public key. This key usage is already included in the self-signed certificate that is included in the default `wso2carbon.jks` keystore. If the **Data Encipherment** key usage is not included in your public key certificate, the following error can occur when you attempt data encryption.
+- The primary keystore's public key certificate must have the **Data Encipherment** key usage to allow direct encipherment of raw data using its public key. This key usage is already included in the self-signed certificate that is included in the default `wso2carbon.{{default_keystore_ext}}` keystore. If the **Data Encipherment** key usage is not included in your public key certificate, the following error can occur when you attempt data encryption.
 
     !!! error
         ``` java

--- a/en/includes/guides/users/user-stores/configure-active-directory-user-stores-for-scim2.md
+++ b/en/includes/guides/users/user-stores/configure-active-directory-user-stores-for-scim2.md
@@ -113,7 +113,7 @@ You need to configure the secondary user store. This can be done in the followin
 To import the user store certificate to the WSO2 Identity Server trust store, navigate to `<IS_HOME>/repository/resources/security` folder and execute the following command:
 
 ``` shell
-keytool -import -alias certalias -file <certificate>.pem -keystore client-truststore.jks -storepass wso2carbon
+keytool -import -alias certalias -file <certificate>.pem -keystore client-truststore.{{default_keystore_ext}} -storetype {{default_keystore_type}} -storepass wso2carbon
 ```
 
 ## Step 3: Map WSO2 attributes to AD attribute

--- a/en/includes/guides/users/user-stores/primary-user-store/configure-a-read-write-active-directory-user-store.md
+++ b/en/includes/guides/users/user-stores/primary-user-store/configure-a-read-write-active-directory-user-store.md
@@ -32,11 +32,11 @@ WSO2 Identity Server’s client trust store. To perform this, you need to naviga
 client-truststore of WSO2 Identity Server.
 
 ```
-keytool -import -alias certalias -file <certificate>.pem -keystore client-truststore.jks -storepass wso2carbon
+keytool -import -alias certalias -file <certificate>.pem -keystore client-truststore.{{default_keystore_ext}} -storetype {{default_keystore_type}} -storepass wso2carbon
 ```
 
 !!! note
-    `wso2carbon` is the keystore password of the default client-truststore.jks file of WSO2 Identity Server.
+    `wso2carbon` is the keystore password of the default client-truststore.{{default_keystore_ext}} file of WSO2 Identity Server.
 
 Furthermore, please make sure to follow the steps mentioned in [Configure Active Directory User stores for SCIM 2.0 based Inbound Provisioning]({{base_path}}/guides/users/user-stores/configure-active-directory-user-stores-for-scim2) 
 since SCIM is enabled by default from the WSO2 Identity Server 5.10.0 onwards.

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-only-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-only-ldap-user-store.md
@@ -45,7 +45,7 @@ Following are the minimum user store properties that are required to configure t
 <a href="ldaps://10.100.1.102:639">ldaps://10.100.1.102:639</a><br />
 <br />
 If you are connecting over ldaps (secured LDAP).<br />
-you need to import the certificate of the user store to <code><&ZeroWidthSpace;IS_HOME>/repository/resources/security/client-truststore.jks</code>. For information on how to add certificates to the truststore and how keystores are configured and used in a system, see <br />
+you need to import the certificate of the user store to <code><&ZeroWidthSpace;IS_HOME>/repository/resources/security/client-truststore.{{default_keystore_ext}}</code>. For information on how to add certificates to the truststore and how keystores are configured and used in a system, see <br />
 <a href="{{base_path}}/deploy/security/asymmetric-encryption/use-asymmetric-encryption">Use asymmetric encryption</a><br />
 <br />
 If LDAP connection pooling is used, see<br />

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-active-directory-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-active-directory-user-store.md
@@ -44,7 +44,7 @@ Following are the minimum user store properties that need to be provided to conf
 <a href="ldaps://10.100.1.102:639">ldaps://10.100.1.102:639</a><br />
 <br />
 If you are connecting over ldaps (secured LDAP),<br />
-you need to import the certificate of user store to <code><&ZeroWidthSpace;IS_HOME>/repository/resources/security/client-truststore.jks</code>. For information on how to add certificates to the truststore and how keystores are configured and used in a system, see<br />
+you need to import the certificate of user store to <code><&ZeroWidthSpace;IS_HOME>/repository/resources/security/client-truststore.{{default_keystore_ext}}</code>. For information on how to add certificates to the truststore and how keystores are configured and used in a system, see<br />
 <a href="{{base_path}}/deploy/security/asymmetric-encryption/use-asymmetric-encryption">Use asymmetric encryption.</a><br />
 <br />
 If LDAP connection pooling is used, see <br />

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
@@ -45,7 +45,7 @@ Following are the minimum user store properties that are needed to be provided t
 <a href="ldaps://10.100.1.102:639">ldaps://10.100.1.102:639</a><br />
 <br />
 If you are connecting over ldaps (secured LDAP)<br />
-Need to import the certificate of user store to the client-truststore.jks of the WSO2 product. For information on how to add certificates to the truststore and how keystores are configured and used in a system, see Using Asymmetric Encryption.<br />
+Need to import the certificate of user store to the client-truststore.{{default_keystore_ext}} of the WSO2 product. For information on how to add certificates to the truststore and how keystores are configured and used in a system, see Using Asymmetric Encryption.<br />
 <a href="{{base_path}}/deploy/security/asymmetric-encryption/use-asymmetric-encryption">Using asymmetric encryption</a><br />
 <br />
 If LDAP connection pooling is used, see enable connection pooling for LDAPS connections.<br />

--- a/en/includes/references/extend/authentication/customize-the-authentication-endpoint.md
+++ b/en/includes/references/extend/authentication/customize-the-authentication-endpoint.md
@@ -90,9 +90,9 @@ If your {{product_name}} setup includes multiple tenants, users typically log in
     tenant_list_enabled="false"
     hostname_verification_enabled="true"
     mutual_ssl_username="admin"
-    client_keystore="wso2carbon.jks"
+    client_keystore="wso2carbon.{{default_keystore_ext}}"
     carbon_security_keystore_password="wso2carbon"
-    client_truststore="client-truststore.jks"
+    client_truststore="client-truststore.{{default_keystore_ext}}"
     carbon_security_truststore_password="wso2carbon"
     identity_server_service_url="https://localhost:9443"
     username_header="UserName"
@@ -116,9 +116,9 @@ If your {{product_name}} setup includes multiple tenants, users typically log in
         mutualSSLManagerEnabled=true
         hostname.verification.enabled=true
         mutual.ssl.username=admin
-        client.keyStore=./repository/resources/security/wso2carbon.jks
+        client.keyStore=./repository/resources/security/wso2carbon.{{default_keystore_ext}}
         Carbon.Security.KeyStore.Password=wso2carbon
-        client.trustStore=./repository/resources/security/client-truststore.jks
+        client.trustStore=./repository/resources/security/client-truststore.{{default_keystore_ext}}
         Carbon.Security.TrustStore.Password=wso2carbon
         identity.server.serviceURL=https://localhost:9443/services/
         username.header=UserName
@@ -146,13 +146,13 @@ If your {{product_name}} setup includes multiple tenants, users typically log in
     === "Export to client truststore"
 
         ``` java
-        keytool -export -alias wso2carbon -file carbon_public2.crt -keystore wso2carbon.jks -storepass  wso2carbon
+        keytool -export -alias wso2carbon -file carbon_public2.crt -keystore wso2carbon.{{default_keystore_ext}} -storetype {{default_keystore_type}} -storepass  wso2carbon
         ```
 
     === "Import to WSO2 Identity Server truststore"
     
         ``` java
-        keytool -import -trustcacerts -alias carbon -file carbon_public2.crt -keystore client-truststore.jks -storepass wso2carbon
+        keytool -import -trustcacerts -alias carbon -file carbon_public2.crt -keystore client-truststore.{{default_keystore_ext}} -storetype {{default_keystore_type}} -storepass wso2carbon
         ```
 
     !!! note


### PR DESCRIPTION
- Changed default keystore type to PKCS12 in IS versions after 7.0.0
- Added a variable to set keystore version and extension
Related issue https://github.com/wso2/product-is/issues/21761