### PR TITLE
[7.0] Add an Immutable attributes note to SCIM2 Enterprise Schema Attributes

### DIFF
--- a/en/identity-server/7.0.0/docs/guides/users/attributes/manage-scim2-attribute-mappings.md
+++ b/en/identity-server/7.0.0/docs/guides/users/attributes/manage-scim2-attribute-mappings.md
@@ -16,4 +16,22 @@
          ```
 "%}
 
+{% set immutable_claims_note = "!!! note
+    A set of attributes in the enterprise schema are immutable. These attributes are used for internal purposes of WSO2 Identity Server and are not intended to be modified. Attempting to modify these attributes, either through the SCIM 2.0 API or from the user profile in the Console, will result in an error.
+
+    These attributes can be identified by the `\"mutability\"` key with the value `\"readOnly\"` configured in the `scim2-schema-extension.config` file.
+
+    The following attributes in the Identity Server are immutable in the default setup:
+
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountState`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastLoginTime`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastLoginTime`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastPasswordUpdateTime`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lockedReason`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isReadOnlyUser`
+    - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:oneTimePassword`
+"%}
+
 {% include "../../../../../../includes/guides/users/attributes/manage-scim2-attribute-mappings.md" %}

--- a/en/includes/guides/users/attributes/manage-scim2-attribute-mappings.md
+++ b/en/includes/guides/users/attributes/manage-scim2-attribute-mappings.md
@@ -11,6 +11,10 @@ The attributes in the core, user, and enterprise schemas are well-defined in the
 
 {{custom_schema_note}}
 
+{% if immutable_claims_note %}
+{{immutable_claims_note}}
+{% endif %}
+
 ## View SCIM 2.0 attributes
 To view the SCIM 2 attributes mapped to user attributes in your organization:
 


### PR DESCRIPTION
## Purpose
- Some attributes in the User Profile cannot be modified either via the SCIM 2.0 API or via the user profile in the Identity Server 7.0 Console.
- This PR adds information on the above attributes