### PR TITLE
Move X509 CN Value Note to Correct Section in Documentation.

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/x509certificate-authenticator.md
+++ b/en/identity-server/5.10.0/docs/learn/x509certificate-authenticator.md
@@ -79,6 +79,9 @@ To create a sample certificate and create your own Certificate Authority to sign
         !!! tip
             You are prompted for details after executing the above command. For "What is your first and last name?" you need to give a name without space(e.g., wso2). 
 
+        !!! note
+            Note that the **CN** value has to be the same as the **user name** of the user that will try to log in in the future.
+
         This command will create a keystore with the following details: 
             - **Keystore name:** localcrt.jks
             - **Alias of public certificate:** localcrt

--- a/en/identity-server/5.11.0/docs/learn/x509certificate-authenticator.md
+++ b/en/identity-server/5.11.0/docs/learn/x509certificate-authenticator.md
@@ -40,9 +40,7 @@ To create a sample certificate and create your own Certificate Authority to sign
     - Locality Name (eg, city) [ ]: Colombo
     - Organization Name (eg, company) [Internet Widgits Pty Ltd]: WSO2
     - Organizational Unit Name (eg, section) [ ]: QA
-    - Common Name (e.g. serverFQDN or YOUR name) [ ]: wso2is.com 
-        !!! note
-            Note that the **CN** value has to be the same as the **user name** of the user that will try to log in in the future.
+    - Common Name (e.g. serverFQDN or YOUR name) [ ]: wso2is.com
     - Email Address [ ]: kim@wso2.com
 
 4.  An OpenSSL CA requires new files and supporting directories. Therefore, create a new directory.
@@ -79,8 +77,11 @@ To create a sample certificate and create your own Certificate Authority to sign
         ```
 
         !!! tip
-            You are prompted for details after executing the above command. For "What is your first and last name?" you need to give a name without space(e.g., wso2). 
-
+            You are prompted for details after executing the above command. For "What is your first and last name?" you need to give a name without space(e.g., wso2).
+        
+        !!! note
+            Note that the **CN** value has to be the same as the **user name** of the user that will try to log in in the future.
+   
         This command will create a keystore with the following details: 
             - **Keystore name:** localcrt.jks
             - **Alias of public certificate:** localcrt

--- a/en/identity-server/6.0.0/docs/guides/mfa/x509.md
+++ b/en/identity-server/6.0.0/docs/guides/mfa/x509.md
@@ -72,6 +72,9 @@ To create a sample certificate and create your own Certificate Authority to sign
         !!! tip
             You are prompted for details after executing the above command. For "What is your first and last name?" you need to give a name without space(e.g., wso2). 
 
+        !!! note
+            Note that the **CN** value has to be the same as the **user name** of the user that will try to log in in the future.
+
         This command will create a keystore with the following details: 
             - **Keystore name:** localcrt.jks
             - **Alias of public certificate:** localcrt

--- a/en/identity-server/6.1.0/docs/guides/mfa/x509.md
+++ b/en/identity-server/6.1.0/docs/guides/mfa/x509.md
@@ -72,6 +72,9 @@ To create a sample certificate and create your own Certificate Authority to sign
         !!! tip
             You are prompted for details after executing the above command. For "What is your first and last name?" you need to give a name without space(e.g., wso2). 
 
+        !!! note
+            Note that the **CN** value has to be the same as the **user name** of the user that will try to log in in the future.
+
         This command will create a keystore with the following details: 
             - **Keystore name:** localcrt.jks
             - **Alias of public certificate:** localcrt

--- a/en/includes/guides/authentication/mfa/add-x509-login.md
+++ b/en/includes/guides/authentication/mfa/add-x509-login.md
@@ -76,6 +76,9 @@ and create your own Certificate Authority to sign the certificates, follow the g
             You are prompted for details after executing the above command. For "What is your first and last name?" 
             you need to give a name without space(e.g., wso2). 
 
+        !!! note
+            Note that the **CN** value has to be the same as the **user name** of the user that will try to log in in the future.
+
         This command will create a keystore with the following details: 
 
         ``` text


### PR DESCRIPTION
## Purpose
To update the X509 Certificate Authenticator documentation by relocating the note regarding the `CN` (Common Name) value to the appropriate section, ensuring clarity and proper guidance for users setting up the certificate.

## Goals
- Fix the incorrect placement of the note explaining that the CN should match the username.
- Align the documentation with the expected behavior of the X509 Authenticator component.

## Approach
- Removed the Note block from the example section where certificate details are entered.
- Added the Note block under the correct section: **Create the server certificate**.
- Ensured the note appears right after the tip block and before the details of the created keystore, improving visibility and relevance.

## Related Issues

product-is issue: [CN Value Note for X509 Certificate Authenticator is Placed in the Wrong Section #23553](https://github.com/wso2/product-is/issues/23553)