### PR TITLE
Add attribute name format property into SAML configurations

### DIFF
--- a/en/asgardeo/docs/apis/restapis/application-management.yaml
+++ b/en/asgardeo/docs/apis/restapis/application-management.yaml
@@ -3798,6 +3798,13 @@ components:
           type: boolean
           default: false
           description: Specifies whether or not to include user attributes in the SAML response.
+        nameFormat:
+          type: string
+          default: urn:oasis:names:tc:SAML:2.0:attrname-format:basic
+          enum: 
+            - urn:oasis:names:tc:SAML:2.0:attrname-format:basic
+            - urn:oasis:names:tc:SAML:2.0:attrname-format:uri
+          description: Specifies the type of attribute names used in the attribute statement of SAML assertions.
 
     SingleLogoutProfile:
       type: object

--- a/en/identity-server/next/docs/apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/restapis/application.yaml
@@ -4637,6 +4637,13 @@ components:
         alwaysIncludeAttributesInResponse:
           type: boolean
           default: false
+        nameFormat:
+          type: string
+          default: urn:oasis:names:tc:SAML:2.0:attrname-format:basic
+          enum: 
+            - urn:oasis:names:tc:SAML:2.0:attrname-format:basic
+            - urn:oasis:names:tc:SAML:2.0:attrname-format:uri
+          description: Specifies the type of attribute names used in the attribute statement of SAML assertions.
     SingleLogoutProfile:
       type: object
       properties:

--- a/en/includes/references/app-settings/saml-settings-for-app.md
+++ b/en/includes/references/app-settings/saml-settings-for-app.md
@@ -196,6 +196,13 @@ The key encryption algorithm you select specifies the asymmetric encryption algo
 
 Specifies whether to include the user's attributes in the SAML assertions as part of the attribute statement. You can configure user attributes by navigating to **User Attributes** section in the application.
 
+#### Attribute name format
+
+The attribute name format specifies the type of attribute names used in the attribute statement of SAML assertions. The following are the attribute name format types supported by {{ product_name }}.
+
+- `urn:oasis:names:tc:SAML:2.0:attrname-format:basic`
+- `urn:oasis:names:tc:SAML:2.0:attrname-format:uri`
+
 <br>
 
 ### Single Logout Profile

--- a/en/includes/references/app-settings/saml-settings-for-app.md
+++ b/en/includes/references/app-settings/saml-settings-for-app.md
@@ -198,7 +198,7 @@ Specifies whether to include the user's attributes in the SAML assertions as par
 
 #### Attribute name format
 
-The attribute name format specifies the type of attribute names used in the attribute statement of SAML assertions. The following are the attribute name format types supported by {{ product_name }}.
+The attribute name format specifies the type of attribute names used in the attribute statements of SAML assertions. The following are the attribute name format types supported by {{ product_name }}.
 
 - `urn:oasis:names:tc:SAML:2.0:attrname-format:basic`
 - `urn:oasis:names:tc:SAML:2.0:attrname-format:uri`


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->
This PR introduces changes for the new SAML configuration, `Attribute Name Format`, which allows modifying the name format of attributes in a SAML assertion.

## Related Issue
- https://github.com/wso2/product-is/issues/4299
