### PR TITLE
Update IS 5.11.0 docs for FIDO Key Progressive Enrolment

### DIFF
--- a/en/identity-server/5.11.0/docs/learn/passwordless-authentication-using-fido2.md
+++ b/en/identity-server/5.11.0/docs/learn/passwordless-authentication-using-fido2.md
@@ -76,7 +76,7 @@ Passkey progressive enrollment enables users to register their FIDO devices on-t
 
     !!! abstract ""    
     
-        This feature is available for WSO2 IS 5.11.0 from update level 398 onwards (Updates 2.0 model). If you don't already have this update, see the instructions on [updating WSO2 products](https://updates.docs.wso2.com/en/latest/updates/overview/).
+        This feature is available for WSO2 IS 5.11.0 from update level 399 onwards (Updates 2.0 model). If you don't already have this update, see the instructions on [updating WSO2 products](https://updates.docs.wso2.com/en/latest/updates/overview/).
     
     1.  Shut down the server if it is running.
     2.  Add the following properties to the `deployment.toml` file in `IS_HOME/repository/conf` to enable the feature.


### PR DESCRIPTION
### Purpose
This updates the docs related to FIDO key progressive enrolment in IS 5.11.0. This feature  provides the support to add the FIDO key during the authentication process.

### Related Issue
- https://github.com/wso2/product-is/issues/23816
