### PR TITLE
Add placeholder for notifications tab

### DIFF
--- a/en/asgardeo/docs/guides/authentication/mfa/add-smsotp-login.md
+++ b/en/asgardeo/docs/guides/authentication/mfa/add-smsotp-login.md
@@ -1,1 +1,3 @@
+{% set notification_tab_name = "Email & SMS" %}
+
 {% include "../../../../../includes/guides/authentication/mfa/add-smsotp-login.md" %}

--- a/en/asgardeo/docs/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md
+++ b/en/asgardeo/docs/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md
@@ -5,5 +5,6 @@
 %}
 
 {% set configure_email_sender = "" %}
+{% set notification_tab_name = "Email & SMS" %}
 
 {% include "../../../../../includes/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md" %}

--- a/en/identity-server/next/docs/guides/authentication/mfa/add-smsotp-login.md
+++ b/en/identity-server/next/docs/guides/authentication/mfa/add-smsotp-login.md
@@ -1,1 +1,3 @@
+{% set notification_tab_name = "Notification Channels" %}
+
 {% include "../../../../../../includes/guides/authentication/mfa/add-smsotp-login.md" %}

--- a/en/identity-server/next/docs/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md
+++ b/en/identity-server/next/docs/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md
@@ -1,3 +1,4 @@
 {% set admin_login_note = "" %}
+{% set notification_tab_name = "Notification Channels" %}
 
 {% include "../../../../../../includes/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md" %}

--- a/en/includes/guides/authentication/mfa/add-smsotp-login.md
+++ b/en/includes/guides/authentication/mfa/add-smsotp-login.md
@@ -49,7 +49,7 @@ To update the default SMS OTP settings:
 
 ## Configuring SMS Providers
 
-Configurations related to SMS providers are located under the **Email & SMS** section.
+Configurations related to SMS providers are located under the **{{ notification_tab_name }}** section.
 
 ### Supported Providers
 

--- a/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md
+++ b/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-sms-otp.md
@@ -49,7 +49,7 @@ To update the default SMS OTP settings:
 
 ## Configuring SMS Providers
 
-Configurations related to SMS providers are located under the **Email & SMS** section On the {{ product_name }} Console.
+Configurations related to SMS providers are located under the **{{ notification_tab_name }}** section On the {{ product_name }} Console.
 
 ### Supported Providers
 


### PR DESCRIPTION
We have renamed the Email & SMS tab as Notification Channels from IS 7.1.0 since we are including push providers into the same menu. Hence added a placeholder to conditionally render the correct tab name for each product.