### PR TITLE
Update validationQuery documentation with correct values per database

### DIFF
--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -78,7 +78,35 @@ A sample configuration is given below.
 
 ### Advanced database configurations
 
-{% include "../../../../includes/db-advanced-config.md" %}
+Apart from the basic configurations specified above, WSO2 Identity Server supports some advanced database configurations as well.
+
+-	`WSO2_IDENTITY_DB` related configurations that should be added to the `deployment.toml` file.
+
+	``` toml
+	[database.identity_db.pool_options]
+	maxActive = "80"
+	maxWait = "360000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
+
+-	`WSO2_SHARED_DB` `deployment.toml` related configurations that should be added to the `deployment.toml` file.
+
+	```toml
+	[database.shared_db.pool_options]
+	maxActive = "80"
+	maxWait = "360000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
 
 {% include "../../../../includes/db-config-table.md" %}
 

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle-rac.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle-rac.md
@@ -91,6 +91,34 @@ A sample configuration is given below.
 
 ### Advanced database configurations
 
-{% include "../../../../includes/db-advanced-config.md" %}
+Apart from the basic configurations specified above, WSO2 Identity Server supports some advanced database configurations as well.
+
+-	`WSO2_IDENTITY_DB` related configurations that should be added to the `deployment.toml` file.
+
+	``` toml
+	[database.identity_db.pool_options]
+	maxActive = "80"
+	maxWait = "360000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery="select 1 from dual"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
+
+-	`WSO2_SHARED_DB` `deployment.toml` related configurations that should be added to the `deployment.toml` file.
+
+	```toml
+	[database.shared_db.pool_options]
+	maxActive = "80"
+	maxWait = "360000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery="select 1 from dual"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
 
 {% include "../../../../includes/db-config-table.md" %}

--- a/en/identity-server/next/docs/includes/db-advanced-config.md
+++ b/en/identity-server/next/docs/includes/db-advanced-config.md
@@ -8,7 +8,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	maxWait = "360000"
 	minIdle ="5"
 	testOnBorrow = true
-	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
+	validationQuery = "SELECT 1"
 	validationInterval="30000"
 	defaultAutoCommit=false
 	commitOnReturn=true
@@ -22,7 +22,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	maxWait = "360000"
 	minIdle ="5"
 	testOnBorrow = true
-	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
+	validationQuery = "SELECT 1"
 	validationInterval="30000"
 	defaultAutoCommit=false
 	commitOnReturn=true


### PR DESCRIPTION
## Purpose
Ensures the documentation includes accurate `validationQuery` values for each supported database, preventing potential misconfigurations during setup.

## Goals
- Provide correct validation queries aligned with each database's syntax.
- Improve clarity and accuracy of database configuration documentation.

## Approach
- `SELECT 1` is used for `MySQL`, `PostgreSQL`, `MSSQL`, and `H2`, as it is valid across these databases.
- `SELECT 1 FROM dual` is specified for `Oracle` and  `Oracle-Rac`.
- `SELECT 1 FROM sysibm.sysdummy1` is specified for `DB2`

These changes were applied across the following documentation versions:
- wso2-is-7.1.0
- wso2-is-7.0.0
- wso2-is-6.1.0
- wso2-is-6.0.0
- wso2-is-5.11.0
- wso2-is-5.10.0
- wso2-is-5.9.0

## Relates Issues

product-is: [Incorrect validationQuery values documented for multiple databases #23551](https://github.com/wso2/product-is/issues/23551)