### PR TITLE
[7.0.0] Update TOTP docs to remove basic authentication

### DIFF
--- a/en/identity-server/7.0.0/docs/apis/restapis/totp.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/totp.yaml
@@ -8,7 +8,6 @@ servers:
   - url: https://localhost:9443/t/{tenant-domain}/api/users/v1
 security:
   - OAuth2: []
-  - BasicAuth: []
 tags:
   - name: me
     description: Operations for the authenticated user.
@@ -48,7 +47,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer-token}'
     post:
       tags:
         - me
@@ -109,7 +108,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer-token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "action": "INIT, REFRESH, VALIDATE",
@@ -146,7 +145,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer-token}'
   /me/totp/secret:
     get:
       tags:
@@ -181,7 +180,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/api/users/v1/me/totp/secret' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='                 
+            -H 'Authorization: Bearer {bearer-token}'             
 components:
   schemas:
     Error:
@@ -232,9 +231,6 @@ components:
           type: string
           description: Refreshed TOTP secret key of the authenticated user
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/restapis/totp.yaml
+++ b/en/identity-server/7.1.0/docs/apis/restapis/totp.yaml
@@ -8,7 +8,6 @@ servers:
   - url: https://localhost:9443/t/{tenant-domain}/api/users/v1
 security:
   - OAuth2: []
-  - BasicAuth: []
 tags:
   - name: me
     description: Operations for the authenticated user.
@@ -48,7 +47,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer-token}'
     post:
       tags:
         - me
@@ -109,7 +108,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer-token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "action": "INIT, REFRESH, VALIDATE",
@@ -146,7 +145,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer-token}'
   /me/totp/secret:
     get:
       tags:
@@ -181,7 +180,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/api/users/v1/me/totp/secret' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='                 
+            -H 'Authorization: Bearer {bearer-token}'             
 components:
   schemas:
     Error:
@@ -232,9 +231,6 @@ components:
           type: string
           description: Refreshed TOTP secret key of the authenticated user
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/restapis/totp.yaml
+++ b/en/identity-server/next/docs/apis/restapis/totp.yaml
@@ -8,7 +8,6 @@ servers:
   - url: https://localhost:9443/t/{tenant-domain}/api/users/v1
 security:
   - OAuth2: []
-  - BasicAuth: []
 tags:
   - name: me
     description: Operations for the authenticated user.
@@ -48,7 +47,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer-token}'
     post:
       tags:
         - me
@@ -109,7 +108,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer-token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "action": "INIT, REFRESH, VALIDATE",
@@ -146,7 +145,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/api/users/v1/me/totp' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer-token}'
   /me/totp/secret:
     get:
       tags:
@@ -181,7 +180,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/api/users/v1/me/totp/secret' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='                 
+            -H 'Authorization: Bearer {bearer-token}'             
 components:
   schemas:
     Error:
@@ -232,9 +231,6 @@ components:
           type: string
           description: Refreshed TOTP secret key of the authenticated user
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:


### PR DESCRIPTION
## Purpose
The TOTP API documentation currently includes outdated authentication mechanisms, specifically the use of Basic Authentication, which is not allowed. This update enhances security by replacing Basic Authentication with OAuth2 and updating the authorization headers in example requests.

## Implementation
This pull request involves updates to the TOTP API documentation across multiple versions of the identity server. The main changes include the removal of BasicAuth and the transition to OAuth2 for security, along with updates to the authorization headers in the example curl commands.

Security updates:

- Removed BasicAuth and updated to use OAuth2 in the servers section for versions 7.0.0, 7.1.0, and next.
- Removed BasicAuth from the components section, retaining OAuth2 for the same versions.
- Updated authorization headers in example curl commands from `Basic` to `Bearer` token in the paths section for versions 7.0.0, 7.1.0, and next.

## Related Issue
- https://github.com/wso2/product-is/issues/23302