### PR TITLE
Add clarification on executing additional steps within eventCallback

### DIFF
--- a/en/identity-server/7.0.0/docs/references/conditional-auth/api-reference.md
+++ b/en/identity-server/7.0.0/docs/references/conditional-auth/api-reference.md
@@ -88,7 +88,8 @@ This method accepts an object as a parameter and should include the details list
   <tr>
     <td><code>&lteventCallbacks&gt</code></td>
     <td>(optional) The object that contains the callback functions, which are to be called based on the result of the step execution.<br />
-    Supported results are <code>onSuccess</code> and <code>onFail</code>, which can have their own optional callbacks as anonymous functions.</td>
+    Supported results are <code>onSuccess</code> and <code>onFail</code> which can have their own optional callbacks as anonymous functions.<br />
+    If the flow reaches the eventCallback stage and additional steps need to be executed, those steps should be included within the callback itself.</td>
   </tr>
 </table>
 

--- a/en/identity-server/7.1.0/docs/references/conditional-auth/api-reference.md
+++ b/en/identity-server/7.1.0/docs/references/conditional-auth/api-reference.md
@@ -89,7 +89,8 @@ This method accepts an object as a parameter and should include the details list
   <tr>
     <td><code>&lteventCallbacks&gt</code></td>
     <td>(optional) The object that contains the callback functions, which are to be called based on the result of the step execution.<br />
-    Supported results are <code>onSuccess</code> and <code>onFail</code> which can have their own optional callbacks as anonymous functions. For these callbacks, the [context](#context) and [data](#data) parameters are passed.
+    Supported results are <code>onSuccess</code> and <code>onFail</code> which can have their own optional callbacks as anonymous functions. For these callbacks, the [context](#context) and [data](#data) parameters are passed.<br />
+    If the flow reaches the eventCallback stage and additional steps need to be executed, those steps should be included within the callback itself.
     </td>
   </tr>
 </table>

--- a/en/identity-server/next/docs/references/conditional-auth/api-reference.md
+++ b/en/identity-server/next/docs/references/conditional-auth/api-reference.md
@@ -89,7 +89,8 @@ This method accepts an object as a parameter and should include the details list
   <tr>
     <td><code>&lteventCallbacks&gt</code></td>
     <td>(optional) The object that contains the callback functions, which are to be called based on the result of the step execution.<br />
-    Supported results are <code>onSuccess</code> and <code>onFail</code> which can have their own optional callbacks as anonymous functions. For these callbacks, the [context](#context) and [data](#data) parameters are passed.
+    Supported results are <code>onSuccess</code> and <code>onFail</code> which can have their own optional callbacks as anonymous functions. For these callbacks, the [context](#context) and [data](#data) parameters are passed.<br />
+    If the flow reaches the eventCallback stage and additional steps need to be executed, those steps should be included within the callback itself.
     </td>
   </tr>
 </table>

--- a/en/includes/references/conditional-auth/api-reference.md
+++ b/en/includes/references/conditional-auth/api-reference.md
@@ -90,7 +90,8 @@ This method accepts an object as a parameter and should include the details list
     <td><code>&lteventCallbacks&gt</code></td>
     <td>(optional) The object that contains the callback functions, which are to be called based on the result of the step execution.<br />
     Supported results are <code>onSuccess</code> and <code>onFail</code> which can
-              have their own optional callbacks as anonymous functions. For these callbacks, the [context](#context) and [data](#data) parameters are passed.
+              have their own optional callbacks as anonymous functions. For these callbacks, the [context](#context) and [data](#data) parameters are passed.<br />
+    If the flow reaches the eventCallback stage and additional steps need to be executed, those steps should be included within the callback itself.
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Purpose
Updated documentation to specify that any additional logic must be included within the eventCallback if the flow reaches that point.