### PR TITLE
Clarify HTTP usage and NGINX configuration path in documentation

### DIFF
--- a/en/identity-server/5.10.0/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/identity-server/5.10.0/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -32,6 +32,11 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java tab="HTTP configuration"
@@ -133,12 +138,22 @@ collectively as "Nginx".)
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3.  Now that you've configured HTTP requests, you must also configure
     HTTPS requests. Configure Nginx to direct the HTTPS requests to the
     two worker nodes via the HTTPS 443 port using ` https://is.wso2.com/
      ` . To do this, create a VHost file ( ` is.https.conf ` ) in the `
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
     

--- a/en/identity-server/5.10.0/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/identity-server/5.10.0/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -32,7 +32,7 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -150,12 +150,10 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
-
-    !!! note
     
         The configurations for nginx community version and NGINX
         Plus are different here since the community version does not support

--- a/en/identity-server/5.11.0/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/identity-server/5.11.0/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -32,6 +32,11 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java tab="HTTP configuration"
@@ -133,12 +138,22 @@ collectively as "Nginx".)
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3.  Now that you've configured HTTP requests, you must also configure
     HTTPS requests. Configure Nginx to direct the HTTPS requests to the
     two worker nodes via the HTTPS 443 port using ` https://is.wso2.com/
      ` . To do this, create a VHost file ( ` is.https.conf ` ) in the `
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
     

--- a/en/identity-server/5.11.0/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/identity-server/5.11.0/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -32,7 +32,7 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -150,12 +150,10 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
-
-    !!! note
     
         The configurations for nginx community version and NGINX
         Plus are different here since the community version does not support

--- a/en/identity-server/5.9.0/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/identity-server/5.9.0/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -32,6 +32,11 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java tab="HTTP configuration"
@@ -133,12 +138,22 @@ collectively as "Nginx".)
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3.  Now that you've configured HTTP requests, you must also configure
     HTTPS requests. Configure Nginx to direct the HTTPS requests to the
     two worker nodes via the HTTPS 443 port using ` https://is.wso2.com/
      ` . To do this, create a VHost file ( ` is.https.conf ` ) in the `
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
     

--- a/en/identity-server/5.9.0/docs/setup/fronting-with-the-nginx-load-balancer.md
+++ b/en/identity-server/5.9.0/docs/setup/fronting-with-the-nginx-load-balancer.md
@@ -32,7 +32,7 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -150,12 +150,10 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
-
-    !!! note
     
         The configurations for nginx community version and NGINX
         Plus are different here since the community version does not support

--- a/en/identity-server/6.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/6.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -34,6 +34,11 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java tab="HTTP configuration"
@@ -135,11 +140,21 @@ collectively as "Nginx".)
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3.  Now that you've configured HTTP requests, you must also configure
     HTTPS requests. Configure Nginx to direct the HTTPS requests to the
     two worker nodes via the HTTPS 443 port using ` https://is.wso2.com/` . To do this, create a VHost file ( ` is.https.conf ` ) in the `
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
     

--- a/en/identity-server/6.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/6.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -34,7 +34,7 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -151,12 +151,10 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
-
-    !!! note
     
         The configurations for nginx community version and NGINX
         Plus are different here since the community version does not support

--- a/en/identity-server/6.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/6.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -34,6 +34,11 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java tab="HTTP configuration"
@@ -135,11 +140,21 @@ collectively as "Nginx".)
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3.  Now that you've configured HTTP requests, you must also configure
     HTTPS requests. Configure Nginx to direct the HTTPS requests to the
     two worker nodes via the HTTPS 443 port using ` https://is.wso2.com/` . To do this, create a VHost file ( ` is.https.conf ` ) in the `
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
     

--- a/en/identity-server/6.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/6.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -34,7 +34,7 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it. 
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -151,12 +151,10 @@ collectively as "Nginx".)
     /etc/nginx/conf.d ` directory and add the following configurations
     into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
-
-    !!! note
     
         The configurations for nginx community version and NGINX
         Plus are different here since the community version does not support

--- a/en/identity-server/7.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/7.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -22,7 +22,7 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 1. Install Nginx (NGINX Plus or Nginx community) in a server configured in your cluster.
 2. Configure Nginx to direct the HTTP requests to the two worker nodes via the HTTP 80 port using the `http://is.wso2.com/>`. To do this, create a VHost file ( ` is.http.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -135,13 +135,12 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 
 3. Now that you've configured HTTP requests, you must also configure HTTPS requests. Configure Nginx to direct the HTTPS requests to the two worker nodes via the HTTPS 443 port using `https://is.wso2.com/`. To do this, create a VHost file ( ` is.https.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
-    !!! note
-        The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.
+         The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.
 
     === "nginx Community Version"
         ```

--- a/en/identity-server/7.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/7.0.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -22,6 +22,11 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 1. Install Nginx (NGINX Plus or Nginx community) in a server configured in your cluster.
 2. Configure Nginx to direct the HTTP requests to the two worker nodes via the HTTP 80 port using the `http://is.wso2.com/>`. To do this, create a VHost file ( ` is.http.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java
@@ -123,7 +128,17 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3. Now that you've configured HTTP requests, you must also configure HTTPS requests. Configure Nginx to direct the HTTPS requests to the two worker nodes via the HTTPS 443 port using `https://is.wso2.com/`. To do this, create a VHost file ( ` is.https.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
         The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.

--- a/en/identity-server/7.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/7.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -22,7 +22,7 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 1. Install Nginx (NGINX Plus or Nginx community) in a server configured in your cluster.
 2. Configure Nginx to direct the HTTP requests to the two worker nodes via the HTTP 80 port using the `http://is.wso2.com/>`. To do this, create a VHost file ( ` is.http.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -135,13 +135,12 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 
 3. Now that you've configured HTTP requests, you must also configure HTTPS requests. Configure Nginx to direct the HTTPS requests to the two worker nodes via the HTTPS 443 port using `https://is.wso2.com/`. To do this, create a VHost file ( ` is.https.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
-    !!! note
-        The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.
+         The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.
 
     === "nginx Community Version"
         ```

--- a/en/identity-server/7.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/7.1.0/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -22,6 +22,11 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 1. Install Nginx (NGINX Plus or Nginx community) in a server configured in your cluster.
 2. Configure Nginx to direct the HTTP requests to the two worker nodes via the HTTP 80 port using the `http://is.wso2.com/>`. To do this, create a VHost file ( ` is.http.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java
@@ -123,7 +128,17 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3. Now that you've configured HTTP requests, you must also configure HTTPS requests. Configure Nginx to direct the HTTPS requests to the two worker nodes via the HTTPS 443 port using `https://is.wso2.com/`. To do this, create a VHost file ( ` is.https.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
         The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.

--- a/en/identity-server/next/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/next/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -22,7 +22,7 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 1. Install Nginx (NGINX Plus or Nginx community) in a server configured in your cluster.
 2. Configure Nginx to direct the HTTP requests to the two worker nodes via the HTTP 80 port using the `http://is.wso2.com/>`. To do this, create a VHost file ( ` is.http.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
@@ -135,13 +135,12 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 
 3. Now that you've configured HTTP requests, you must also configure HTTPS requests. Configure Nginx to direct the HTTPS requests to the two worker nodes via the HTTPS 443 port using `https://is.wso2.com/`. To do this, create a VHost file ( ` is.https.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
-    !!! info
+    !!! note
          For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
 
          _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
-    !!! note
-        The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.
+         The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.
 
     === "nginx Community Version"
         ```

--- a/en/identity-server/next/docs/deploy/front-with-the-nginx-load-balancer.md
+++ b/en/identity-server/next/docs/deploy/front-with-the-nginx-load-balancer.md
@@ -22,6 +22,11 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
 1. Install Nginx (NGINX Plus or Nginx community) in a server configured in your cluster.
 2. Configure Nginx to direct the HTTP requests to the two worker nodes via the HTTP 80 port using the `http://is.wso2.com/>`. To do this, create a VHost file ( ` is.http.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
 
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
+
     ??? abstract "Click here to view a generic Nginx configuration"
 
         ```java
@@ -123,7 +128,17 @@ Use the following steps to configure [NGINX Plus](https://www.nginx.com/products
         }
         ```
 
+    !!! warning "Security Notice"
+         While HTTP (port 80) is demonstrated here for completeness, it is not recommended for use in production environments due to security concerns.
+         Instead, configure HTTPS (port 443) to ensure all communication is encrypted.
+         If HTTP must be enabled, it is advisable to use it only for redirection to HTTPS, not for transmitting sensitive data.
+
 3. Now that you've configured HTTP requests, you must also configure HTTPS requests. Configure Nginx to direct the HTTPS requests to the two worker nodes via the HTTPS 443 port using `https://is.wso2.com/`. To do this, create a VHost file ( ` is.https.conf ` ) in the `/etc/nginx/conf.d` directory and add the following configurations into it.
+
+    !!! info
+         For NGINX Open Source, the location depends on the installation method and OS. Common locations include `/usr/local/nginx/conf`, `/etc/nginx`, or `/usr/local/etc/nginx`.
+
+         _See [NGINX docs](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/) for details._
 
     !!! note
         The configurations for the Nginx community version and NGINX Plus are different here since the community version does not support the `sticky` directive.


### PR DESCRIPTION
## Purpose
To enhance the accuracy and security clarity of the NGINX load balancer setup documentation by addressing HTTP usage guidance and platform-specific config path differences.

## Goals
- Add a security notice regarding HTTP usage.
- Clarify that the NGINX configuration file path may vary based on OS and installation method.
- Improve usability for non-Linux users without affecting Linux-based deployment instructions.

## Approach
- A warning block was added below the HTTP configuration section to discourage the production use of HTTP.
- An info block was included near the config file path reference to explain cross-platform differences and link to official NGINX documentation.

## Related Issues
product-is issue: [Improvements to HTTP usage disclaimer and NGINX config path clarity #23577](https://github.com/wso2/product-is/issues/23577)