### PR TITLE
Remove basic auth header usages in organization APIs and update cURLs with bearer token

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/api-resources.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/api-resources.yaml
@@ -126,7 +126,7 @@ paths:
           source: |
             curl --location 'https://api.asgardeo.io/t/{organization-name}/o/api/server/v1/api-resources/{apiResourceId}/scopes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /scopes:
     get:
       tags:
@@ -168,7 +168,7 @@ paths:
           source: |
             curl --location 'https://api.asgardeo.io/t/{organization-name}/o/api/server/v1/scopes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     organizationId:
@@ -770,9 +770,6 @@ components:
             error: []
 
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/asgardeo/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -567,7 +567,7 @@ paths:
           source: |
             curl --location --request PATCH 'https://api.asgardeo.io/t/{root-organization-name}/o/api/server/v1/applications/{application-id}/authorized-apis/{api-id}' \
             -H 'Content-Type: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
                 "addedScopes": [
                     "bookings:write"
@@ -1116,9 +1116,6 @@ components:
       schema:
         type: string
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/application.yaml
@@ -379,7 +379,7 @@ components:
       flows:
         authorizationCode:
           authorizationUrl: 'https://localhost:9443/oauth2/authorize'
-          tokenUrl: 'http://localhost:9763/oauth2/token'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
           scopes: {}
   schemas:
     Link:

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -11,7 +11,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 paths:
   /authenticators:
@@ -330,9 +329,6 @@ components:
   # Applicable authentication mechanisms.
   #-----------------------------------------------------
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/organization-discovery.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/organization-discovery.yaml
@@ -52,7 +52,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/check-discovery' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "type": "emailDomain",
               "value": "abc.com"

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -58,7 +58,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "ABC Builders",
               "description": "Building constructions",
@@ -114,7 +114,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/check-name:
     post:
       summary: Check organization with given name exist among the organizations hierarchy.
@@ -157,7 +157,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/check-name' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "XYZ Builders"
             }'
@@ -203,7 +203,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
     patch:
       description: |
         This API provides the capability to update an organization property
@@ -271,7 +271,7 @@ paths:
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '[
               {
                 "operation": "REPLACE",
@@ -354,7 +354,7 @@ paths:
             curl --location --request PUT 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "ABCD Builders",
               "description": "Building constructions company",
@@ -402,7 +402,7 @@ paths:
           source: |
             curl --location --request DELETE 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/metadata:
     get:
       tags:
@@ -432,7 +432,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/api-resources.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/api-resources.yaml
@@ -8,7 +8,6 @@ info:
 
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 servers:
   - url: 'https://{server-url}/t/{tenant-domain}/o/api/server/v1'
@@ -57,7 +56,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/api-resources' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /api-resources/{apiResourceId}:
     get:
       tags:
@@ -91,7 +90,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/api-resources/{apiResourceId}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /api-resources/{apiResourceId}/scopes:
     get:
       tags:
@@ -133,7 +132,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/api-resources/{apiResourceId}/scopes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /scopes:
     get:
       tags:
@@ -175,7 +174,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/scopes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     organizationId:
@@ -777,9 +776,6 @@ components:
             error: []
 
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/application.yaml
@@ -379,7 +379,7 @@ components:
       flows:
         authorizationCode:
           authorizationUrl: 'https://localhost:9443/oauth2/authorize'
-          tokenUrl: 'http://localhost:9763/oauth2/token'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
           scopes: {}
   schemas:
     Link:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -11,7 +11,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 paths:
   /authenticators:
@@ -330,9 +329,6 @@ components:
   # Applicable authentication mechanisms.
   #-----------------------------------------------------
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/certificate-validation-management.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/certificate-validation-management.yaml
@@ -17,7 +17,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 paths:
   /certificate-validation/revocation-validators:
@@ -54,7 +53,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/revocation-validators' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /certificate-validation/revocation-validators/{validatorName}:
     get:
       summary: Get a specific certificate validator configurations
@@ -105,7 +104,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/revocation-validators/{validator-name}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
     put:
       summary: Update the certificate validator configurations
       description: |
@@ -154,7 +153,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/revocation-validators/{validator-name}' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "enable": false,
@@ -194,7 +193,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4='
+              -H 'Authorization: Bearer {bearer_token}'
     post:
       summary: Add a new ca certificate
       description: |
@@ -237,7 +236,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"
@@ -291,7 +290,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"
@@ -344,7 +343,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca/{certificate-id}' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"
@@ -389,7 +388,7 @@ paths:
           source: |
             curl --location --request DELETE 
             'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca/{certificate-id}' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:
@@ -562,9 +561,6 @@ components:
   # Applicable authentication mechanisms.
   #-----------------------------------------------------
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/claim-mgt.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/claim-mgt.yaml
@@ -143,7 +143,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/o/api/server/v1/claim-dialects/local/claims' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "claimURI": "http://wso2.org/claims/username",
@@ -278,7 +278,7 @@ paths:
             curl -X 'PUT' \
             'https://localhost:9443/o/api/server/v1/claim-dialects/local/claims/{claim-id}' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "claimURI": "http://wso2.org/claims/username",
@@ -345,7 +345,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/o/api/server/v1/claim-dialects/local/claims/{claim-id}' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /claim-dialects:
     get:
       tags:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/email-templates-v2.yaml
@@ -774,9 +774,6 @@ components:
     Updated:
       description: Item Updated.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/email-templates.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/email-templates.yaml
@@ -555,9 +555,6 @@ components:
     Updated:
       description: Item Updated
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/notification-templates.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/notification-templates.yaml
@@ -1470,9 +1470,6 @@ components:
     Updated:
       description: Item Updated.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -574,7 +574,7 @@ paths:
           source: |
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/applications/{application-id}/authorized-apis/{api-id}' \
             -H 'Content-Type: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
                 "addedScopes": [
                     "bookings:write"
@@ -1125,9 +1125,6 @@ components:
       schema:
         type: string
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/organization-discovery.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/organization-discovery.yaml
@@ -52,7 +52,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/check-discovery' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "type": "emailDomain",
               "value": "abc.com"

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -58,7 +58,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "ABC Builders",
               "description": "Building constructions",
@@ -118,7 +118,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/check-name:
     post:
       summary: Check organization with given name exist among the organizations hierarchy.
@@ -161,7 +161,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/check-name' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "XYZ Builders"
             }'
@@ -207,7 +207,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
     patch:
       description: |
         This API provides the capability to update an organization property
@@ -275,7 +275,7 @@ paths:
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '[
               {
                 "operation": "REPLACE",
@@ -358,7 +358,7 @@ paths:
             curl --location --request PUT 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "ABCD Builders",
               "description": "Building constructions company",
@@ -406,7 +406,7 @@ paths:
           source: |
             curl --location --request DELETE 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/metadata:
     get:
       tags:
@@ -436,7 +436,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/meta-attributes:
     get:
       tags:
@@ -481,7 +481,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/meta-attributes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/user-store.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/user-store.yaml
@@ -7,7 +7,7 @@ info:
 
 security:
   - OAuth2: []
-  - BasicAuth: []
+
 paths:
   /userstores:
     post:
@@ -53,7 +53,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/o/api/server/v1/userstores' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "typeId": "VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg",
@@ -110,7 +110,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='  
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/import:
     post:
       tags:
@@ -186,7 +186,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/primary' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='           
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/{userstore-domain-id}:
     get:
       tags:
@@ -220,7 +220,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='          
+            -H 'Authorization: Bearer {bearer_token}'
     delete:
       tags:
         - User Store
@@ -248,7 +248,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='           
+            -H 'Authorization: Bearer {bearer_token}'
     put:
       tags:
         - User Store
@@ -290,7 +290,7 @@ paths:
             curl -X 'PUT' \
             'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "typeId": "VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg",
@@ -347,7 +347,7 @@ paths:
             curl -X 'PATCH' \
             'https://localhost:9443/o/api/server/v1/userstores/userstore-domain-id' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '[
             {
@@ -510,7 +510,7 @@ paths:
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}/attribute-mappings' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '[
               {
                 "claimURI": "http://wso2.org/claims/username",
@@ -547,7 +547,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/meta/types' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='         
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/meta/types/{type-id}:
     get:
       tags:
@@ -590,7 +590,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/meta/types/{user-store-type-id}' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   '/userstores/meta/types/{type-id}/attributes':
     get:
       tags:
@@ -634,7 +634,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/meta/types/{user-store-type-id}/attributes' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/test-connection:
     post:
       tags:
@@ -665,7 +665,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/o/api/server/v1/userstores/test-connection' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "driverName": "com.mysql.jdbc.Driver",
@@ -806,9 +806,6 @@ components:
     Forbidden:
       description: Resource Forbidden.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/api-resources.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/api-resources.yaml
@@ -8,7 +8,6 @@ info:
 
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 servers:
   - url: 'https://{server-url}/t/{tenant-domain}/o/api/server/v1'
@@ -57,7 +56,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/api-resources' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /api-resources/{apiResourceId}:
     get:
       tags:
@@ -91,7 +90,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/api-resources/{apiResourceId}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /api-resources/{apiResourceId}/scopes:
     get:
       tags:
@@ -133,7 +132,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/api-resources/{apiResourceId}/scopes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /scopes:
     get:
       tags:
@@ -175,7 +174,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/scopes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     organizationId:
@@ -777,9 +776,6 @@ components:
             error: []
 
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/application.yaml
@@ -379,7 +379,7 @@ components:
       flows:
         authorizationCode:
           authorizationUrl: 'https://localhost:9443/oauth2/authorize'
-          tokenUrl: 'http://localhost:9763/oauth2/token'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
           scopes: {}
   schemas:
     Link:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -11,7 +11,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 paths:
   /authenticators:
@@ -330,9 +329,6 @@ components:
   # Applicable authentication mechanisms.
   #-----------------------------------------------------
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/certificate-validation-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/certificate-validation-management.yaml
@@ -17,7 +17,6 @@ servers:
         default: carbon.super
 security:
   - OAuth2: []
-  - BasicAuth: []
 
 paths:
   /certificate-validation/revocation-validators:
@@ -54,7 +53,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/revocation-validators' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /certificate-validation/revocation-validators/{validatorName}:
     get:
       summary: Get a specific certificate validator configurations
@@ -105,7 +104,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/revocation-validators/{validator-name}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
     put:
       summary: Update the certificate validator configurations
       description: |
@@ -154,7 +153,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/revocation-validators/{validator-name}' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "enable": false,
@@ -194,7 +193,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4='
+              -H 'Authorization: Bearer {bearer_token}'
     post:
       summary: Add a new ca certificate
       description: |
@@ -237,7 +236,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"
@@ -291,7 +290,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"
@@ -344,7 +343,7 @@ paths:
           - lang: Curl
             source: |
               curl --location 'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca/{certificate-id}' \
-              -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+              -H 'Authorization: Bearer {bearer_token}' \
               -H 'Content-Type: application/json' \
               -d '{
                   "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"
@@ -389,7 +388,7 @@ paths:
           source: |
             curl --location --request DELETE 
             'https://localhost:9443/t/carbon.super/o/api/server/v1/certificate-validation/ca/{certificate-id}' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:
@@ -562,9 +561,6 @@ components:
   # Applicable authentication mechanisms.
   #-----------------------------------------------------
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/claim-mgt.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/claim-mgt.yaml
@@ -143,7 +143,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/o/api/server/v1/claim-dialects/local/claims' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "claimURI": "http://wso2.org/claims/username",
@@ -278,7 +278,7 @@ paths:
             curl -X 'PUT' \
             'https://localhost:9443/o/api/server/v1/claim-dialects/local/claims/{claim-id}' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "claimURI": "http://wso2.org/claims/username",
@@ -345,7 +345,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/o/api/server/v1/claim-dialects/local/claims/{claim-id}' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /claim-dialects:
     get:
       tags:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/email-templates-v2.yaml
@@ -774,9 +774,6 @@ components:
     Updated:
       description: Item Updated.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/email-templates.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/email-templates.yaml
@@ -555,9 +555,6 @@ components:
     Updated:
       description: Item Updated
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/notification-templates.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/notification-templates.yaml
@@ -1470,9 +1470,6 @@ components:
     Updated:
       description: Item Updated.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -286,7 +286,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationResponse'
+                $ref: '#/components/schemas/ApplicationResponseModel'
               example:
                 id: "394b8adcce24c64a8a09a0d80abf8c337bd253de"
                 name: "pickup"
@@ -712,7 +712,7 @@ paths:
           source: |
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/applications/{application-id}/authorized-apis/{api-id}' \
             -H 'Content-Type: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
                 "addedScopes": [
                     "bookings:write"
@@ -1403,9 +1403,6 @@ components:
       schema:
         type: string
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-discovery.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-discovery.yaml
@@ -52,7 +52,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/check-discovery' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "type": "emailDomain",
               "value": "abc.com"

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/organization-management.yaml
@@ -58,7 +58,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "ABC Builders",
               "description": "Building constructions",
@@ -118,7 +118,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/check-name:
     post:
       summary: Check organization with given name exist among the organizations hierarchy.
@@ -161,7 +161,7 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/check-name' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "XYZ Builders"
             }'
@@ -207,7 +207,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
     patch:
       description: |
         This API provides the capability to update an organization property
@@ -275,7 +275,7 @@ paths:
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '[
               {
                 "operation": "REPLACE",
@@ -358,7 +358,7 @@ paths:
             curl --location --request PUT 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '{
               "name": "ABCD Builders",
               "description": "Building constructions company",
@@ -406,7 +406,7 @@ paths:
           source: |
             curl --location --request DELETE 'https://localhost:9443/o/api/server/v1/organizations/{organization-id}' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/metadata:
     get:
       tags:
@@ -436,7 +436,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/metadata' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /organizations/meta-attributes:
     get:
       tags:
@@ -481,7 +481,7 @@ paths:
           source: |
             curl --location 'https://localhost:9443/o/api/server/v1/organizations/meta-attributes' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
 components:
   parameters:
     filterQueryParam:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/user-store.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/user-store.yaml
@@ -7,7 +7,7 @@ info:
 
 security:
   - OAuth2: []
-  - BasicAuth: []
+
 paths:
   /userstores:
     post:
@@ -53,7 +53,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/o/api/server/v1/userstores' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "typeId": "VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg",
@@ -110,7 +110,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='  
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/import:
     post:
       tags:
@@ -186,7 +186,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/primary' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='           
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/{userstore-domain-id}:
     get:
       tags:
@@ -220,7 +220,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='          
+            -H 'Authorization: Bearer {bearer_token}'
     delete:
       tags:
         - User Store
@@ -248,7 +248,7 @@ paths:
             curl -X 'DELETE' \
             'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}' \
             -H 'accept: */*' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='           
+            -H 'Authorization: Bearer {bearer_token}'
     put:
       tags:
         - User Store
@@ -290,7 +290,7 @@ paths:
             curl -X 'PUT' \
             'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "typeId": "VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg",
@@ -347,7 +347,7 @@ paths:
             curl -X 'PATCH' \
             'https://localhost:9443/o/api/server/v1/userstores/userstore-domain-id' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '[
             {
@@ -510,7 +510,7 @@ paths:
             curl --location --request PATCH 'https://localhost:9443/o/api/server/v1/userstores/{userstore-domain-id}/attribute-mappings' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -d '[
               {
                 "claimURI": "http://wso2.org/claims/username",
@@ -547,7 +547,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/meta/types' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='         
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/meta/types/{type-id}:
     get:
       tags:
@@ -590,7 +590,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/meta/types/{user-store-type-id}' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   '/userstores/meta/types/{type-id}/attributes':
     get:
       tags:
@@ -634,7 +634,7 @@ paths:
             curl -X 'GET' \
             'https://localhost:9443/o/api/server/v1/userstores/meta/types/{user-store-type-id}/attributes' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4='
+            -H 'Authorization: Bearer {bearer_token}'
   /userstores/test-connection:
     post:
       tags:
@@ -665,7 +665,7 @@ paths:
             curl -X 'POST' \
             'https://localhost:9443/o/api/server/v1/userstores/test-connection' \
             -H 'accept: application/json' \
-            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Authorization: Bearer {bearer_token}' \
             -H 'Content-Type: application/json' \
             -d '{
             "driverName": "com.mysql.jdbc.Driver",
@@ -806,9 +806,6 @@ components:
     Forbidden:
       description: Resource Forbidden.
   securitySchemes:
-    BasicAuth:
-      type: http
-      scheme: basic
     OAuth2:
       type: oauth2
       flows:


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->
- Organization APIs can't be invoked with basic auth. Updated all the sample curls given with basic auth Authorization header including https://github.com/wso2/product-is/issues/21015
Fixed the organization APIs in IS-7.0.0, IS-7.1.0, IS next version and Asgardeo 

- Updated wrong token endpoint `http://localhost:9763/oauth2/token` to `https://localhost:9443/oauth2/token` in some APIs

