### PR TITLE
Fix example filter value to match the filtering capability of the /scopes API

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/api-resources.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/api-resources.yaml
@@ -137,7 +137,7 @@ paths:
 
         <b>Scope(Permission) required:</b> `internal_org_api_resource_view`
       parameters:
-        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/scopeFilter'
       responses:
         200:
           description: OK
@@ -251,6 +251,16 @@ components:
       schema:
         type: string
       example: identifier+eq+greetings
+
+    scopeFilter:
+      name: filter
+      in: query
+      required: false
+      description: |
+        Condition to filter the retrieval of scopes by name. Supports 'sw', 'co', 'ew' and 'eq' operations.
+      schema:
+        type: string
+      example: name+co+greetings
 
     collectionFilter:
       name: filter

--- a/en/asgardeo/docs/apis/restapis/api-resources.yaml
+++ b/en/asgardeo/docs/apis/restapis/api-resources.yaml
@@ -435,7 +435,7 @@ paths:
 
         <b>Scope(Permission) required:</b> `internal_api_resource_view`
       parameters:
-        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/scopeFilter'
       responses:
         200:
           description: OK
@@ -620,6 +620,16 @@ components:
       schema:
         type: string
       example: identifier+eq+greetings
+    
+    scopeFilter:
+      name: filter
+      in: query
+      required: false
+      description: |
+        Condition to filter the retrieval of scopes by name. Supports 'sw', 'co', 'ew' and 'eq' operations.
+      schema:
+        type: string
+      example: name+co+greetings
 
     collectionFilter:
       name: filter

--- a/en/identity-server/7.0.0/docs/apis/restapis/api-resources.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/api-resources.yaml
@@ -489,7 +489,7 @@ paths:
 
         <b>Scope(Permission) required:</b> `internal_api_resource_view`
       parameters:
-        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/scopeFilter'
       responses:
         200:
           description: OK
@@ -674,6 +674,16 @@ components:
       schema:
         type: string
       example: identifier+eq+greetings
+    
+    scopeFilter:
+      name: filter
+      in: query
+      required: false
+      description: |
+        Condition to filter the retrieval of scopes by name. Supports 'sw', 'co', 'ew' and 'eq' operations.
+      schema:
+        type: string
+      example: name+co+greetings
 
     collectionFilter:
       name: filter

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/api-resources.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/api-resources.yaml
@@ -144,7 +144,7 @@ paths:
 
         <b>Scope(Permission) required:</b> `internal_org_api_resource_view`
       parameters:
-        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/scopeFilter'
       responses:
         200:
           description: OK
@@ -258,6 +258,16 @@ components:
       schema:
         type: string
       example: identifier+eq+greetings
+
+    scopeFilter:
+      name: filter
+      in: query
+      required: false
+      description: |
+        Condition to filter the retrieval of scopes by name. Supports 'sw', 'co', 'ew' and 'eq' operations.
+      schema:
+        type: string
+      example: name+co+greetings
 
     collectionFilter:
       name: filter

--- a/en/identity-server/next/docs/apis/restapis/api-resources.yaml
+++ b/en/identity-server/next/docs/apis/restapis/api-resources.yaml
@@ -489,7 +489,7 @@ paths:
 
         <b>Scope(Permission) required:</b> `internal_api_resource_view`
       parameters:
-        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/scopeFilter'
       responses:
         200:
           description: OK
@@ -674,6 +674,16 @@ components:
       schema:
         type: string
       example: identifier+eq+greetings
+
+    scopeFilter:
+      name: filter
+      in: query
+      required: false
+      description: |
+        Condition to filter the retrieval of scopes by name. Supports 'sw', 'co', 'ew' and 'eq' operations.
+      schema:
+        type: string
+      example: name+co+greetings
 
     collectionFilter:
       name: filter


### PR DESCRIPTION
## Purpose
$subject

The filtering is only allowed by name:

<img width="1095" alt="Screenshot 2025-02-24 at 14 01 14" src="https://github.com/user-attachments/assets/49acd90f-0bb8-4cfb-bb23-93bf9017f7ba" />

<img width="1095" alt="Screenshot 2025-02-24 at 14 01 03" src="https://github.com/user-attachments/assets/9a733aad-73b7-4cad-ab6b-3fd418ccad1e" />
