### PR TITLE
Improve the docs for mysql.

### DIFF
--- a/en/identity-server/6.0.0/docs/deploy/change-to-mysql.md
+++ b/en/identity-server/6.0.0/docs/deploy/change-to-mysql.md
@@ -4,6 +4,13 @@ By default, WSO2 Identity Server uses the embedded H2 database as the database
 for storing user management and registry data. Given below are the steps
 you need to follow in order to use MySQL for this purpose. 
 
+!!! note
+    If you are using MySQL version 8.0 or later, make sure that you 
+    create the database with charset latin1 as shown in the example below:
+
+    ```
+    create database <db_name> character set latin1;
+    ```
 ---
 
 ## Datasource configurations

--- a/en/identity-server/6.1.0/docs/deploy/change-to-mysql.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-mysql.md
@@ -4,6 +4,14 @@ By default, WSO2 Identity Server uses the embedded H2 database as the database
 for storing user management and registry data. Given below are the steps
 you need to follow in order to use MySQL for this purpose. 
 
+!!! note
+    If you are using MySQL version 8.0 or later, make sure that you 
+    create the database with charset latin1 as shown in the example below:
+
+    ```
+    create database <db_name> character set latin1;
+    ```
+
 ---
 
 ## Datasource configurations


### PR DESCRIPTION
### Purpose
- Add character set configuration for the mysql database to solve the db script executing issue.
- This has been previously mentioned in the [5.11 docs](https://is.docs.wso2.com/en/5.11.0/setup/changing-to-mysql/#datasource-configurations)

### Related issues
- https://github.com/wso2/product-is/issues/20885

### Preview
<img width="1512" alt="Screenshot 2025-03-04 at 13 24 04" src="https://github.com/user-attachments/assets/28631d8a-892d-42a5-b0e0-15cd42fd258d" />
