### PR TITLE
Add guide to recover a locked super admin user account

### DIFF
--- a/en/identity-server/7.0.0/docs/guides/your-is/recover-super-admin-account.md
+++ b/en/identity-server/7.0.0/docs/guides/your-is/recover-super-admin-account.md
@@ -1,0 +1,2 @@
+{% set product_name = "WSO2 Identity Server" %}
+{% include "../../../../../includes/guides/admin-portal/recover-super-admin-account.md" %}

--- a/en/identity-server/7.0.0/mkdocs.yml
+++ b/en/identity-server/7.0.0/mkdocs.yml
@@ -680,6 +680,7 @@ nav:
         - Manage Console access: guides/your-is/manage-console-access.md
         - Self-service: guides/your-is/is-self-service.md
         - Recover your password: guides/your-is/recover-password.md
+        - Recover super admin account: guides/your-is/recover-super-admin-account.md
       - Multitenancy:
         - Multitenancy: guides/multitenancy/index.md
         - Manage tenants: guides/multitenancy/manage-tenants.md

--- a/en/identity-server/7.1.0/docs/guides/your-is/recover-super-admin-account.md
+++ b/en/identity-server/7.1.0/docs/guides/your-is/recover-super-admin-account.md
@@ -1,0 +1,2 @@
+{% set product_name = "WSO2 Identity Server" %}
+{% include "../../../../../includes/guides/admin-portal/recover-super-admin-account.md" %}

--- a/en/identity-server/7.1.0/mkdocs.yml
+++ b/en/identity-server/7.1.0/mkdocs.yml
@@ -723,6 +723,7 @@ nav:
         - Self-service: guides/your-is/is-self-service.md
         - Recover your password: guides/your-is/recover-password.md
         - Recover your username: guides/your-is/recover-username.md
+        - Recover super admin account: guides/your-is/recover-super-admin-account.md
       - Multitenancy:
         - Multitenancy: guides/multitenancy/index.md
         - Manage Root Organizations (Tenants): guides/multitenancy/manage-tenants.md

--- a/en/identity-server/next/docs/guides/your-is/recover-super-admin-account.md
+++ b/en/identity-server/next/docs/guides/your-is/recover-super-admin-account.md
@@ -1,0 +1,2 @@
+{% set product_name = "WSO2 Identity Server" %}
+{% include "../../../../../includes/guides/admin-portal/recover-super-admin-account.md" %}

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -723,6 +723,7 @@ nav:
         - Self-service: guides/your-is/is-self-service.md
         - Recover your password: guides/your-is/recover-password.md
         - Recover your username: guides/your-is/recover-username.md
+        - Recover super admin account: guides/your-is/recover-super-admin-account.md
       - Multitenancy:
         - Multitenancy: guides/multitenancy/index.md
         - Manage Root Organizations (Tenants): guides/multitenancy/manage-tenants.md

--- a/en/includes/guides/admin-portal/recover-super-admin-account.md
+++ b/en/includes/guides/admin-portal/recover-super-admin-account.md
@@ -1,0 +1,61 @@
+# Recover a Locked Super Admin User Account
+
+If the super admin account in {{ product_name }} becomes locked (for example, due to exceeding the maximum number of failed login attempts), follow the instructions below to recover access.
+
+## Recovering the Super Admin User
+
+When the super admin account is locked, you can recover access by temporarily switching to a new super admin account and using it to unlock or manage the original user.
+
+### Step 1
+Open the `deployment.toml` file located in the `<IS_HOME>/repository/conf directory` and update the [super_admin] 
+section with a new username and password:
+
+```toml
+[super_admin]
+username = "temporary-admin"
+password = "Temp@1234"
+create_admin_account = true
+```
+
+> 💡 The above configuration will create a new super admin user named `temporary-admin` on server startup.
+
+### Step 2
+Restart {{ product_name }} to apply the configuration changes and create the new admin account.
+
+```bash
+sh wso2server.sh
+```
+
+Once the server is up, log in to the Management Console using the new super admin credentials.
+
+
+### Step 3
+Use the new super admin account to:
+
+- Unlock the original super admin account.
+- Reset the password if necessary.
+- Assign the **Internal/system** role to prevent future lockouts (optional).
+
+> 🔒 Users assigned the `Internal/system` role are not subject to account locking policies.
+
+### Step 4
+Once the original account is recovered:
+
+1. Revert the changes in `deployment.toml`:
+   ```toml
+   [super_admin]
+   username = "admin"
+   password = "Admin@123"
+   create_admin_account = false
+   ```
+2. Restart the server again to remove the temporary super admin configuration.
+
+---
+
+## ⚠️ Important Notes
+
+- **Do not attempt direct DB updates** in a production environment to unlock a user unless instructed by WSO2 support.
+- The temporary super admin account is created only when `create_admin_account = true`. After recovery, it is recommended to disable this by setting the value to `false`.
+- Ensure that at least one super admin account is always accessible to avoid such situations.
+
+---


### PR DESCRIPTION
## Purpose
To provide clear and accessible instructions for users on how to recover a super admin account in WSO2 Identity Server if it gets locked due to account locking policies.

## Goals
- Minimize confusion and delays during critical incidents involving super admin account lockouts.
- Improve the self-service capability for customers and internal teams.
- Ensure consistent and centralized documentation for this recovery scenario.

## Approach
- Introduced a new page under `guides/your-is` titled `recover-super-admin-account`.
- Added the new page to the side navigation panel under **Guides -> Your WSO2 Identity Server**, alongside related pages like _Manage Console access_ and _Recover your password_.
- The guide outlines a safe and supported method to recover access by creating a temporary super admin user via the `deployment.toml` file.