### PR TITLE
Update organization definitions send in the request.

### DIFF
--- a/en/asgardeo/docs/references/service-extensions/in-flow-extensions/custom-authentication/api/custom-authentication-action-v1.yaml
+++ b/en/asgardeo/docs/references/service-extensions/in-flow-extensions/custom-authentication/api/custom-authentication-action-v1.yaml
@@ -244,7 +244,7 @@ components:
           type: string
           description: Defines the name of the organization.
           example: sub1.bar.com
-      description: Metadata of the organization the user belongs to. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
+      description: Metadata of the organization the user is trying to log into. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
       
     UserStoreInEvent:
       type: object

--- a/en/asgardeo/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
+++ b/en/asgardeo/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
@@ -79,8 +79,6 @@ components:
           $ref: '#/components/schemas/Tenant'
         user:
           $ref: '#/components/schemas/User'
-        organization:
-          $ref: '#/components/schemas/Organization'
         userStore:
           $ref: '#/components/schemas/UserStore'
         accessToken:
@@ -149,21 +147,6 @@ components:
           description: Defines the unique identifier of the user.
           example: e204849c-4ec2-41f1-8ff7-ec1ebff02821
       description: Contains information about the authenticated user associated with the token request.
-    Organization:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the organization.
-          example: 5c7930f2-c97d-4b38-89a6-7be5fb138a35
-        name:
-          type: string
-          description: Name of the organization used to identify the organization in configurations, user interfaces, etc.
-          example: foo.com
-      description: Refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
     UserStore:
       type: object
       required:

--- a/en/asgardeo/docs/references/service-extensions/pre-flow-extensions/pre-update-password-action/api/pre_update_password_action-v1.yaml
+++ b/en/asgardeo/docs/references/service-extensions/pre-flow-extensions/pre-update-password-action/api/pre_update_password_action-v1.yaml
@@ -89,8 +89,6 @@ components:
           $ref: '#/components/schemas/Tenant'
         user:
           $ref: '#/components/schemas/User'
-        organization:
-          $ref: '#/components/schemas/Organization'
         userStore:
           $ref: '#/components/schemas/UserStore'
       description: Defines the context data related to the pre issue access token event that needs to be shared with the custom service to process and execute.
@@ -177,21 +175,6 @@ components:
     
         This ensures secure transmission of the credential while allowing validation upon decryption.
       example: eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFsQ.48V1_ALb6US04U3b.5eym8X3LNvUubV4Y0kH.XFBoMYUZodetZdvTiFvSkQ
-    Organization:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the organization.
-          example: 5c7930f2-c97d-4b38-89a6-7be5fb138a35
-        name:
-          type: string
-          description: "Name of the organization used to identify the organization in configurations, user interfaces, etc."
-          example: foo.com
-      description: Refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
     UserStore:
       type: object
       required:

--- a/en/identity-server/7.1.0/docs/references/service-extensions/in-flow-extensions/custom-authentication/api/custom-authentication-action-v1.yaml
+++ b/en/identity-server/7.1.0/docs/references/service-extensions/in-flow-extensions/custom-authentication/api/custom-authentication-action-v1.yaml
@@ -250,7 +250,7 @@ components:
           type: string
           description: Defines the name of the organization.
           example: sub1.bar.com
-      description: Metadata of the organization the user belongs to. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
+      description: Metadata of the organization the user is trying to log into. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
       
     UserStoreInEvent:
       type: object

--- a/en/identity-server/7.1.0/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
+++ b/en/identity-server/7.1.0/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
@@ -85,8 +85,6 @@ components:
           $ref: '#/components/schemas/Tenant'
         user:
           $ref: '#/components/schemas/User'
-        organization:
-          $ref: '#/components/schemas/Organization'
         userStore:
           $ref: '#/components/schemas/UserStore'
         accessToken:
@@ -155,21 +153,6 @@ components:
           description: Defines the unique identifier of the user.
           example: e204849c-4ec2-41f1-8ff7-ec1ebff02821
       description: Contains information about the authenticated user associated with the token request.
-    Organization:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the organization.
-          example: 5c7930f2-c97d-4b38-89a6-7be5fb138a35
-        name:
-          type: string
-          description: Name of the organization used to identify the organization in configurations, user interfaces, etc.
-          example: foo.com
-      description: Refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
     UserStore:
       type: object
       required:

--- a/en/identity-server/7.1.0/docs/references/service-extensions/pre-flow-extensions/pre-update-password-action/api/pre_update_password_action-v1.yaml
+++ b/en/identity-server/7.1.0/docs/references/service-extensions/pre-flow-extensions/pre-update-password-action/api/pre_update_password_action-v1.yaml
@@ -95,8 +95,6 @@ components:
           $ref: '#/components/schemas/Tenant'
         user:
           $ref: '#/components/schemas/User'
-        organization:
-          $ref: '#/components/schemas/Organization'
         userStore:
           $ref: '#/components/schemas/UserStore'
       description: Defines the context data related to the pre issue access token event that needs to be shared with the custom service to process and execute.
@@ -183,21 +181,6 @@ components:
     
         This ensures secure transmission of the credential while allowing validation upon decryption.
       example: eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFsQ.48V1_ALb6US04U3b.5eym8X3LNvUubV4Y0kH.XFBoMYUZodetZdvTiFvSkQ
-    Organization:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the organization.
-          example: 5c7930f2-c97d-4b38-89a6-7be5fb138a35
-        name:
-          type: string
-          description: "Name of the organization used to identify the organization in configurations, user interfaces, etc."
-          example: foo.com
-      description: Refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
     UserStore:
       type: object
       required:

--- a/en/identity-server/next/docs/references/service-extensions/in-flow-extensions/custom-authentication/api/custom-authentication-action-v1.yaml
+++ b/en/identity-server/next/docs/references/service-extensions/in-flow-extensions/custom-authentication/api/custom-authentication-action-v1.yaml
@@ -250,7 +250,7 @@ components:
           type: string
           description: Defines the name of the organization.
           example: sub1.bar.com
-      description: Metadata of the organization the user belongs to. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
+      description: Metadata of the organization the user is trying to log into. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
       
     UserStoreInEvent:
       type: object

--- a/en/identity-server/next/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
+++ b/en/identity-server/next/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
@@ -85,8 +85,6 @@ components:
           $ref: '#/components/schemas/Tenant'
         user:
           $ref: '#/components/schemas/User'
-        organization:
-          $ref: '#/components/schemas/Organization'
         userStore:
           $ref: '#/components/schemas/UserStore'
         accessToken:
@@ -155,21 +153,6 @@ components:
           description: Defines the unique identifier of the user.
           example: e204849c-4ec2-41f1-8ff7-ec1ebff02821
       description: Contains information about the authenticated user associated with the token request.
-    Organization:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the organization.
-          example: 5c7930f2-c97d-4b38-89a6-7be5fb138a35
-        name:
-          type: string
-          description: Name of the organization used to identify the organization in configurations, user interfaces, etc.
-          example: foo.com
-      description: Refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
     UserStore:
       type: object
       required:

--- a/en/identity-server/next/docs/references/service-extensions/pre-flow-extensions/pre-update-password-action/api/pre_update_password_action-v1.yaml
+++ b/en/identity-server/next/docs/references/service-extensions/pre-flow-extensions/pre-update-password-action/api/pre_update_password_action-v1.yaml
@@ -95,8 +95,6 @@ components:
           $ref: '#/components/schemas/Tenant'
         user:
           $ref: '#/components/schemas/User'
-        organization:
-          $ref: '#/components/schemas/Organization'
         userStore:
           $ref: '#/components/schemas/UserStore'
       description: Defines the context data related to the pre issue access token event that needs to be shared with the custom service to process and execute.
@@ -183,21 +181,6 @@ components:
     
         This ensures secure transmission of the credential while allowing validation upon decryption.
       example: eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFsQ.48V1_ALb6US04U3b.5eym8X3LNvUubV4Y0kH.XFBoMYUZodetZdvTiFvSkQ
-    Organization:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: The unique identifier of the organization.
-          example: 5c7930f2-c97d-4b38-89a6-7be5fb138a35
-        name:
-          type: string
-          description: "Name of the organization used to identify the organization in configurations, user interfaces, etc."
-          example: foo.com
-      description: Refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.
     UserStore:
       type: object
       required:

--- a/en/includes/guides/service-extensions/in-flow-extensions/custom-authentication.md
+++ b/en/includes/guides/service-extensions/in-flow-extensions/custom-authentication.md
@@ -264,7 +264,7 @@ E.g.,
 </tr>
 <tr class="even">
 <td>event.organization</td>
-<td><p>This property refers to the organization to which the authenticating user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.</p>
+<td><p>This property refers to the organization to which the authenticating user is trying to log into. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.</p>
 </td>
 </tr>
 <tr class="odd">

--- a/en/includes/guides/service-extensions/pre-flow-extensions/pre-issue-access-token-action.md
+++ b/en/includes/guides/service-extensions/pre-flow-extensions/pre-issue-access-token-action.md
@@ -109,11 +109,6 @@ All request parameters are not incorporated, specially sensitive parameters like
 </td>
 </tr>
 <tr class="odd">
-<td>event.organization</td>
-<td><p>This property refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.</p>
-</td>
-</tr>
-<tr class="even">
 <td>event.accessToken</td>
 <td><p>This property represents the access token that is about to be issued. It contains claims and scopes, of the access token which can then be modified by your external service based on the logic implemented in the pre-issue access token action.
 .</p>

--- a/en/includes/guides/service-extensions/pre-flow-extensions/pre-update-password-action.md
+++ b/en/includes/guides/service-extensions/pre-flow-extensions/pre-update-password-action.md
@@ -96,16 +96,11 @@ The request from {{product_name}} includes following in the JSON request payload
 </td>
 </tr>
 <tr class="odd">
-<td>event.organization</td>
-<td><p>This property refers to the organization to which the user belongs. Organizations represent partners/enterprise customers in Business-to-Business (B2B) use cases.</p>
-</td>
-</tr>
-<tr class="even">
 <td>event.initiatorType</td>
 <td><p>This property indicates whether the password update was initiated by an administrator, a user, or an application. Refer <a href="#initatorType-and-action">initiatorType and action properties in request</a> section for details.</p>
 </td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>event.action</td>
 <td><p>This property indicates whether the password update was initiated over a password reset flow, update flow, or an invite flow. Refer <a href="#initatorType-and-action">initiatorType and action properties in request</a> section for details.</p>
 </td>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23400

Upon reevaluating the intent of the organization sent in the request to the external service within the sub-organization context, the organization's purpose has been repurposed. It now represents the organization in which the corresponding flow is processing when the action is triggered.

With the above changes, the documentation must be updated as follows:
- Remove the organization from the request event for pre-issue access tokens and pre-password access tokens.
- Update the description of the organization in the custom authentication extension to reflect its revised purpose.