### PR TITLE
Fix incorrect config in Self-Registration Account Confirmation docs

### DIFF
--- a/en/identity-server/7.0.0/docs/guides/user-self-service/account-confirmation-for-self-register.md
+++ b/en/identity-server/7.0.0/docs/guides/user-self-service/account-confirmation-for-self-register.md
@@ -40,7 +40,7 @@ The section of the guide walks you through configuring account confirmation meth
 2. Add the following configurations to the `deployment.toml` file:
 
     ``` toml
-    [identity_mgt.user_self_registration]
+    [identity_mgt.notification]
     default_notification_channel = "<value>"
     resolve_notification_channel = true
     ```

--- a/en/identity-server/7.1.0/docs/guides/user-self-service/account-confirmation-for-self-register.md
+++ b/en/identity-server/7.1.0/docs/guides/user-self-service/account-confirmation-for-self-register.md
@@ -40,7 +40,7 @@ The section of the guide walks you through configuring account confirmation meth
 2. Add the following configurations to the `deployment.toml` file:
 
     ``` toml
-    [identity_mgt.user_self_registration]
+    [identity_mgt.notification]
     default_notification_channel = "<value>"
     resolve_notification_channel = true
     ```

--- a/en/identity-server/next/docs/guides/user-self-service/account-confirmation-for-self-register.md
+++ b/en/identity-server/next/docs/guides/user-self-service/account-confirmation-for-self-register.md
@@ -40,7 +40,7 @@ The section of the guide walks you through configuring account confirmation meth
 2. Add the following configurations to the `deployment.toml` file:
 
     ``` toml
-    [identity_mgt.user_self_registration]
+    [identity_mgt.notification]
     default_notification_channel = "<value>"
     resolve_notification_channel = true
     ```


### PR DESCRIPTION
## Description
The Account Confirmation methods for Self-Registration docs mention an incorrect config. The previously mentioned config doesn’t exist. This PR updates it to the correct one.

https://is.docs.wso2.com/en/7.0.0/guides/user-self-service/account-confirmation-for-self-register/#configure-account-confirmation-methods-on-wso2-identity-server

### Incorrect Config
```
[identity_mgt.user_self_registration]
default_notification_channel = "<value>"
resolve_notification_channel = true
```

### Correct Config
```
[identity_mgt.notification]
default_notification_channel = "<value>"
resolve_notification_channel = true
```

## Related Issues
- https://github.com/wso2/product-is/issues/23527