### PR TITLE
Remove Download Step for Mutual TLS Client Authenticator v2.0.3 in IS Docs Since It Is Packaged by Default with IS versions 5.8 and Above

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/5.10.0/docs/learn/mutual-tls-for-oauth-clients.md
@@ -77,17 +77,7 @@ with a sample.
         clientAuth="want"
         ```
 
-3.  Download Mutual TLS Client Authenticator v2.0.3 connector from
-    [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls)
-    .  
-    Note that an OSGI bundle (
-    `          org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls-<VERSION>.jar         `
-    ) gets downloaded.
-4.  Copy the OSGI bundle to the
-    `           <IS_HOME>/repository/components/dropins          `
-    directory.
-
-5.  Open the `           deployment.toml         ` file in the
+2.  Open the `           deployment.toml         ` file in the
     `           <IS_HOME>/repository/conf/          ` directory
     and add the following configuration.
 
@@ -100,7 +90,7 @@ with a sample.
     enable = true
     ```
 
-6.  In order for mutual TLS authentication to work, the public
+3.  In order for mutual TLS authentication to work, the public
     certificates of the client application and authorization server
     (WSO2 Identity Server) should be imported to each other's
     truststores.
@@ -192,7 +182,7 @@ with a sample.
 
     6.  Click **Update**.
 
-7.  Restart WSO2 Identity Server.
+4.  Restart WSO2 Identity Server.
 
 ### Testing the Sample
 

--- a/en/identity-server/5.10.0/docs/learn/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/5.10.0/docs/learn/mutual-tls-for-oauth-clients.md
@@ -78,7 +78,7 @@ with a sample.
         ```
 
 3.  Download Mutual TLS Client Authenticator v2.0.3 connector from
-    [here](https://store.wso2.com/store/assets/isconnector/details/bab13ed8-5835-480f-92be-fdd5ee900970)
+    [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls)
     .  
     Note that an OSGI bundle (
     `          org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls-<VERSION>.jar         `

--- a/en/identity-server/5.11.0/docs/learn/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/5.11.0/docs/learn/mutual-tls-for-oauth-clients.md
@@ -77,7 +77,7 @@ with a sample.
         ```
 
 3.  Download Mutual TLS Client Authenticator v2.0.3 connector from
-    [here](https://store.wso2.com/store/assets/isconnector/details/bab13ed8-5835-480f-92be-fdd5ee900970)
+    [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls)
     .  
     Note that an OSGI bundle (
     `          org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls-<VERSION>.jar         `

--- a/en/identity-server/5.11.0/docs/learn/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/5.11.0/docs/learn/mutual-tls-for-oauth-clients.md
@@ -76,17 +76,7 @@ with a sample.
         clientAuth="want"
         ```
 
-3.  Download Mutual TLS Client Authenticator v2.0.3 connector from
-    [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls)
-    .  
-    Note that an OSGI bundle (
-    `          org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls-<VERSION>.jar         `
-    ) gets downloaded.
-4.  Copy the OSGI bundle to the
-    `           <IS_HOME>/repository/components/dropins          `
-    directory.
-
-5.  Open the `           deployment.toml         ` file in the
+2.  Open the `           deployment.toml         ` file in the
     `           <IS_HOME>/repository/conf/          ` directory
     and add the following configuration.
 
@@ -99,7 +89,7 @@ with a sample.
     enable = true
     ```
 
-6.  In order for mutual TLS authentication to work, the public
+3.  In order for mutual TLS authentication to work, the public
     certificates of the client application and authorization server
     (WSO2 Identity Server) should be imported to each other's
     truststores.
@@ -191,7 +181,7 @@ with a sample.
 
     6.  Click **Update**.
 
-7.  Restart WSO2 Identity Server.
+4.  Restart WSO2 Identity Server.
 
 ### Testing the Sample
 

--- a/en/identity-server/5.9.0/docs/learn/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/5.9.0/docs/learn/mutual-tls-for-oauth-clients.md
@@ -77,7 +77,7 @@ with a sample.
         ```
 
 3.  Download Mutual TLS Client Authenticator v2.0.3 connector from
-    [here](https://store.wso2.com/store/assets/isconnector/details/bab13ed8-5835-480f-92be-fdd5ee900970)
+    [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls)
     .  
     Note that an OSGI bundle (
     `          org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls-<VERSION>.jar         `

--- a/en/identity-server/5.9.0/docs/learn/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/5.9.0/docs/learn/mutual-tls-for-oauth-clients.md
@@ -76,17 +76,7 @@ with a sample.
             clientAuth="want"
         ```
 
-3.  Download Mutual TLS Client Authenticator v2.0.3 connector from
-    [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls)
-    .  
-    Note that an OSGI bundle (
-    `          org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls-<VERSION>.jar         `
-    ) gets downloaded.
-4.  Copy the OSGI bundle to the
-    `           <IS_HOME>/repository/components/dropins          `
-    directory.
-
-5.  Open the `           deployment.toml         ` file in the
+2.  Open the `           deployment.toml         ` file in the
     `           <IS_HOME>/repository/conf/          ` directory
     and add the following configuration.
 
@@ -99,7 +89,7 @@ with a sample.
     enable = true
     ```
 
-6.  In order for mutual TLS authentication to work, the public
+3.  In order for mutual TLS authentication to work, the public
     certificates of the client application and authorization server
     (WSO2 Identity Server) should be imported to each other's
     truststores.
@@ -191,7 +181,7 @@ with a sample.
 
     6.  Click **Update**.
 
-7.  Restart WSO2 Identity Server.
+4.  Restart WSO2 Identity Server.
 
 ### Testing the Sample
 

--- a/en/identity-server/6.0.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/6.0.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
@@ -65,11 +65,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
     clientAuth="want"
     ```
 
-3. Download the Mutual TLS Client Authenticator v2.0.3 connector from [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls).  
-
-4. Copy the OSGi bundle to the `<IS_HOME>/repository/components/dropins` directory.
-
-5. Open the `deployment.toml` file in the `<IS_HOME>/repository/conf/` directory and add the following configuration.
+3. Open the `deployment.toml` file in the `<IS_HOME>/repository/conf/` directory and add the following configuration.
 
     ``` toml
     [[event_listener]]
@@ -80,7 +76,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
     enable = true
     ```
 
-6. For mutual TLS authentication to work, the public certificates of the client application and authorization server (WSO2 Identity Server) should be imported to each other's trust stores.
+4. For mutual TLS authentication to work, the public certificates of the client application and authorization server  (WSO2 Identity Server) should be imported to each other's trust stores.
 
     For demonstration purposes, let's assume that both the authorization server's truststore (`WSO2_TRUSTSTORE`) and the client's truststore (`CLIENT_TRUSTSTORE`) are in WSO2 Identity Server.
 
@@ -155,7 +151,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
 
     6. Click **Update**.
 
-7. Restart the Identity Server.
+5. Restart the Identity Server.
 
 ### Configure the authenticator artifacts
 

--- a/en/identity-server/6.0.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/6.0.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
@@ -65,7 +65,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
     clientAuth="want"
     ```
 
-3. Download the Mutual TLS Client Authenticator v2.0.3 connector from [here](https://store.wso2.com/store/assets/isconnector/details/bab13ed8-5835-480f-92be-fdd5ee900970).  
+3. Download the Mutual TLS Client Authenticator v2.0.3 connector from [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls).  
 
 4. Copy the OSGi bundle to the `<IS_HOME>/repository/components/dropins` directory.
 

--- a/en/identity-server/6.1.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/6.1.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
@@ -65,11 +65,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
     clientAuth="want"
     ```
 
-3. Download the Mutual TLS Client Authenticator v2.0.3 connector from [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls).  
-
-4. Copy the OSGi bundle to the `<IS_HOME>/repository/components/dropins` directory.
-
-5. Open the `deployment.toml` file in the `<IS_HOME>/repository/conf/` directory and add the following configuration.
+3. Open the `deployment.toml` file in the `<IS_HOME>/repository/conf/` directory and add the following configuration.
 
     ``` toml
     [[event_listener]]
@@ -80,7 +76,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
     enable = true
     ```
 
-6. For mutual TLS authentication to work, the public certificates of the client application and authorization server (WSO2 Identity Server) should be imported to each other's trust stores.
+4. For mutual TLS authentication to work, the public certificates of the client application and authorization server  (WSO2 Identity Server) should be imported to each other's trust stores.
 
     For demonstration purposes, let's assume that both the authorization server's truststore (`WSO2_TRUSTSTORE`) and the client's truststore (`CLIENT_TRUSTSTORE`) are in WSO2 Identity Server.
 
@@ -155,7 +151,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
 
     6. Click **Update**.
 
-7. Restart the Identity Server.
+5. Restart the Identity Server.
 
 ### Configure the authenticator artifacts
 

--- a/en/identity-server/6.1.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
+++ b/en/identity-server/6.1.0/docs/guides/access-delegation/mutual-tls-for-oauth-clients.md
@@ -65,7 +65,7 @@ To configure the mutual TLS authenticator, follow the [prequisite steps](#prereq
     clientAuth="want"
     ```
 
-3. Download the Mutual TLS Client Authenticator v2.0.3 connector from [here](https://store.wso2.com/store/assets/isconnector/details/bab13ed8-5835-480f-92be-fdd5ee900970).  
+3. Download the Mutual TLS Client Authenticator v2.0.3 connector from [here](https://store.wso2.com/connector/identity-oauth-clientauth-mutualtls).  
 
 4. Copy the OSGi bundle to the `<IS_HOME>/repository/components/dropins` directory.
 


### PR DESCRIPTION
## Purpose
Remove the outdated instruction to download the Mutual TLS Client Authenticator v2.0.3 from the IS Store, as it is packaged by default starting from Identity Server version 5.8.

## Goals
- Eliminate redundant steps from the documentation.
- Improve clarity and reduce confusion around connector version compatibility.

## Approach
- Removed the step instructing users to download the connector.
- Clarified that the authenticator is included by default from IS 5.8 onwards.
- Verified that the removal aligns with the current product packaging.

## Related Issues
product-is issue: [Incorrect Link to Download Mutual TLS Client Authenticator v2.0.3 in IS Store Documentation #23578](https://github.com/wso2/product-is/issues/23578)