### PR TITLE
Update API paths for the SCIM user and group mgt API docs

### DIFF
--- a/en/asgardeo/docs/apis/restapis/scim2-groups.yaml
+++ b/en/asgardeo/docs/apis/restapis/scim2-groups.yaml
@@ -72,7 +72,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups' \
             -H 'accept: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}'                
     post:
@@ -135,7 +135,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups' \
             -H 'accept: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}'                 
       x-codegen-request-body-name: body
@@ -177,7 +177,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups/.search' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups/.search' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \
@@ -244,7 +244,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups/{group-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups/{group-id}' \
             -H 'accept: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}'                  
     put:
@@ -313,7 +313,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PUT' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups/{group-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups/{group-id}' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \
@@ -368,7 +368,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups/{group-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups/{group-id}' \
             -H 'accept: */*' \
             -H 'Authorization: Bearer {bearer_token}'                   
     patch:
@@ -431,7 +431,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PATCH' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Groups/{group-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Groups/{group-id}' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \

--- a/en/asgardeo/docs/apis/restapis/scim2-users.yaml
+++ b/en/asgardeo/docs/apis/restapis/scim2-users.yaml
@@ -72,7 +72,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users' \
             -H 'accept: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}'                 
     post:
@@ -137,7 +137,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \
@@ -203,7 +203,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users/.search' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users/.search' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \
@@ -276,7 +276,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users/{user-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users/{user-id}' \
             -H 'accept: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}'                   
     put:
@@ -339,7 +339,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PUT' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users/{user-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users/{user-id}' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \
@@ -404,7 +404,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users/{user-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users/{user-id}' \
             -H 'accept: */*' \
             -H 'Authorization: Bearer {bearer_token}'                 
     patch:
@@ -468,7 +468,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PATCH' \
-            'https://api.asgardeo.io/o/{organization-name}/scim2/Users/{user-id}' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Users/{user-id}' \
             -H 'accept: application/scim+json' \
             -H 'Content-Type: application/scim+json' \
             -H 'Authorization: Bearer {bearer_token}' \


### PR DESCRIPTION
## Purpose
SCIM user management API docs under management APIs have an invalid uri where it contains `/o/` instead of `/t/`. This PR fixes such incorrect paths for the scim users and groups APIs.

## Goals
Fix SCIM Users and Groups API paths.

## Approach
<!-- Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

## Release note
<!-- Brief description of the new feature or bug fix as it will appear in the release notes -->

## Documentation
<!-- Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact -->

## Security checks
- [] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [] Ran FindSecurityBugs plugin and verified report?
- [] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->
