### PR TITLE
[Docs][API][IS] Remove Unwanted Query Parameters in rolesRef Example in API Documentation

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -697,8 +697,7 @@ components:
               rolesRef:
                 type: string
                 description: URL reference to retrieve paginated roles for the shared user in this organization
-                example: "/o/api/server/v1/users/{userId}/shared-roles?orgId=b028ca17-8f89-449c-ae27-fa955e66465d
-                &after=&before=&limit=2&filter=&recursive=false"
+                example: "/o/api/server/v1/users/{userId}/shared-roles?orgId={orgId}"
 
     UserSharedRolesResponse:
       type: object

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -701,7 +701,7 @@ components:
               rolesRef:
                 type: string
                 description: URL reference to retrieve paginated roles for the shared user in this organization
-                example: "/api/server/v1/users/{userId}/shared-roles?orgId=b028ca17-8f89-449c-ae27-fa955e66465d&after=&before=&limit=2&filter=&recursive=false"
+                example: "/api/server/v1/users/{userId}/shared-roles?orgId={orgId}"
 
     UserSharedRolesResponse:
       type: object


### PR DESCRIPTION
## Purpose
The API documentation currently includes unnecessary query parameters in the `rolesRef` example for retrieving roles for shared users in an organization. These extra parameters (`after`, `before`, `limit`, `filter`, and `recursive`) should not be part of the example, as they may cause confusion for users referencing the documentation.

## Goals
- Improve clarity in API documentation by removing unnecessary query parameters.
- Ensure that the example URL only includes the required `orgId` parameter.
- Maintain consistency in API examples across the documentation.

## Approach
- Update the `rolesRef` example in `organization-user-share.yaml` by removing the query parameters.
- Ensure that the example URL follows the expected format:
```
example: "/api/server/v1/users/{userId}/shared-roles?orgId={orgId}"
example: "/o/api/server/v1/users/{userId}/shared-roles?orgId={orgId}"
```
- Verify that other parts of the documentation do not include similar unnecessary parameters.

--- 

## Related Issue

[[Docs][API] Introduce User Sharing from Parent Org to Sub-Org #22823](https://github.com/wso2/product-is/issues/22823)