### PR TITLE
Fix Incorrect References to Asgardeo in IS Documentation

### DIFF
--- a/en/includes/guides/fragments/manage-connection/add-groups.md
+++ b/en/includes/guides/fragments/manage-connection/add-groups.md
@@ -22,7 +22,7 @@ Follow the steps below to map attributes of {{product_name}} with that of a conn
 
     ![Submit attribute mappings]({{base_path}}/assets/img/guides/idp/group-mapping/submit-attribute-mappings.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
-### Add groups to connection
+### Add groups to connections
 
 Follow the steps below to add the groups from your connection to {{ product_name }}:
 

--- a/en/includes/guides/fragments/manage-connection/add-groups.md
+++ b/en/includes/guides/fragments/manage-connection/add-groups.md
@@ -10,7 +10,7 @@ Follow the steps below to map attributes of {{product_name}} with that of a conn
 
     ![Add attribute mappings]({{base_path}}/assets/img/guides/idp/group-mapping/add-attribute-mappings.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
-4. Enter the  **External IdP Attribute** of the connection and map it to the **Groups** attribute of Asgardeo.
+4. Enter the  **External IdP Attribute** of the connection and map it to the **Groups** attribute of {{ product_name }}.
 
     ![Add new group attribute mapping]({{base_path}}/assets/img/guides/idp/group-mapping/add-new-group-attribute-mapping.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
@@ -22,11 +22,11 @@ Follow the steps below to map attributes of {{product_name}} with that of a conn
 
     ![Submit attribute mappings]({{base_path}}/assets/img/guides/idp/group-mapping/submit-attribute-mappings.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
-### Add groups to connections
+### Add groups to connection
 
-Follow the steps below to add the groups from your connection to Asgardeo:
+Follow the steps below to add the groups from your connection to {{ product_name }}:
 
-1. On the Asgardeo Console, go to **Connections**.
+1. On the {{ product_name }} Console, go to **Connections**.
 2. Select your connection and go to its **Groups** tab.
 3. Click **New Group** and enter the group name. Be sure to enter the exact group name that will be returned from the connection.
 


### PR DESCRIPTION
## Purpose
To address incorrect branding in the authentication guide where **Asgardeo** was referenced instead of using a generic placeholder.

## Goals
- Remove hardcoded mentions of **Asgardeo**.
- Use the `{{ product_name }}` placeholder for dynamic product rendering.
- Ensure consistency and maintainability across documentation.

## Approach
Existing hardcoded references to "Asgardeo" were replaced with the `{{ product_name }}` placeholder.

## Related Issues
product-is issue: [Incorrect References to Asgardeo in IS Documentation #23561](https://github.com/wso2/product-is/issues/23561)