### PR TITLE
Increase font size in docs navbar to 14px

### DIFF
--- a/en/theme/material/assets/css/theme.css
+++ b/en/theme/material/assets/css/theme.css
@@ -390,6 +390,7 @@
 
 .md-nav__item {
     margin-top: .8em;
+    font-size: 14px;
 }
 
 .md-nav {


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

$subject as 12px is barely readable.

Before:

<img width="566" alt="Screenshot 2025-03-22 at 18 38 01" src="https://github.com/user-attachments/assets/7f486e0d-4827-4e1d-a8c1-c3ab389bef67" />

After:

<img width="566" alt="Screenshot 2025-03-22 at 18 37 10" src="https://github.com/user-attachments/assets/cafe6eac-9484-473b-9911-5ff18005b007" />

