### PR TITLE
Fix punctuation marks not being visible in API code snippets in light mode

### DIFF
--- a/en/theme/material/assets/css/redoc.css
+++ b/en/theme/material/assets/css/redoc.css
@@ -144,14 +144,6 @@
     color: var(--md-default-fg-color--light) !important;
 }
 
-.api-content code {
-    color: var(--md-code-bg-color) !important;
-    background-color: var(--md-code-fg-color) !important;
-    border-radius: .25rem !important;
-    padding: .1rem .3rem !important;
-    border: none !important;
-} 
-
 [data-md-color-scheme=slate] .api-content code {
     color: var(--md-code-fg-color) !important;
     background-color: var(--md-code-bg-color) !important;


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

$subject

<img width="1508" alt="Screenshot 2025-03-28 at 14 44 59" src="https://github.com/user-attachments/assets/ea6145b5-f948-41a0-93f6-792aef885d83" />

