### PR TITLE
[Docs][API][IS] Update Documentation to Address Resource Sharing Policy Switching Behaviour

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -26,7 +26,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective sharing policy or vice versa, without unsharing a user, it can lead to access issues. To ensure a smooth transition, first unshare the user from all organizations and share them again with the desired organization(s) under the updated policy. </br> 
-        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/users/unshare-with-all` API to reset access before applying the new sharing policy.
+        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/o/users/unshare-with-all` API to reset access before applying the new sharing policy.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharing
@@ -118,7 +118,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective sharing policy or vice versa, without unsharing a user, it can lead to access issues. To ensure a smooth transition, first unshare the user from all organizations and share them again with the desired organization(s) under the updated policy. </br> 
-        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/users/unshare-with-all` API to reset access before applying the new sharing policy.
+        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/o/users/unshare-with-all` API to reset access before applying the new sharing policy.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -25,8 +25,8 @@ paths:
         This API shares one or more users across specified organizations, assigning roles based on the provided policy. The policy defines the sharing scope for each organization, including whether access extends to child organizations.
         
         > **Important** </br>
-        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/o/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
+        > If you switch a user from a general sharing policy to a selective sharing policy or vice versa, without unsharing a user, it can lead to access issues. To ensure a smooth transition, first unshare the user from all organizations and share them again with the desired organization(s) under the updated policy. </br> 
+        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/users/unshare-with-all` API to reset access before applying the new sharing policy.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharing
@@ -117,8 +117,8 @@ paths:
         This API shares users across all organizations, applying the provided roles to each organization. The policy determines the scope of sharing, including whether it applies to all current organizations or future organizations as well.
         
         > **Important** </br>
-        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/o/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
+        > If you switch a user from a general sharing policy to a selective sharing policy or vice versa, without unsharing a user, it can lead to access issues. To ensure a smooth transition, first unshare the user from all organizations and share them again with the desired organization(s) under the updated policy. </br> 
+        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/users/unshare-with-all` API to reset access before applying the new sharing policy.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -24,6 +24,10 @@ paths:
       description: |
         This API shares one or more users across specified organizations, assigning roles based on the provided policy. The policy defines the sharing scope for each organization, including whether access extends to child organizations.
         
+        > **Important** </br>
+        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
+        
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharing
       requestBody:
@@ -111,6 +115,10 @@ paths:
       summary: Share a user with all organizations
       description: |
         This API shares users across all organizations, applying the provided roles to each organization. The policy determines the scope of sharing, including whether it applies to all current organizations or future organizations as well.
+        
+        > **Important** </br>
+        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -26,7 +26,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharing
@@ -118,7 +118,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -209,7 +209,7 @@ paths:
         - unsharing can only be done from the same organization that initially shared the user.
         - if you have shared a user with an organization and its children, unsharing the user from that 
           organization will not unshare the user from the child organizations.
-          You must explicitly delcare all the organization IDs from which the user should be removed.
+          You must explicitly declare all the organization IDs from which the user should be removed.
         
         <b>Scope(Permission) required:</b> `internal_org_user_unshare`
       operationId: processUserUnsharing

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -26,7 +26,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharing
@@ -118,7 +118,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-user-share.yaml
@@ -26,7 +26,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/o/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharing
@@ -118,7 +118,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/o/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-apis/organization-user-share/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/o/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_org_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -210,7 +210,7 @@ paths:
         - unsharing can only be done from the same organization that initially shared the user.
         - if you have shared a user with an organization and its children, unsharing the user from that 
           organization will not unshare the user from the child organizations.
-          You must explicitly delcare all the organization IDs from which the user should be removed.
+          You must explicitly declare all the organization IDs from which the user should be removed.
 
         <b>Scope(Permission) required:</b> `internal_user_unshare`
       operationId: processUserUnsharing

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -25,6 +25,10 @@ paths:
       description: |
         This API shares one or more users across specified organizations, assigning roles based on the provided policy. The policy defines the sharing scope for each organization, including whether access extends to child organizations.
         
+        > **Important** </br>
+        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
+        
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharing
       requestBody:
@@ -112,6 +116,10 @@ paths:
       summary: Share a user with all organizations
       description: |
         This API shares users across all organizations, applying the provided roles to each organization. The policy determines the scope of sharing, including whether it applies to all current organizations or future organizations as well.
+        
+        > **Important** </br>
+        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -27,7 +27,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharing
@@ -119,7 +119,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -26,8 +26,8 @@ paths:
         This API shares one or more users across specified organizations, assigning roles based on the provided policy. The policy defines the sharing scope for each organization, including whether access extends to child organizations.
         
         > **Important** </br>
-        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
+        > If you switch a user from a general sharing policy to a selective sharing policy or vice versa, without unsharing a user, it can lead to access issues. To ensure a smooth transition, first unshare the user from all organizations and share them again with the desired organization(s) under the updated policy. </br> 
+        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/users/unshare-with-all` API to reset access before applying the new sharing policy.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharing
@@ -118,8 +118,8 @@ paths:
         This API shares users across all organizations, applying the provided roles to each organization. The policy determines the scope of sharing, including whether it applies to all current organizations or future organizations as well.
         
         > **Important** </br>
-        > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-with-all` API to reset shared access before setting up a new user sharing.
+        > If you switch a user from a general sharing policy to a selective sharing policy or vice versa, without unsharing a user, it can lead to access issues. To ensure a smooth transition, first unshare the user from all organizations and share them again with the desired organization(s) under the updated policy. </br> 
+        > If you overlook this step and notice unexpected user-sharing behavior when new organizations are created, use the `/users/unshare-with-all` API to reset access before applying the new sharing policy.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -27,7 +27,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharing
@@ -119,7 +119,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the `/users/unshare-all` API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharingAll

--- a/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-user-share.yaml
@@ -27,7 +27,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharing
@@ -119,7 +119,7 @@ paths:
         
         > **Important** </br>
         > If you switch a user from a general sharing policy to a selective one or vice versa, changing it directly might cause access issues. To keep things clear and consistent, first, unshare the user from all organizations, then share them again with the desired organization(s) under the new policy/policies. </br> 
-        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/next/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
+        > Suppose this step is overlooked and unexpected behavior in user sharing is noticed when new organizations are created. In that case, you can use the [`/users/unshare-with-all`](https://is.docs.wso2.com/en/7.1.0/apis/organization-user-share-rest-api/#tag/User-Sharing/operation/removeUserSharing) API to reset shared access before setting up a new user sharing.
         
         <b>Scope(Permission) required:</b> `internal_user_share`
       operationId: processUserSharingAll


### PR DESCRIPTION
## Purpose
Clarify the expected behavior when switching a user between general and selective resource-sharing policies, preventing unexpected access issues.

## Goals
- Inform users about the importance of unsharing before switching policies.
- Provide a clear recommendation to avoid conflicts in user sharing.
- Guide users on how to reset shared access if inconsistencies arise.

## Approach
- Added an Important note in the documentation explaining the expected behavior when switching resource-sharing policies.
- Advised users to unshare first before switching between general and selective policies.
- Included a reference to the `/users/unshare-all` API for resetting shared access in case of issues.

--- 

## Related Issue
[[Docs][API][IS] Clarify Documentation on Switching Between General and Selective Resource Sharing Policies #23254](https://github.com/wso2/product-is/issues/23254)