### PR TITLE
Remove structural type from Organization POST request documentation

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/org-management.yaml
@@ -34,7 +34,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/asgardeo/docs/apis/restapis/org-management.yaml
+++ b/en/asgardeo/docs/apis/restapis/org-management.yaml
@@ -33,7 +33,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -29,7 +29,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/identity-server/7.0.0/docs/apis/restapis/organization-management.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/organization-management.yaml
@@ -33,7 +33,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -29,7 +29,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/identity-server/7.1.0/docs/apis/restapis/organization-management.yaml
+++ b/en/identity-server/7.1.0/docs/apis/restapis/organization-management.yaml
@@ -33,7 +33,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -29,7 +29,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:

--- a/en/identity-server/next/docs/apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/restapis/organization-management.yaml
@@ -33,7 +33,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationPOSTRequest'
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: "ABC Builders"
+                description:
+                  type: string
+                  example: "Building constructions"
+                parentId:
+                  type: string
+                  description: "The parent organization id should be the organization where the request is invoked. If a value is not specified it will be resolved internally."
+                attributes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Attribute'
+              example:
+                {
+                  "name": "ABC Builders",
+                  "description": "Building constructions",
+                  "attributes": [
+                    {
+                      "key": "Country",
+                      "value": "USA"
+                    }
+                  ]
+                }
         description: This represents the organization to be added.
         required: true
       responses:


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/wso2/product-is/issues/23539

## Goals
Since we are moving away from the "STRUCTURAL" type for organizations, it will be deprecated, hence this needs to be removed from the Docs.