### PR TITLE
Fix incorrectly swapped example Curl commands in Authenticators API docs

### DIFF
--- a/en/identity-server/7.0.0/docs/apis/restapis/authenticators.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/authenticators.yaml
@@ -103,7 +103,7 @@ paths:
       x-codeSamples:
         - lang: Curl
           source: |
-            curl --location 'https://localhost:9443/api/server/v1/authenticators/meta/tags' \
+            curl --location 'https://localhost:9443/api/server/v1/authenticators/{authenticator-id}/connected-apps' \
             -H 'Accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4='
   /authenticators/meta/tags:
@@ -135,7 +135,7 @@ paths:
       x-codeSamples:
         - lang: Curl
           source: |
-            curl --location 'https://localhost:9443/api/server/v1/authenticators/{authenticator-id}/connected-apps' \
+            curl --location 'https://localhost:9443/api/server/v1/authenticators/meta/tags' \
             -H 'Accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4='
 

--- a/en/identity-server/next/docs/apis/restapis/authenticators.yaml
+++ b/en/identity-server/next/docs/apis/restapis/authenticators.yaml
@@ -103,7 +103,7 @@ paths:
       x-codeSamples:
         - lang: Curl
           source: |
-            curl --location 'https://localhost:9443/api/server/v1/authenticators/meta/tags' \
+            curl --location 'https://localhost:9443/api/server/v1/authenticators/{authenticator-id}/connected-apps' \
             -H 'Accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4='
   /authenticators/meta/tags:
@@ -135,7 +135,7 @@ paths:
       x-codeSamples:
         - lang: Curl
           source: |
-            curl --location 'https://localhost:9443/api/server/v1/authenticators/{authenticator-id}/connected-apps' \
+            curl --location 'https://localhost:9443/api/server/v1/authenticators/meta/tags' \
             -H 'Accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4='
 


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/22758

## Goals
> This PR updates the example curl command in the Authenticators API documentation.