### PR TITLE
[IS 5.11.0 & IS 5.10.0]Update instruction for the AWS ECS schema in Hazelcast clustering

### DIFF
--- a/en/identity-server/5.10.0/docs/setup/deployment-guide.md
+++ b/en/identity-server/5.10.0/docs/setup/deployment-guide.md
@@ -209,7 +209,8 @@ WSO2 supports the following membership schemes for clustering
         ??? tip "Click to see the instructions for AWS ECS membership scheme"  
                       
             1. Create a working AWS ECS Cluster. Note the following when creating a cluster.
-                -   Note the `name` and `VPC CIDR block` of the cluster as you will require them later for configurations.
+                -   Select the `EC2 instance` type.
+                -   Note the `name` and `VPC CIDR block` of the cluster, as you will require them later for configurations.
                 -   Ensure that the `Container instance IAM role` that you assign to the ECS cluster has the following permission policy attached. 
                         ```
                         { "Version": "2012-10-17", 
@@ -228,12 +229,9 @@ WSO2 supports the following membership schemes for clustering
                         }
     
                         ```
-                -   Make sure that the security group of the cluster instances has an inbound rule to allow incoming 
-                traffic on the Hazelcast default port range `(5701 - 5708)`. It is advised to restrict the access to 
-                instances in the same security group for this inbound rule. 
+                -   Make sure that the security group of the cluster instances has an inbound rule to allow incoming traffic on the Hazelcast default port range `(5701 - 5708)`. It is advised to restrict access to instances in the same security group for this inbound rule.
             
-            2. Create a `deployment.toml` file in a preferred directory to add following configurations.
-            Configure the following entries.                    
+            2. Create a `deployment.toml` file in a preferred directory and add the following configurations.
                     ```
                     [clustering]
                     membership_scheme = "aws-ecs"
@@ -241,16 +239,17 @@ WSO2 supports the following membership schemes for clustering
                     [clustering.properties]
                     region = "us-east-1"
                     clusterName = "ECS-IS-CLUSTER"
+                    hostHeader = "ec2"
                     vpcCidrBlock = "10.0.*.*"
+                    tagValue = "a_tag_value"
                     ```                    
-            Under the `clustering.properties` section, set the `region`, `clusterName`, and `vpcCidrBlock` based on 
-            the AWS ECS cluster that you created in the previous step.       
+            Under the `clustering.properties` section, set the `region`, `clusterName`, `tagValue` and `vpcCidrBlock` based on the AWS ECS cluster you created in the previous step. The `tagValue` is derived from the auto-generated tag `aws:cloudformation:stack-name` in the AWS cluster. If you want to use a custom tag, you'll need to update both the `tagKey` and the `tagValue` accordingly.
 
             !!! note
-                Once all the configurations are complete, build a docker image including the configurations. You can 
-                consume this docker image to 
-                create a `Task Definition` and run a new `Service` or a `Task` 
-                on the `AWS ECS cluster` that you created.
+                As only the `host` network mode is supported, the `hostHeader` value should be set to `"ec2"` in the `clustering.properties` section.
+
+            !!! note
+                Once all the configurations are complete, build a docker image including the configurations. You can use this Docker image to create a `Task Definition`, and make sure to set the network mode to `host` in the definition. Then run a new `Service` or a `Task` on the `AWS ECS cluster` you created.
 
         ??? tip "Click to see the instructions for AWS EC2 membership scheme"  
 

--- a/en/identity-server/5.11.0/docs/setup/deployment-guide.md
+++ b/en/identity-server/5.11.0/docs/setup/deployment-guide.md
@@ -211,7 +211,8 @@ WSO2 supports the following membership schemes for clustering
         ??? tip "Click to see the instructions for AWS ECS membership scheme"  
                       
             1. Create a working AWS ECS Cluster. Note the following when creating a cluster.
-                -   Note the `name` and `VPC CIDR block` of the cluster as you will require them later for configurations.
+                -   Select the `EC2 instance` type.
+                -   Note the `name` and `VPC CIDR block` of the cluster, as you will require them later for configurations.
                 -   Ensure that the `Container instance IAM role` that you assign to the ECS cluster has the following permission policy attached. 
                         ```
                         { "Version": "2012-10-17", 
@@ -230,12 +231,9 @@ WSO2 supports the following membership schemes for clustering
                         }
     
                         ```
-                -   Make sure that the security group of the cluster instances has an inbound rule to allow incoming 
-                traffic on the Hazelcast default port range `(5701 - 5708)`. It is advised to restrict the access to 
-                instances in the same security group for this inbound rule. 
+                -   Make sure that the security group of the cluster instances has an inbound rule to allow incoming traffic on the Hazelcast default port range `(5701 - 5708)`. It is advised to restrict access to instances in the same security group for this inbound rule.
             
-            2. Create a `deployment.toml` file in a preferred directory to add following configurations.
-            Configure the following entries.                    
+            2. Create a `deployment.toml` file in a preferred directory and add the following configurations.
                     ```
                     [clustering]
                     membership_scheme = "aws-ecs"
@@ -243,16 +241,17 @@ WSO2 supports the following membership schemes for clustering
                     [clustering.properties]
                     region = "us-east-1"
                     clusterName = "ECS-IS-CLUSTER"
+                    hostHeader = "ec2"
                     vpcCidrBlock = "10.0.*.*"
+                    tagValue = "a_tag_value"
                     ```                    
-            Under the `clustering.properties` section, set the `region`, `clusterName`, and `vpcCidrBlock` based on 
-            the AWS ECS cluster that you created in the previous step.       
+            Under the `clustering.properties` section, set the `region`, `clusterName`, `tagValue` and `vpcCidrBlock` based on the AWS ECS cluster you created in the previous step. The `tagValue` is derived from the auto-generated tag `aws:cloudformation:stack-name` in the AWS cluster. If you want to use a custom tag, you'll need to update both the `tagKey` and the `tagValue` accordingly.
 
             !!! note
-                Once all the configurations are complete, build a docker image including the configurations. You can 
-                consume this docker image to 
-                create a `Task Definition` and run a new `Service` or a `Task` 
-                on the `AWS ECS cluster` that you created.
+                As only the `host` network mode is supported, the `hostHeader` value should be set to `"ec2"` in the `clustering.properties` section.
+
+            !!! note
+                Once all the configurations are complete, build a docker image including the configurations. You can use this Docker image to create a `Task Definition`, and make sure to set the network mode to `host` in the definition. Then run a new `Service` or a `Task` on the `AWS ECS cluster` you created.
 
         ??? tip "Click to see the instructions for AWS EC2 membership scheme"  
 


### PR DESCRIPTION
## Purpose
$note subject. Related to https://github.com/wso2/docs-is/pull/5365

Need add information about
- `hostHeader` - this should be set `host`
-  `tagValue` - should be based on the autogenerated tag `aws:cloudformation:stack-name`
-  mention about E2 instance type in the cluster creation
-  network mode should be set to `host` in the task definition.

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?