### PR TITLE
Fix typo in TOML config for X509Certificate Authenticator documentation in IS 5.11.0

### DIFF
--- a/en/identity-server/5.11.0/docs/learn/x509certificate-authenticator.md
+++ b/en/identity-server/5.11.0/docs/learn/x509certificate-authenticator.md
@@ -151,7 +151,7 @@ Once you have done the above steps, you have the keystore (`localcrt.jks`), trus
     `<IS_HOME>/repository/conf/deployment.toml` file.
 
     ``` toml 
-    [custom_trasport.x509.properties]
+    [custom_transport.x509.properties]
     protocols="HTTP/1.1"
     port="8443"
     maxThreads="200"


### PR DESCRIPTION
## Purpose
The X509Certificate Authenticator documentation for IS 5.11.0 contains a typo in the TOML configuration. The section header is written as `[custom_trasport.x509.properties]`, missing the `'n'` in transport.

## Goals
- Correct the typo in the TOML configuration to ensure users configuring the authenticator in IS 5.11.0 have accurate information.

## Approach
Updated the TOML block in the documentation to correctly state:
```
[custom_transport.x509.properties]
```
This ensures the config block is accurate and aligns with the expected configuration format in IS 5.11.0.

## Related Issues
product-is: [Configuring X509Certificate Authenticator doc has a typo in the toml configs #20591](https://github.com/wso2/product-is/issues/20591)