### PR TITLE
Add `{{current-year}}` literal for email and sms templates

### DIFF
--- a/en/includes/references/email-templates.md
+++ b/en/includes/references/email-templates.md
@@ -237,11 +237,16 @@ The following literals about the user are accessible for all email templates.
             <td>{{"{{tenant-domain}}"}}</td>
             <td>Domain name specific to the organization. For organization (root), this is a human-readable domain name. For organizations, a UUID is used to uniquely identify them. Utilize this placeholder within URL paths to denote the tenant.</td>
         </tr>
+        <tr>
+            <td>{{"{{current-year}}"}}</td>
+            <td>Current calendar year.</td>
+        </tr>
     </tbody>
 </table>
 
 !!! note
-    Organizations (root) created before October 2022 will utilize `\{\{ tenant-domain \}\}` as the placeholder to represent the organization name. As this placeholder may not provide the organization name in a human-readable format, consider updating it to `\{\{ organization-name \}\}` as needed for clarity and ease of understanding.
+    Organizations (root) created before October 2022 will utilize `{{"{{ tenant-domain }}"}}`
+     as the placeholder to represent the organization name. As this placeholder may not provide the organization name in a human-readable format, consider updating it to `{{"{{ organization-name }}"}}` as needed for clarity and ease of understanding.
 
 ---
 

--- a/en/includes/references/sms-templates.md
+++ b/en/includes/references/sms-templates.md
@@ -73,6 +73,10 @@ The following user-related literals are accessible for all SMS templates.
             <td>{{"{{tenant-domain}}"}}</td>
             <td>Domain name specific to the organization. For root organizations, this is the human-readable domain name. For other organizations, it is the UUID.</td>
         </tr>
+        <tr>
+            <td>{{"{{current-year}}"}}</td>
+            <td>Current calendar year.</td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
## Purpose
Currently the `{{current-year}}` literal can be used in email templates and has supported for sms templates through a recent bug fix. This PR is to document them in the template references.

![Screenshot 2025-04-01 at 9 57 41 AM](https://github.com/user-attachments/assets/f3632af8-4c62-4faa-a2ee-d1dec7421f20)

![Screenshot 2025-04-01 at 9 57 49 AM](https://github.com/user-attachments/assets/ab8c17ce-fab1-4651-a6a0-dde037e4add8)



## Related Issues
- https://github.com/wso2/product-is/issues/23641

## Goals
<!-- Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

## Approach
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

## Release note
<!-- Brief description of the new feature or bug fix as it will appear in the release notes -->

## Documentation
<!-- Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact -->

## Security checks
- [] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [] Ran FindSecurityBugs plugin and verified report?
- [] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->
