### PR TITLE
Use git commands to retrieve the latest release

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,11 +1,9 @@
-name: Asgardeo Docs Release
+name: Docs Release
 
 on:
   push:
     branches:
       - master
-    paths-ignore:
-      - 'VERSION'  # This will ignore changes only to the VERSION file.
   workflow_dispatch:
     inputs:
       version:
@@ -44,7 +42,7 @@ jobs:
 
       - name: Get the current version
         run: |
-          echo "CURRENT_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Increment version
         run: |
@@ -153,14 +151,6 @@ jobs:
           asset_path: ./asgardeo-docs-${{ env.NEW_VERSION }}-prod.zip
           asset_name: asgardeo-docs-${{ env.NEW_VERSION }}-prod.zip
           asset_content_type: application/zip
-
-      - name: Commit and push new version
-        if: ${{ env.IS_HOTFIX == 'false' }}  
-        run: |
-          echo "${{ env.NEW_VERSION }}" > VERSION
-          git add VERSION
-          git commit -m "Increment release version to ${{ env.NEW_VERSION }}"
-          git push "https://$GIT_USERNAME:$GITHUB_TOKEN@github.com/${{ github.repository }}" master
 
       - name: Update Downstream Repository Version
         if: ${{ env.IS_HOTFIX == 'false' }}


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

Using a file in the repo to store latest doc version is not a good approach as we can get that info from git directly. 
This PR removes the usage of VERSION file to manage doc versions in the release workflow and uses the plain git commands to retrieve the current latest doc version instead.