### PR TITLE
[DOCS] Refresh token expiry time modifications via pre issue access token action

### DIFF
--- a/en/identity-server/next/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
+++ b/en/identity-server/next/docs/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/api/pre-issue-access-token-action-v1.yaml
@@ -34,8 +34,8 @@ paths:
                   - $ref: '#/components/schemas/SuccessResponse'
                   - $ref: '#/components/schemas/FailedResponse'
               examples:
-                successExample:
-                  summary: Success response
+                successExampleForAsscessTokenClaims:
+                  summary: Success response for access token claims add
                   value:
                     actionStatus: SUCCESS
                     operations:
@@ -44,6 +44,14 @@ paths:
                         value:
                           name: customSID
                           value: "12345"
+                successExampleForRefreshTokenClaims:
+                  summary: Successful response for refresh token expiry time update
+                  value:
+                    actionStatus: SUCCESS
+                    operations:
+                      - op: replace
+                        path: /refreshToken/claims/expires_in
+                        value: 42000
                 failedExample:
                   summary: Failed response
                   value:
@@ -89,6 +97,8 @@ components:
           $ref: '#/components/schemas/UserStore'
         accessToken:
           $ref: '#/components/schemas/AccessToken'
+        refreshToken:
+          $ref: '#/components/schemas/RefreshToken'
       description: Defines the context data related to the pre issue access token event that needs to be shared with the custom service to process and execute.
     Request:
       type: object
@@ -176,7 +186,7 @@ components:
       properties:
         tokenType:
           type: string
-          example: HASH
+          example: JWT
           enum:
             - JWT
           description: Defines the type of token.
@@ -226,6 +236,25 @@ components:
           example:
             - read
       description: Represents the access token that is about to be issued. It contains claims and scopes, of the access token which can then be modified by your external service based on the logic implemented in the pre-issue access token action.
+    RefreshToken:
+      type: object
+      required:
+        - claims
+      properties:
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/RefreshTokenClaims'
+          description: |
+            An array that contains refresh token claims.
+            
+            Standard claims:
+            
+            - **expires_in**: The duration (in seconds) for which the refresh token is valid.
+          example:
+            - name: expires_in
+              value: 3600
+      description: Represents the refresh token that is about to be issued. It contains claims, of the refresh token which can then be modified by your external service based on the logic implemented in the pre-issue access token action.
     AllowedOperations:
       type: array
       description: Defines the set of operations that your external service is permitted to perform on the access token's claims and scopes.
@@ -269,6 +298,7 @@ components:
             example: 
             - /accessToken/claims
             - /accessToken/scopes
+            - /refreshToken/claims/expires_in
       description: Defines the replace operation.
     removeOperation:
       type: object
@@ -412,6 +442,19 @@ components:
             - type: array
               items:
                 type: string
+    RefreshTokenClaims:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          oneOf:
+            - type: string
+            - type: integer
+            - type: boolean
+            - type: array
+              items:
+                type: string
     addOperationResponse:
       type: object
       required:
@@ -451,7 +494,8 @@ components:
           example: 
             - /accessToken/claims/1
             - /accessToken/scopes/-
-          description: Defines the path for the replace operation. Should be one from the allowed paths of `replace` operation in the allowedOperations. 
+            - /refreshToken/claims/expires_in
+          description: Defines the path for the replace operation. Should be one from the allowed paths of `replace` operation in the allowedOperations.
         value:
           type: string
           description: Defines the value for the replace operation.

--- a/en/includes/guides/service-extensions/pre-flow-extensions/pre-issue-access-token-action.md
+++ b/en/includes/guides/service-extensions/pre-flow-extensions/pre-issue-access-token-action.md
@@ -174,13 +174,33 @@ All request parameters are not incorporated, specially sensitive parameters like
 </table>
 </td>
 </tr>
+<tr class="even">
+<td>event.refreshToken</td>
+<td><p>This property represents the refresh token associated with the token issuance event. It contains the claims related to the refresh token, such as expires_in. These claims can be modified by your external service during the pre-issue access token action based on custom logic.</p>
+<table>
+<tbody>
+<tr>
+<td>claims</td>
+<td><p>This property is an array that contains the claims related to the refresh token.</p>
+<table>
+<tbody>
+<tr>
+<td>expires_in</td>
+<td>The duration (in seconds) for which the refresh token is valid.</td>
+</tr>
+</tbody>
+</table>
+</tbody>
+</table>
+</td>
+</tr>
 </tbody>
 </table>
 
 #### allowedOperations
 <a name="allowed-operations"></a>
 
-The allowedOperations property in the context of the pre-issue access token action defines the set of operations that your external service is permitted to perform on the access token's claims and scopes. This property is specifically related to the <code>event.accessToken</code> property and outlines which attributes can have additional properties added, values replaced, or be removed. The <code>allowedOperations</code> are defined using JSON Patch modification semantics.
+The allowedOperations property in the context of the pre-issue access token action defines the set of operations that your external service is permitted to perform on the access token's claims as well as on certain claims of the refresh token. This property is specifically related to the <code>event.accessToken</code> and <code>event.refreshToken</code> properties and outlines which attributes can have additional properties added, values replaced, or be removed. The <code>allowedOperations</code> are defined using JSON Patch modification semantics.
 
 In the context of the pre-issue access token action, certain claims related to authorization decisions, such as audience (aud), access token validity (expires_in), and scopes (scopes), are allowed to be modified. These claims are typically associated with the resource server and influence how access is granted.
 
@@ -210,7 +230,8 @@ Here is the example of an allowedOperations object in a request formatted as a J
       "paths": [
         "/accessToken/scopes/",
         "/accessToken/claims/aud/",
-        "/accessToken/claims/expires_in"
+        "/accessToken/claims/expires_in",
+        "/refreshToken/claims/expires_in"
       ]
     }
   ]
@@ -297,6 +318,14 @@ Content-Type: application/json
                     "value": "e204849c-4ec2-41f1-8ff7-ec1ebff02821"
                 }
             ]
+        },
+        "refreshToken": {
+            "claims": {
+                {
+                    "name": "expires_in",
+                    "value": 86400
+                }
+            }
         }
     },
     "allowedOperations": [
@@ -320,7 +349,8 @@ Content-Type: application/json
             "paths": [
                 "/accessToken/scopes/",
                 "/accessToken/claims/aud/",
-                "/accessToken/claims/expires_in"
+                "/accessToken/claims/expires_in",
+                "/refreshToken/claims/expires_in"
             ]
         }
     ]

--- a/en/includes/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/sample-success-responses.md
+++ b/en/includes/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/sample-success-responses.md
@@ -168,3 +168,23 @@ Content-Type: application/json;charset=UTF-8
  ]
 }
 ```
+## Changing the refresh token validity period
+
+The duration for which the refresh token is valid can be changed in seconds.
+Refer to the example response below, which demonstrates changing the validity period of the refresh token:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "actionStatus": "SUCCESS",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "/refreshToken/claims/expires_in",
+      "value": 48600
+    }
+ ]
+}
+```


### PR DESCRIPTION
This PR includes the documentation improvements done to incorporate the enhancement done for modifying the refresh token expiry on pre issue access token action.

Paren issue:
- https://github.com/wso2/product-is/issues/23733