### PR TITLE
Fix account recovery v0.9 api definition UI

### DIFF
--- a/en/identity-server/7.0.0/docs/apis/use-the-account-recovery-rest-apis.md
+++ b/en/identity-server/7.0.0/docs/apis/use-the-account-recovery-rest-apis.md
@@ -3,4 +3,3 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url=../../apis/restapis/account-recovery.yaml></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>

--- a/en/identity-server/7.1.0/docs/apis/use-the-account-recovery-rest-apis.md
+++ b/en/identity-server/7.1.0/docs/apis/use-the-account-recovery-rest-apis.md
@@ -3,4 +3,3 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url=../../apis/restapis/account-recovery.yaml></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>

--- a/en/identity-server/next/docs/apis/use-the-account-recovery-rest-apis.md
+++ b/en/identity-server/next/docs/apis/use-the-account-recovery-rest-apis.md
@@ -3,4 +3,3 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url=../../apis/restapis/account-recovery.yaml></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>


### PR DESCRIPTION
### Purpose

This PR removes the unnecessary inclusion of the Redoc standalone script (redoc.standalone.js) from the API documentation files for the Account Recovery v0.9 API. Since the Redoc template already includes the required script, this duplication was redundant and caused UI inconsistencies when rendering the OpenAPI definition.

### Related Issue
- https://github.com/wso2/product-is/issues/23832

