### PR TITLE
Fix formatting issues and broken links in super admin recovery guide backported for IS 5.9.0 to IS 6.1.0

### DIFF
--- a/en/identity-server/5.10.0/docs/setup/recover-super-admin-account.md
+++ b/en/identity-server/5.10.0/docs/setup/recover-super-admin-account.md
@@ -1,6 +1,6 @@
 # Recover a locked super admin account
 
-If you are the super admin of your {{product_name}} deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
+If you are the super admin of your WSO2 Identity Server deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
 
 In such a case, recovering a super admin account involves temporarily creating a new super admin account and using it to unlock or manage the original super admin account. To do so, follow the steps below.
 
@@ -16,38 +16,25 @@ create_admin_account = true
 ```
 
 !!! info
-The above configuration will create a new super admin user named `temporary-admin` on server startup.
+    The above configuration will create a new super admin user named `temporary-admin` on server startup.
 
-## Step 2: Restart {{product_name}}
+## Step 2: Restart WSO2 Identity Server
 
-For your new configurations to apply, restart {{ product_name }} using the appropriate command.
+For your new configurations to apply, restart WSO2 Identity Server using the appropriate command.
 
-=== "Linux/MacOS"
-
-    ```bash
-    sh wso2server.sh
-    ```
-
-=== "Windows"
-
-    ```bash
-    wso2server.bat
-    ```
-
-
+    -   On Linux/Mac OS:`sh wso2server.sh`
+    -   On Windows:`wso2server.bat`
 
 ## Step 3: Manage the old super admin user account
 
 Once the server starts, log in to the Console using the new super admin credentials. With this account you may now do the following:
 
-- [Unlock]({{base_path}}/guides/users/manage-users/#lock-a-user-account) the original super admin account.
-- [Reset the password]({{base_path}}/guides/users/manage-users/#reset-the-users-password) if necessary.
-- Optionally, you can [assign the system role]({{base_path}}/guides/users/manage-roles/#assign-users-to-a-role) to the original super admin account to prevent future lockouts.
+- [Unlock](https://is.docs.wso2.com/en/5.10.0/learn/locking-a-specific-user-account/#lock-a-specific-user-account) the original super admin account.
+- [Reset the password](https://is.docs.wso2.com/en/5.10.0/learn/forced-password-reset/) if necessary.
+- Optionally, you can [assign the system role](https://is.docs.wso2.com/en/5.10.0/learn/configuring-roles-and-permissions/#adding-a-user-role) to the original super admin account to prevent future lockouts.
 
-  !!! tip
-
-        Users assigned the `system` role are not subject to account locking policies.
-
+!!! info "Tip"
+    Users assigned the `system` role are not subject to account locking policies.
 
 
 ## Step 4: Restore configurations
@@ -55,13 +42,13 @@ Once the server starts, log in to the Console using the new super admin credenti
 Once you recover the original account, you can continue using it as the super admin. To do so,
 
 1. Navigate to the `<IS_HOME>/repository/conf/deployment.toml` file and update the [super_admin] section to reflect the credentials of the original super admin account.
-2. Restart {{product_name}}.
-3. Log in to the Console and if necessary, [delete the temporary account]({{base_path}}/guides/users/manage-users/#delete-a-user) you created earlier.
+2. Restart WSO2 Identity Server.
+3. Log in to the Console and if necessary, [delete the temporary account](https://is.docs.wso2.com/en/5.10.0/learn/configuring-users/#delete-user-using-scim) you created earlier.
 
-   !!! note "Temporary super admin accounts"
+!!! info "Temporary super admin accounts"
 
-        - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
+    - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
 
-        - If you no longer need this account, you must go to the Console and delete this user manually.
+    - If you no longer need this account, you must go to the Console and delete this user manually.
 
-        - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.
+    - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.

--- a/en/identity-server/5.11.0/docs/setup/recover-super-admin-account.md
+++ b/en/identity-server/5.11.0/docs/setup/recover-super-admin-account.md
@@ -1,6 +1,6 @@
 # Recover a locked super admin account
 
-If you are the super admin of your {{product_name}} deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
+If you are the super admin of your WSO2 Identity Server deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
 
 In such a case, recovering a super admin account involves temporarily creating a new super admin account and using it to unlock or manage the original super admin account. To do so, follow the steps below.
 
@@ -16,38 +16,25 @@ create_admin_account = true
 ```
 
 !!! info
-The above configuration will create a new super admin user named `temporary-admin` on server startup.
+    The above configuration will create a new super admin user named `temporary-admin` on server startup.
 
-## Step 2: Restart {{product_name}}
+## Step 2: Restart WSO2 Identity Server
 
-For your new configurations to apply, restart {{ product_name }} using the appropriate command.
+For your new configurations to apply, restart WSO2 Identity Server using the appropriate command.
 
-=== "Linux/MacOS"
-
-    ```bash
-    sh wso2server.sh
-    ```
-
-=== "Windows"
-
-    ```bash
-    wso2server.bat
-    ```
-
-
+    -   On Linux/Mac OS:`sh wso2server.sh`
+    -   On Windows:`wso2server.bat`
 
 ## Step 3: Manage the old super admin user account
 
 Once the server starts, log in to the Console using the new super admin credentials. With this account you may now do the following:
 
-- [Unlock]({{base_path}}/guides/users/manage-users/#lock-a-user-account) the original super admin account.
-- [Reset the password]({{base_path}}/guides/users/manage-users/#reset-the-users-password) if necessary.
-- Optionally, you can [assign the system role]({{base_path}}/guides/users/manage-roles/#assign-users-to-a-role) to the original super admin account to prevent future lockouts.
+- [Unlock](https://is.docs.wso2.com/en/5.11.0/learn/locking-a-specific-user-account/#lock-a-specific-user-account) the original super admin account.
+- [Reset the password](https://is.docs.wso2.com/en/5.11.0/learn/my-account/#reset-password) if necessary.
+- Optionally, you can [assign the system role](https://is.docs.wso2.com/en/5.11.0/learn/configuring-roles-and-permissions/#adding-a-user-role) to the original super admin account to prevent future lockouts.
 
-  !!! tip
-
-        Users assigned the `system` role are not subject to account locking policies.
-
+!!! info "Tip"
+    Users assigned the `system` role are not subject to account locking policies.
 
 
 ## Step 4: Restore configurations
@@ -55,13 +42,13 @@ Once the server starts, log in to the Console using the new super admin credenti
 Once you recover the original account, you can continue using it as the super admin. To do so,
 
 1. Navigate to the `<IS_HOME>/repository/conf/deployment.toml` file and update the [super_admin] section to reflect the credentials of the original super admin account.
-2. Restart {{product_name}}.
-3. Log in to the Console and if necessary, [delete the temporary account]({{base_path}}/guides/users/manage-users/#delete-a-user) you created earlier.
+2. Restart WSO2 Identity Server.
+3. Log in to the Console and if necessary, [delete the temporary account](https://is.docs.wso2.com/en/5.11.0/learn/configuring-users/#delete-user-using-scim) you created earlier.
 
-   !!! note "Temporary super admin accounts"
+!!! info "Temporary super admin accounts"
 
-        - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
+    - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
 
-        - If you no longer need this account, you must go to the Console and delete this user manually.
+    - If you no longer need this account, you must go to the Console and delete this user manually.
 
-        - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.
+    - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.

--- a/en/identity-server/5.9.0/docs/setup/recover-super-admin-account.md
+++ b/en/identity-server/5.9.0/docs/setup/recover-super-admin-account.md
@@ -1,6 +1,6 @@
 # Recover a locked super admin account
 
-If you are the super admin of your {{product_name}} deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
+If you are the super admin of your WSO2 Identity Server deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
 
 In such a case, recovering a super admin account involves temporarily creating a new super admin account and using it to unlock or manage the original super admin account. To do so, follow the steps below.
 
@@ -16,38 +16,25 @@ create_admin_account = true
 ```
 
 !!! info
-The above configuration will create a new super admin user named `temporary-admin` on server startup.
+    The above configuration will create a new super admin user named `temporary-admin` on server startup.
 
-## Step 2: Restart {{product_name}}
+## Step 2: Restart WSO2 Identity Server
 
-For your new configurations to apply, restart {{ product_name }} using the appropriate command.
+For your new configurations to apply, restart WSO2 Identity Server using the appropriate command.
 
-=== "Linux/MacOS"
-
-    ```bash
-    sh wso2server.sh
-    ```
-
-=== "Windows"
-
-    ```bash
-    wso2server.bat
-    ```
-
-
+    -   On Linux/Mac OS:`sh wso2server.sh`
+    -   On Windows:`wso2server.bat`
 
 ## Step 3: Manage the old super admin user account
 
 Once the server starts, log in to the Console using the new super admin credentials. With this account you may now do the following:
 
-- [Unlock]({{base_path}}/guides/users/manage-users/#lock-a-user-account) the original super admin account.
-- [Reset the password]({{base_path}}/guides/users/manage-users/#reset-the-users-password) if necessary.
-- Optionally, you can [assign the system role]({{base_path}}/guides/users/manage-roles/#assign-users-to-a-role) to the original super admin account to prevent future lockouts.
+- [Unlock](https://is.docs.wso2.com/en/5.9.0/learn/locking-a-specific-user-account/#lock-a-specific-user-account)the original super admin account.
+- [Reset the password](https://is.docs.wso2.com/en/5.9.0/learn/forced-password-reset/) if necessary.
+- Optionally, you can [assign the system role](https://is.docs.wso2.com/en/5.9.0/learn/configuring-roles-and-permissions/#adding-a-user-role) to the original super admin account to prevent future lockouts.
 
-  !!! tip
-
-        Users assigned the `system` role are not subject to account locking policies.
-
+!!! info "Tip"
+    Users assigned the `system` role are not subject to account locking policies.
 
 
 ## Step 4: Restore configurations
@@ -55,13 +42,13 @@ Once the server starts, log in to the Console using the new super admin credenti
 Once you recover the original account, you can continue using it as the super admin. To do so,
 
 1. Navigate to the `<IS_HOME>/repository/conf/deployment.toml` file and update the [super_admin] section to reflect the credentials of the original super admin account.
-2. Restart {{product_name}}.
-3. Log in to the Console and if necessary, [delete the temporary account]({{base_path}}/guides/users/manage-users/#delete-a-user) you created earlier.
+2. Restart WSO2 Identity Server.
+3. Log in to the Console and if necessary, [delete the temporary account](https://is.docs.wso2.com/en/5.9.0/learn/configuring-users/#delete-user-using-scim) you created earlier.
 
-   !!! note "Temporary super admin accounts"
+!!! info "Temporary super admin accounts"
 
-        - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
+    - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
 
-        - If you no longer need this account, you must go to the Console and delete this user manually.
+    - If you no longer need this account, you must go to the Console and delete this user manually.
 
-        - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.
+    - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.

--- a/en/identity-server/6.0.0/docs/guides/identity-lifecycles/recover-super-admin-account.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-lifecycles/recover-super-admin-account.md
@@ -1,6 +1,6 @@
 # Recover a locked super admin account
 
-If you are the super admin of your {{product_name}} deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
+If you are the super admin of your WSO2 Identity Server deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
 
 In such a case, recovering a super admin account involves temporarily creating a new super admin account and using it to unlock or manage the original super admin account. To do so, follow the steps below.
 
@@ -16,38 +16,25 @@ create_admin_account = true
 ```
 
 !!! info
-The above configuration will create a new super admin user named `temporary-admin` on server startup.
+    The above configuration will create a new super admin user named `temporary-admin` on server startup.
 
-## Step 2: Restart {{product_name}}
+## Step 2: Restart WSO2 Identity Server
 
-For your new configurations to apply, restart {{ product_name }} using the appropriate command.
+For your new configurations to apply, restart WSO2 Identity Server using the appropriate command.
 
-=== "Linux/MacOS"
-
-    ```bash
-    sh wso2server.sh
-    ```
-
-=== "Windows"
-
-    ```bash
-    wso2server.bat
-    ```
-
-
+    -   On Linux/Mac OS:`sh wso2server.sh`
+    -   On Windows:`wso2server.bat`
 
 ## Step 3: Manage the old super admin user account
 
 Once the server starts, log in to the Console using the new super admin credentials. With this account you may now do the following:
 
-- [Unlock]({{base_path}}/guides/users/manage-users/#lock-a-user-account) the original super admin account.
-- [Reset the password]({{base_path}}/guides/users/manage-users/#reset-the-users-password) if necessary.
-- Optionally, you can [assign the system role]({{base_path}}/guides/users/manage-roles/#assign-users-to-a-role) to the original super admin account to prevent future lockouts.
+- [Unlock](https://is.docs.wso2.com/en/6.0.0/guides/identity-lifecycles/lock-account/#unlock-a-user-account) the original super admin account.
+- [Reset the password](https://is.docs.wso2.com/en/6.0.0/guides/password-mgt/password-mgt-overview/) if necessary.
+- Optionally, you can [assign the system role](https://is.docs.wso2.com/en/6.0.0/apis/scim2-patch-operations/#assign-users) to the original super admin account to prevent future lockouts.
 
-  !!! tip
-
-        Users assigned the `system` role are not subject to account locking policies.
-
+!!! info "Tip"
+    Users assigned the `system` role are not subject to account locking policies.
 
 
 ## Step 4: Restore configurations
@@ -55,13 +42,13 @@ Once the server starts, log in to the Console using the new super admin credenti
 Once you recover the original account, you can continue using it as the super admin. To do so,
 
 1. Navigate to the `<IS_HOME>/repository/conf/deployment.toml` file and update the [super_admin] section to reflect the credentials of the original super admin account.
-2. Restart {{product_name}}.
-3. Log in to the Console and if necessary, [delete the temporary account]({{base_path}}/guides/users/manage-users/#delete-a-user) you created earlier.
+2. Restart WSO2 Identity Server.
+3. Log in to the Console and if necessary, [delete the temporary account](https://is.docs.wso2.com/en/6.0.0/guides/identity-lifecycles/delete-users/) you created earlier.
 
-   !!! note "Temporary super admin accounts"
+!!! info "Temporary super admin accounts"
 
-        - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
+    - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
 
-        - If you no longer need this account, you must go to the Console and delete this user manually.
+    - If you no longer need this account, you must go to the Console and delete this user manually.
 
-        - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.
+    - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.

--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/recover-super-admin-account.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/recover-super-admin-account.md
@@ -1,6 +1,6 @@
 # Recover a locked super admin account
 
-If you are the super admin of your {{product_name}} deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
+If you are the super admin of your WSO2 Identity Server deployment, and have enforced account lockout features (such as when exceeding the maximum number of failed login attempts), there is a chance that you will be locked out of your own account.
 
 In such a case, recovering a super admin account involves temporarily creating a new super admin account and using it to unlock or manage the original super admin account. To do so, follow the steps below.
 
@@ -16,38 +16,25 @@ create_admin_account = true
 ```
 
 !!! info
-The above configuration will create a new super admin user named `temporary-admin` on server startup.
+    The above configuration will create a new super admin user named `temporary-admin` on server startup.
 
-## Step 2: Restart {{product_name}}
+## Step 2: Restart WSO2 Identity Server
 
-For your new configurations to apply, restart {{ product_name }} using the appropriate command.
+For your new configurations to apply, restart WSO2 Identity Server using the appropriate command.
 
-=== "Linux/MacOS"
-
-    ```bash
-    sh wso2server.sh
-    ```
-
-=== "Windows"
-
-    ```bash
-    wso2server.bat
-    ```
-
-
+    -   On Linux/Mac OS:`sh wso2server.sh`
+    -   On Windows:`wso2server.bat`
 
 ## Step 3: Manage the old super admin user account
 
 Once the server starts, log in to the Console using the new super admin credentials. With this account you may now do the following:
 
-- [Unlock]({{base_path}}/guides/users/manage-users/#lock-a-user-account) the original super admin account.
-- [Reset the password]({{base_path}}/guides/users/manage-users/#reset-the-users-password) if necessary.
-- Optionally, you can [assign the system role]({{base_path}}/guides/users/manage-roles/#assign-users-to-a-role) to the original super admin account to prevent future lockouts.
+- [Unlock](https://is.docs.wso2.com/en/6.1.0/guides/identity-lifecycles/lock-account/#unlock-a-user-account) the original super admin account.
+- [Reset the password](https://is.docs.wso2.com/en/6.1.0/guides/password-mgt/password-mgt-overview/) if necessary.
+- Optionally, you can [assign the system role](https://is.docs.wso2.com/en/6.1.0/apis/scim2-patch-operations/#assign-users) to the original super admin account to prevent future lockouts.
 
-  !!! tip
-
-        Users assigned the `system` role are not subject to account locking policies.
-
+!!! info "Tip"
+    Users assigned the `system` role are not subject to account locking policies.
 
 
 ## Step 4: Restore configurations
@@ -55,13 +42,13 @@ Once the server starts, log in to the Console using the new super admin credenti
 Once you recover the original account, you can continue using it as the super admin. To do so,
 
 1. Navigate to the `<IS_HOME>/repository/conf/deployment.toml` file and update the [super_admin] section to reflect the credentials of the original super admin account.
-2. Restart {{product_name}}.
-3. Log in to the Console and if necessary, [delete the temporary account]({{base_path}}/guides/users/manage-users/#delete-a-user) you created earlier.
+2. Restart WSO2 Identity Server.
+3. Log in to the Console and if necessary, [delete the temporary account](https://is.docs.wso2.com/en/6.1.0/guides/identity-lifecycles/delete-users/) you created earlier.
 
-   !!! note "Temporary super admin accounts"
+!!! info "Temporary super admin accounts"
 
-        - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
+    - A temporary super admin account gets created only when you set `create_admin_account = true`. Once the recovery is complete, this temporary super admin account does not get deleted automatically.
 
-        - If you no longer need this account, you must go to the Console and delete this user manually.
+    - If you no longer need this account, you must go to the Console and delete this user manually.
 
-        - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.
+    - To prevent being locked out, make sure that at least one super admin account is always accessible before deleting any admin accounts.


### PR DESCRIPTION
## Purpose
To fix formatting issues and incorrect links introduced in https://github.com/wso2/docs-is/pull/5201, which backported the super admin account recovery guide to older WSO2 Identity Server versions from https://github.com/wso2/docs-is/pull/5197.

## Goals
- Fix template rendering errors (e.g., `{{ product_name }}` not resolving).
- Correct broken or incorrect links in the backported versions.
- Ensure consistent readability and usability across all supported IS documentation versions.

## Approach
- Fixed unresolved placeholders such as `{{ product_name }}` to display the appropriate product name.
- Replaced invalid or broken links that previously led to `Page not found` errors.
- Ensured consistency in formatting (code blocks, titles, and info boxes) to match the main guide in https://github.com/wso2/docs-is/pull/5197.
- Verified navigation and formatting across:
  - IS 5.9.0
  - IS 5.10.0
  - IS 5.11.0
  - IS 6.0.0
  - IS 6.1.0

## Related Issues
product-is issue: https://github.com/wso2/product-is/issues/23570