### PR TITLE
Update sample curls and example responses in Organization Application API

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -118,7 +118,7 @@ paths:
                     mandatory: false
                 subject:
                   claim:
-                    uri: "http://wso2.org/claims/username"
+                    uri: "http://wso2.org/claims/userid"
                   includeUserDomain: false
                   includeTenantDomain: false
                   useMappedLocalSubject: false
@@ -217,7 +217,7 @@ paths:
               ],
               "subject": {
                 "claim": {
-                  "uri": "http://wso2.org/claims/username"
+                  "uri": "http://wso2.org/claims/userid"
                 },
                 "includeUserDomain": false,
                 "includeTenantDomain": false,
@@ -286,7 +286,50 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationResponseModel'
+                $ref: '#/components/schemas/ApplicationResponse'
+              example:
+                id: "394b8adcce24c64a8a09a0d80abf8c337bd253de"
+                name: "pickup"
+                description: "This is the configuration for Pickup application."
+                applicationVersion: "v1.0.0"
+                imageUrl: "https://example.com/logo/my-logo.png"
+                clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
+                applicationEnabled: true
+                associatedRoles:
+                  allowedAudience: "APPLICATION"
+                  roles:
+                    - id: "bf5abd05-3667-4a2a-a6c2-2fb9f4d26e47"
+                      name: "RoleA"
+                claimConfiguration:
+                  dialect: "LOCAL"
+                  requestedClaims:
+                    - claim:
+                        id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                        uri: "http://wso2.org/claims/username"
+                        displayName: "Username"
+                      mandatory: false
+                  subject:
+                    claim:
+                      id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                      uri: "http://wso2.org/claims/userid"
+                      displayName: "User ID"
+                    includeUserDomain: false
+                    includeTenantDomain: false
+                    useMappedLocalSubject: false
+                    mappedLocalSubjectMandatory: false
+                  role:
+                    includeUserDomain: true
+                    claim:
+                      id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                      uri: "http://wso2.org/claims/roles"
+                      displayName: "Roles"
+                advancedConfigurations:
+                  discoverableByEndUsers: false
+                  certificate:
+                    type: "string"
+                    value: "string"
+                  skipLoginConsent: false
+                  skipLogoutConsent: false
         '400':
           description: Bad Request
           content:
@@ -351,22 +394,18 @@ paths:
               description: "This is the configuration for Pickup application."
               applicationVersion: "v1.0.0"
               imageUrl: "https://example.com/logo/my-logo.png"
-              clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
               applicationEnabled: true
               associatedRoles:
                 allowedAudience: "APPLICATION"
-                roles:
-                  - id: "bf5abd05-3667-4a2a-a6c2-2fb9f4d26e47"
-                    name: "RoleA"
               claimConfiguration:
-                dialect: "CUSTOM"
+                dialect: "LOCAL"
                 requestedClaims:
                   - claim:
                       uri: "http://wso2.org/claims/username"
                     mandatory: false
                 subject:
                   claim:
-                    uri: "http://wso2.org/claims/username"
+                    uri: "http://wso2.org/claims/userid"
                   includeUserDomain: false
                   includeTenantDomain: false
                   useMappedLocalSubject: false
@@ -376,7 +415,6 @@ paths:
                   claim:
                     uri: "http://wso2.org/claims/roles"
               advancedConfigurations:
-                saas: false
                 discoverableByEndUsers: false
                 certificate:
                   type: "string"
@@ -386,25 +424,7 @@ paths:
                 useExternalConsentPage: false
                 returnAuthenticatedIdpList: false
                 enableAuthorization: true
-                fragment: false
                 enableAPIBasedAuthentication: false
-                attestationMetaData:
-                  enableClientAttestation: false
-                  androidPackageName: "com.wso2.mobile.sample"
-                  androidAttestationServiceCredentials: {}
-                  appleAppId: "APPLETEAMID.com.wso2.mobile.sample"
-                trustedAppConfiguration:
-                  isFIDOTrustedApp: false
-                  isConsentGranted: false
-                  androidPackageName: "com.wso2.mobile.sample"
-                  androidThumbprints:
-                    - "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
-                  appleAppId: "APPLETEAMID.com.org.mobile.sample"
-                additionalSpProperties:
-                  - name: "isInternalApp"
-                    value: "true"
-                    displayName: "Internal Application"
-              access: "READ"
         description: This represents the application details to be updated.
         required: true
       responses:
@@ -445,19 +465,12 @@ paths:
               "description": "This is the configuration for Pickup application.",
               "applicationVersion": "v1.0.0",
               "imageUrl": "https://example.com/logo/my-logo.png",
-              "clientId": "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18",
               "applicationEnabled": true,
               "associatedRoles": {
-                "allowedAudience": "APPLICATION",
-                "roles": [
-                  {
-                    "id": "bf5abd05-3667-4a2a-a6c2-2fb9f4d26e47",
-                    "name": "RoleA"
-                  }
-                ]
+                "allowedAudience": "APPLICATION"
               },
               "claimConfiguration": {
-                "dialect": "CUSTOM",
+                "dialect": "LOCAL",
                 "requestedClaims": [
                   {
                     "claim": {
@@ -468,7 +481,7 @@ paths:
                 ],
                 "subject": {
                   "claim": {
-                    "uri": "http://wso2.org/claims/username"
+                    "uri": "http://wso2.org/claims/userid"
                   },
                   "includeUserDomain": false,
                   "includeTenantDomain": false,
@@ -483,7 +496,6 @@ paths:
                 }
               },
               "advancedConfigurations": {
-                "saas": false,
                 "discoverableByEndUsers": false,
                 "certificate": {
                   "type": "string",
@@ -494,32 +506,8 @@ paths:
                 "useExternalConsentPage": false,
                 "returnAuthenticatedIdpList": false,
                 "enableAuthorization": true,
-                "fragment": false,
-                "enableAPIBasedAuthentication": false,
-                "attestationMetaData": {
-                  "enableClientAttestation": false,
-                  "androidPackageName": "com.wso2.mobile.sample",
-                  "androidAttestationServiceCredentials": {},
-                  "appleAppId": "APPLETEAMID.com.wso2.mobile.sample"
-                },
-                "trustedAppConfiguration": {
-                  "isFIDOTrustedApp": false,
-                  "isConsentGranted": false,
-                  "androidPackageName": "com.wso2.mobile.sample",
-                  "androidThumbprints": [
-                    "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
-                  ],
-                  "appleAppId": "APPLETEAMID.com.org.mobile.sample"
-                },
-                "additionalSpProperties": [
-                  {
-                    "name": "isInternalApp",
-                    "value": "true",
-                    "displayName": "Internal Application"
-                  }
-                ]
-              },
-              "access": "READ"
+                "enableAPIBasedAuthentication": false
+              }
             }'
     delete:
       tags:
@@ -798,6 +786,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboundProtocolsListResponse'
+              example:
+              - type: "oauth2"
+                self: "/o/api/server/v1/applications/85e3f4b8-0d22-4181-b1e3-1651f71b88bd/inbound-protocols/oidc"
         '400':
           description: Bad Request
           content:
@@ -851,6 +842,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenIDConnectConfiguration'
+              example:
+                clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
+                clientSecret: "RwrNGNNf9dkqJh6NSCqfXj1h6DrmNdNfpzNfJms4jC4a"
+                state: "ACTIVE"
+                grantTypes:
+                  - "client_credentials"
+                  - "password"
+                publicClient: false
+                accessToken:
+                  type: "JWT"
+                  userAccessTokenExpiryInSeconds: 3600
+                  applicationAccessTokenExpiryInSeconds: 3600
+                  bindingType: "cookie"
+                  revokeTokensWhenIDPSessionTerminated: true
+                  validateTokenBinding: true
+                  accessTokenAttributes:
+                    - "string"
+                refreshToken:
+                  expiryInSeconds: 86400
+                  renewRefreshToken: true
+                idToken:
+                  expiryInSeconds: 3600
+                  audience:
+                    - "http://idp.xyz.com"
+                    - "http://idp.abc.com"
+                  idTokenSignedResponseAlg: "PS256"
+                  encryption:
+                    enabled: false
+                    algorithm: "RSA-OAEP"
+                    method: "A128CBC+HS256"
+                scopeValidators:
+                  - "Role based scope validator"
+                clientAuthentication:
+                  tokenEndpointAuthMethod: "client_secret_basic"
+                  tokenEndpointAllowReusePvtKeyJwt: false
+                  tokenEndpointAuthSigningAlg: "PS256"
+                  tlsClientAuthSubjectDn: "CN=John Doe,OU=OrgUnit,O=Organization,L=Colombo,ST=Western,C=LK"
+                subject:
+                  subjectType: "public"
+                  sectorIdentifierUri: "https://app.example.com"
+                isFAPIApplication: false
         '400':
           description: Bad Request
           content:
@@ -943,46 +975,100 @@ paths:
             -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
-            "clientId": "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18",
-            "clientSecret": "RwrNGNNf9dkqJh6NSCqfXj1h6DrmNdNfpzNfJms4jC4a",
-            "grantTypes": [
-              "client_credentials",
-              "password"
-            ],
-            "publicClient": false,
-            "accessToken": {
-              "type": "JWT",
-              "userAccessTokenExpiryInSeconds": 3600,
-              "applicationAccessTokenExpiryInSeconds": 3600,
-              "bindingType": "cookie",
-              "revokeTokensWhenIDPSessionTerminated": true,
-              "validateTokenBinding": true
-            },
-            "refreshToken": {
-              "expiryInSeconds": 86400,
-              "renewRefreshToken": true
-            },
-            "idToken": {
-              "expiryInSeconds": 3600,
-              "audience": [
-                "http://idp.xyz.com",
-                "http://idp.abc.com"
+              "clientId": "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18",
+              "clientSecret": "RwrNGNNf9dkqJh6NSCqfXj1h6DrmNdNfpzNfJms4jC4a",
+              "grantTypes": [
+                "client_credentials",
+                "password"
               ],
-              "encryption": {
-                "enabled": false,
-                "algorithm": "RSA-OAEP",
-                "method": "A128CBC+HS256"
-              }
-            },
-            "scopeValidators": [
-              "Role based scope validator"
-            ]
+              "allowedOrigins": [],
+              "publicClient": false,
+              "accessToken": {
+                "type": "JWT",
+                "userAccessTokenExpiryInSeconds": 3600,
+                "applicationAccessTokenExpiryInSeconds": 3600,
+                "bindingType": "cookie",
+                "revokeTokensWhenIDPSessionTerminated": true,
+                "validateTokenBinding": true,
+                "accessTokenAttributes": []
+              },
+              "refreshToken": {
+                "expiryInSeconds": 86400,
+                "renewRefreshToken": true
+              },
+              "idToken": {
+                "expiryInSeconds": 3600,
+                "audience": [
+                  "http://idp.xyz.com",
+                  "http://idp.abc.com"
+                ],
+                "idTokenSignedResponseAlg": "PS256",
+                "encryption": {
+                  "enabled": false,
+                  "algorithm": "RSA-OAEP",
+                  "method": "A128CBC+HS256"
+                }
+              },
+              "scopeValidators": [
+                "Role based scope validator"
+              ],
+              "clientAuthentication": {
+                "tokenEndpointAuthMethod": "private_key_jwt",
+                "tokenEndpointAllowReusePvtKeyJwt": false,
+                "tokenEndpointAuthSigningAlg": ""
+              },
+              "subject": {
+                "subjectType": "public",
+                "sectorIdentifierUri": "https://app.example.com"
+              },
+              "isFAPIApplication": false
             }'
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/OpenIDConnectConfiguration'
+            example:
+              clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
+              clientSecret: "RwrNGNNf9dkqJh6NSCqfXj1h6DrmNdNfpzNfJms4jC4a"
+              grantTypes:
+                - "client_credentials"
+                - "password"
+              allowedOrigins: []
+              publicClient: false
+              accessToken:
+                type: "JWT"
+                userAccessTokenExpiryInSeconds: 3600
+                applicationAccessTokenExpiryInSeconds: 3600
+                bindingType: "cookie"
+                revokeTokensWhenIDPSessionTerminated: true
+                validateTokenBinding: true
+                accessTokenAttributes:
+                  - "string"
+              refreshToken:
+                expiryInSeconds: 86400
+                renewRefreshToken: true
+              idToken:
+                expiryInSeconds: 3600
+                audience:
+                  - "http://idp.xyz.com"
+                  - "http://idp.abc.com"
+                idTokenSignedResponseAlg: "PS256"
+                encryption:
+                  enabled: false
+                  algorithm: "RSA-OAEP"
+                  method: "A128CBC+HS256"
+              scopeValidators:
+                - "Role based scope validator"
+              clientAuthentication:
+                tokenEndpointAuthMethod: "client_secret_basic"
+                tokenEndpointAllowReusePvtKeyJwt: false
+                tokenEndpointAuthSigningAlg: "PS256"
+                tlsClientAuthSubjectDn: "CN=John Doe,OU=OrgUnit,O=Organization,L=Colombo,ST=Western,C=LK"
+              subject:
+                subjectType: "public"
+                sectorIdentifierUri: "https://app.example.com"
+              isFAPIApplication: false
         description: >-
           This represents the OIDC authentication protocol parameters of an
           application.
@@ -1059,6 +1145,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenIDConnectConfiguration'
+              example:
+                clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
+                clientSecret: "RwrNGNNf9dkqJh6NSCqfXj1h6DrmNdNfpzNfJms4jC4a"
+                state: "ACTIVE"
+                grantTypes:
+                  - "client_credentials"
+                  - "password"
+                allowedOrigins: []
+                publicClient: false
+                accessToken:
+                  type: "JWT"
+                  userAccessTokenExpiryInSeconds: 3600
+                  applicationAccessTokenExpiryInSeconds: 3600
+                  bindingType: "cookie"
+                  revokeTokensWhenIDPSessionTerminated: true
+                  validateTokenBinding: true
+                  accessTokenAttributes:
+                    - "string"
+                refreshToken:
+                  expiryInSeconds: 86400
+                  renewRefreshToken: true
+                idToken:
+                  expiryInSeconds: 3600
+                  audience:
+                    - "http://idp.xyz.com"
+                    - "http://idp.abc.com"
+                  idTokenSignedResponseAlg: "PS256"
+                  encryption:
+                    enabled: false
+                    algorithm: "RSA-OAEP"
+                    method: "A128CBC+HS256"
+                scopeValidators:
+                  - "Role based scope validator"
+                clientAuthentication:
+                  tokenEndpointAuthMethod: "client_secret_basic"
+                  tokenEndpointAllowReusePvtKeyJwt: false
+                  tokenEndpointAuthSigningAlg: "PS256"
+                  tlsClientAuthSubjectDn: "CN=John Doe,OU=OrgUnit,O=Organization,L=Colombo,ST=Western,C=LK"
+                subject:
+                  subjectType: "public"
+                  sectorIdentifierUri: "https://app.example.com"
+                isFAPIApplication: false
         '400':
           description: Bad Request
           content:
@@ -1109,8 +1237,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/AuthProtocolMetadata'
                 example:
-                  - name: "saml"
-                    displayName: "SAML2 Web SSO Configuration"
+                  - name: "oidc"
+                    displayName: "OAuth/OpenID Connect Configuration"
         '401':
           description: Unauthorized
         '403':
@@ -1131,7 +1259,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/o/api/server/v1/applications/meta/inbound-protocols?customOnly=true' \
+            'https://localhost:9443/o/api/server/v1/applications/meta/inbound-protocols' \
             -H 'accept: application/json' \
             -H 'Authorization: Bearer {bearer_token}'
 components:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -42,6 +42,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApplicationListResponse'
+              example:
+                totalResults: 1
+                startIndex: 1
+                count: 1
+                applications:
+                  - id: "85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+                    name: "user-portal"
+                    applicationVersion: "v1.0.0"
+                    access: "READ"
+                    self: "/o/api/server/v1/applications/85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+                links:
+                  - href: "applications?offset=10&limit=10"
+                    rel: "next"
         '400':
           description: Bad Request
           content:
@@ -93,6 +106,55 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ApplicationModel'
+            example:
+              name: "pickup"
+              description: "This is the configuration for Pickup application."
+              imageUrl: "https://example.com/logo/my-logo.png"
+              claimConfiguration:
+                dialect: "LOCAL"
+                requestedClaims:
+                  - claim:
+                      uri: "http://wso2.org/claims/username"
+                    mandatory: false
+                subject:
+                  claim:
+                    uri: "http://wso2.org/claims/username"
+                  includeUserDomain: false
+                  includeTenantDomain: false
+                  useMappedLocalSubject: false
+              role:
+                includeUserDomain: true
+                claim:
+                  uri: "http://wso2.org/claims/roles"
+              inboundProtocolConfiguration:
+                oidc:
+                  clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
+                  clientSecret: "RwrNGNNf9dkqJh6NSCqfXj1h6DrmNdNfpzNfJms4jC4a"
+                  grantTypes:
+                    - "client_credentials"
+                    - "password"
+                  publicClient: false
+                  accessToken:
+                    type: "JWT"
+                    userAccessTokenExpiryInSeconds: 3600
+                    applicationAccessTokenExpiryInSeconds: 3600
+                    bindingType: "cookie"
+                    revokeTokensWhenIDPSessionTerminated: true
+                    validateTokenBinding: true
+                  refreshToken:
+                    expiryInSeconds: 86400
+                    renewRefreshToken: true
+                  idToken:
+                    expiryInSeconds: 3600
+                    audience:
+                      - "http://idp.xyz.com"
+                      - "http://idp.abc.com"
+                    encryption:
+                      enabled: false
+                      algorithm: "RSA-OAEP"
+                      method: "A128CBC+HS256"
+                  scopeValidators:
+                    - "Role based scope validator"
         description: This represents the application to be created.
         required: true
       responses:
@@ -145,14 +207,6 @@ paths:
             "imageUrl": "https://example.com/logo/my-logo.png",
             "claimConfiguration": {
               "dialect": "LOCAL",
-              "claimMappings": [
-                {
-                  "applicationClaim": "firstname",
-                  "localClaim": {
-                    "uri": "http://wso2.org/claims/username"
-                  }
-                }
-              ],
               "requestedClaims": [
                 {
                   "claim": {
@@ -292,6 +346,65 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ApplicationPatchModel'
+            example:
+              name: "pickup"
+              description: "This is the configuration for Pickup application."
+              applicationVersion: "v1.0.0"
+              imageUrl: "https://example.com/logo/my-logo.png"
+              clientId: "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18"
+              applicationEnabled: true
+              associatedRoles:
+                allowedAudience: "APPLICATION"
+                roles:
+                  - id: "bf5abd05-3667-4a2a-a6c2-2fb9f4d26e47"
+                    name: "RoleA"
+              claimConfiguration:
+                dialect: "CUSTOM"
+                requestedClaims:
+                  - claim:
+                      uri: "http://wso2.org/claims/username"
+                    mandatory: false
+                subject:
+                  claim:
+                    uri: "http://wso2.org/claims/username"
+                  includeUserDomain: false
+                  includeTenantDomain: false
+                  useMappedLocalSubject: false
+                  mappedLocalSubjectMandatory: false
+                role:
+                  includeUserDomain: true
+                  claim:
+                    uri: "http://wso2.org/claims/roles"
+              advancedConfigurations:
+                saas: false
+                discoverableByEndUsers: false
+                certificate:
+                  type: "string"
+                  value: "string"
+                skipLoginConsent: false
+                skipLogoutConsent: false
+                useExternalConsentPage: false
+                returnAuthenticatedIdpList: false
+                enableAuthorization: true
+                fragment: false
+                enableAPIBasedAuthentication: false
+                attestationMetaData:
+                  enableClientAttestation: false
+                  androidPackageName: "com.wso2.mobile.sample"
+                  androidAttestationServiceCredentials: {}
+                  appleAppId: "APPLETEAMID.com.wso2.mobile.sample"
+                trustedAppConfiguration:
+                  isFIDOTrustedApp: false
+                  isConsentGranted: false
+                  androidPackageName: "com.wso2.mobile.sample"
+                  androidThumbprints:
+                    - "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
+                  appleAppId: "APPLETEAMID.com.org.mobile.sample"
+                additionalSpProperties:
+                  - name: "isInternalApp"
+                    value: "true"
+                    displayName: "Internal Application"
+              access: "READ"
         description: This represents the application details to be updated.
         required: true
       responses:
@@ -328,48 +441,85 @@ paths:
             -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
-            "name": "pickup",
-            "description": "This is the configuration for Pickup application.",
-            "imageUrl": "https://example.com/logo/my-logo.png",
-            "claimConfiguration": {
-              "dialect": "LOCAL",
-              "claimMappings": [
-                {
-                  "applicationClaim": "firstname",
-                  "localClaim": {
-                    "uri": "http://wso2.org/claims/username"
+              "name": "pickup",
+              "description": "This is the configuration for Pickup application.",
+              "applicationVersion": "v1.0.0",
+              "imageUrl": "https://example.com/logo/my-logo.png",
+              "clientId": "fd52e37f-1b8b-44f5-ad1a-5d846ad03b18",
+              "applicationEnabled": true,
+              "associatedRoles": {
+                "allowedAudience": "APPLICATION",
+                "roles": [
+                  {
+                    "id": "bf5abd05-3667-4a2a-a6c2-2fb9f4d26e47",
+                    "name": "RoleA"
                   }
-                }
-              ],
-              "requestedClaims": [
-                {
+                ]
+              },
+              "claimConfiguration": {
+                "dialect": "CUSTOM",
+                "requestedClaims": [
+                  {
+                    "claim": {
+                      "uri": "http://wso2.org/claims/username"
+                    },
+                    "mandatory": false
+                  }
+                ],
+                "subject": {
                   "claim": {
                     "uri": "http://wso2.org/claims/username"
                   },
-                  "mandatory": false
-                }
-              ],
-              "subject": {
-                "claim": {
-                  "uri": "http://wso2.org/claims/username"
+                  "includeUserDomain": false,
+                  "includeTenantDomain": false,
+                  "useMappedLocalSubject": false,
+                  "mappedLocalSubjectMandatory": false
                 },
-                "includeUserDomain": false,
-                "includeTenantDomain": false,
-                "useMappedLocalSubject": false
-              },
-              "role": {
-                "mappings": [
-                  {
-                    "localRole": "admin",
-                    "applicationRole": "Administrator"
+                "role": {
+                  "includeUserDomain": true,
+                  "claim": {
+                    "uri": "http://wso2.org/claims/roles"
                   }
-                ],
-                "includeUserDomain": true,
-                "claim": {
-                  "uri": "http://wso2.org/claims/username"
                 }
-              }
-            }
+              },
+              "advancedConfigurations": {
+                "saas": false,
+                "discoverableByEndUsers": false,
+                "certificate": {
+                  "type": "string",
+                  "value": "string"
+                },
+                "skipLoginConsent": false,
+                "skipLogoutConsent": false,
+                "useExternalConsentPage": false,
+                "returnAuthenticatedIdpList": false,
+                "enableAuthorization": true,
+                "fragment": false,
+                "enableAPIBasedAuthentication": false,
+                "attestationMetaData": {
+                  "enableClientAttestation": false,
+                  "androidPackageName": "com.wso2.mobile.sample",
+                  "androidAttestationServiceCredentials": {},
+                  "appleAppId": "APPLETEAMID.com.wso2.mobile.sample"
+                },
+                "trustedAppConfiguration": {
+                  "isFIDOTrustedApp": false,
+                  "isConsentGranted": false,
+                  "androidPackageName": "com.wso2.mobile.sample",
+                  "androidThumbprints": [
+                    "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
+                  ],
+                  "appleAppId": "APPLETEAMID.com.org.mobile.sample"
+                },
+                "additionalSpProperties": [
+                  {
+                    "name": "isInternalApp",
+                    "value": "true",
+                    "displayName": "Internal Application"
+                  }
+                ]
+              },
+              "access": "READ"
             }'
     delete:
       tags:


### PR DESCRIPTION
## Purpose
&subject

Fixes: https://github.com/wso2/product-is/issues/23221

Fixes the error thrown when using the sample curl given:

<img width="1107" alt="Screenshot 2025-02-21 at 21 30 57" src="https://github.com/user-attachments/assets/c3ed1ebd-ec5f-4a16-8a6a-1cc9a267995f" />

```
"code": "APP-60001",
    "message": "Error patching application with id: d9a93339-b23c-479f-b434-54049593fc8c",
    "description": "Invalid application configuration for application: 'pickup2' of tenantDomain: 9870650c-f4b5-43a0-8977-d0650dea04f2. Groups including: admin, are prohibited for role mapping. Use roles instead.",
    "traceId": "bede6c21-8e7a-4ba2-85da-dfe6b6d76c8e"
}
```