### PR TITLE
Show unicode user attributes in documentations

### DIFF
--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
@@ -4,13 +4,13 @@ By default, WSO2 Identity Server uses the embedded H2 database as the database
 for storing user management and registry data. Given below are the steps
 you need to follow in order to use MS SQL for this purpose.
 
----    
+---
 
 ## Set up datasource configurations
 
 {% include "../../../../includes/datasource-config.md" %}
-                       
-After setting up the MS SQL database, you can point the `WSO2_IDENTITY_DB` or 
+                 
+After setting up the MS SQL database, you can point the `WSO2_IDENTITY_DB` or
 `WSO2_SHARED_DB` or both to that MS SQL database by following the instructions given below.
 
 ---
@@ -18,16 +18,16 @@ After setting up the MS SQL database, you can point the `WSO2_IDENTITY_DB` or
 ## Change the default datasource
 
 ### Minimum configurations for changing default datasource to MS SQL
- 
-You can configure the datasource by editing the default configurations in `<IS-HOME>/repository/conf/deployment.toml`. 
 
-Following are the basic configurations and their descriptions. 
+You can configure the datasource by editing the default configurations in `<IS-HOME>/repository/conf/deployment.toml`.
+
+Following are the basic configurations and their descriptions.
 
 {% include "../../../../includes/db-basic-config.md" %}
  
 A sample configuration is given below.
 
-1. `WSO2_IDENTITY_DB` 
+1. `WSO2_IDENTITY_DB`
 
     1. Configure the `<IS-HOME>/repository/conf/deployment.toml` file.
 

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
@@ -9,7 +9,7 @@ you need to follow in order to use MS SQL for this purpose.
 ## Set up datasource configurations
 
 {% include "../../../../includes/datasource-config.md" %}
-                 
+
 After setting up the MS SQL database, you can point the `WSO2_IDENTITY_DB` or
 `WSO2_SHARED_DB` or both to that MS SQL database by following the instructions given below.
 
@@ -24,7 +24,7 @@ You can configure the datasource by editing the default configurations in `<IS-H
 Following are the basic configurations and their descriptions.
 
 {% include "../../../../includes/db-basic-config.md" %}
- 
+
 A sample configuration is given below.
 
 1. `WSO2_IDENTITY_DB`
@@ -40,16 +40,16 @@ A sample configuration is given below.
         password = "regadmin"
         port = "1433"
         ```
-    
+
     2. Execute database scripts.
-    
+
         Navigate to `<IS-HOME>/dbscripts`. Execute the scripts in the following files against the database created.
         
         - `<IS-HOME>/dbscripts/identity/mssql.sql`
         - `<IS-HOME>/dbscripts/consent/mssql.sql`
-        
+
 2. `WSO2_SHARED_DB`
-    
+
     1.  Configure the `<IS-HOME>/repository/conf/deployment.toml` file.
 
         ``` toml
@@ -61,9 +61,9 @@ A sample configuration is given below.
         password = "regadmin"
         port = "1433"
         ```
-        
+
     2.  Execute database scripts.
-    
+
         Execute the scripts in the `<IS-HOME>/dbscripts/mssql.sql` file, against the database created.
 
     !!! note
@@ -77,7 +77,7 @@ A sample configuration is given below.
         CaseInsensitiveUsername = false
         UseCaseSensitiveUsernameForCacheKeys = false
         ```  
-    
+
         For secondary user stores, add the following configurations to the `<userstore>.xml` file found in the `<IS_HOME>/repository/deployment/server/userstores` directory.
 
         ``` xml

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-mssql.md
@@ -84,6 +84,20 @@ A sample configuration is given below.
         <Property name="CaseInsensitiveUsername">false</Property>
         <Property name="UseCaseSensitiveUsernameForCacheKeys">false</Property>
         ```
+
+    !!! note
+        To store user attributes as Unicode for the primary user store, open the `deployment.toml` file found in the `<IS-HOME>/repository/conf/` directory and add the following configuration under the primary user store.
+
+        ```toml
+        [user_store.properties]
+        StoreUserAttributeValueAsUnicode = true
+        ```
+
+        For secondary user stores, this setting is enabled by default. However, if you need to explicitly configure it, add the following property to the `<userstore>.xml` file located in the `<IS_HOME>/repository/deployment/server/userstores` directory.
+
+        ```xml
+        <Property name="StoreUserAttributeValueAsUnicode">true</Property>
+        ```
     
 3.  Download the MS SQL JDBC driver for the version you are using and copy it to the `<IS_HOME>/repository/components/lib` folder.  
 

--- a/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
+++ b/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
@@ -159,7 +159,7 @@ false: Set it to <code>false</code> if the user roles are changed by external me
 <td>Store User Attribute Value As Unicode</td>
 <td>
 Applicable only to MSSQL user stores. Specifies whether user attributes are stored as Unicode (<code>true</code>) or plain text (<code>false</code>). To ensure compatibility with non-ASCII characters, it's recommended to set this property to true.<br/>
-{% if product_version > "7.1.0" %}
+{% if is_version > "7.1.0" %}
 <p>Default : false for primary user store, true for secondary user stores </p>
 {% else %}
 <p>Default : false </p>

--- a/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
+++ b/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
@@ -158,10 +158,12 @@ false: Set it to <code>false</code> if the user roles are changed by external me
 <td><code>properties.StoreUserAttribute.ValueAsUnicode</code></td>
 <td>Store User Attribute Value As Unicode</td>
 <td>
-Applicable only to MSSQL user stores.<br/>
-Stores user attributes as Unicode (<code>true</code>) or plain text (<code>false</code>).<br/>
-Use <code>true</code> to support non-ASCII characters.<br/>
+Applicable only to MSSQL user stores. Specifies whether user attributes are stored as Unicode (<code>true</code>) or plain text (<code>false</code>). To ensure compatibility with non-ASCII characters, it is recommended to set this property to true.<br/>
+{% if product_version > "7.1.0" %}
 <p>Default : false for primary user store, true for secondary user stores </p>
+{% else %}
+<p>Default : false </p>
+{% endif %}
 </td>
 </tr>
 </tbody>

--- a/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
+++ b/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
@@ -84,7 +84,7 @@ Default: ^[\S]{5,30}$</td>
 </tr>
 <tr class="even">
 <td>PasswordJavaReg<br>ExViolationErrorMsg</td>
-<td><code>password_java_reg<br>ex_violation_error_msg</code></td>
+<td><code>password_java_regex_violation_error_msg</code></td>
 <td>Password RegEx Violation Error Message</td>
 <td>Error message when the Password is not matched with passwordJavaRegEx<br />
 <p>Default: The password length should be within 5 to 30 characters.</p></td>
@@ -155,10 +155,10 @@ false: Set it to <code>false</code> if the user roles are changed by external me
 </tr>
 <tr class="even">
 <td>StoreUserAttribute</br>ValueAsUnicode</td>
-<td><code>properties.StoreUserAttribute.ValueAsUnicode</code></td>
+<td><code>properties.StoreUserAttributeValueAsUnicode</code></td>
 <td>Store User Attribute Value As Unicode</td>
 <td>
-Applicable only to MSSQL user stores. Specifies whether user attributes are stored as Unicode (<code>true</code>) or plain text (<code>false</code>). To ensure compatibility with non-ASCII characters, it is recommended to set this property to true.<br/>
+Applicable only to MSSQL user stores. Specifies whether user attributes are stored as Unicode (<code>true</code>) or plain text (<code>false</code>). To ensure compatibility with non-ASCII characters, it's recommended to set this property to true.<br/>
 {% if product_version > "7.1.0" %}
 <p>Default : false for primary user store, true for secondary user stores </p>
 {% else %}

--- a/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
+++ b/en/includes/guides/users/user-stores/properties-jdbc-user-store.md
@@ -12,7 +12,7 @@ Following are the properties that can be configured in JDBC user store manager.
 <tbody>
 <tr class="odd">
 <td>ReadGroups</td>
-<td>read_groups</td>
+<td><code>read_groups</code></td>
 <td>ReadGroups</td>
 <td>When ReadGroups is set to <code>false</code>, it indicates whether groups should be read from the user store. If this is disabled, none of the groups in the user store can be read, and the following group configurations are NOT mandatory: GroupSearchBase, GroupNameListFilter, or GroupNameAttribute.<br />
 <br />
@@ -23,7 +23,7 @@ false: Does not read groups from user store</p></td>
 </tr>
 <tr class="even">
 <td>WriteGroups</td>
-<td>write_groups</td>
+<td><code>write_groups</code></td>
 <td>WriteGroups</td>
 <td>Indicates whether groups should be written to the user store<br />
 <br />
@@ -34,7 +34,7 @@ false : Does not write groups to the user store, so only internal roles can be c
 </tr>
 <tr class="odd">
 <td>PasswordHashMethod</td>
-<td>password_hash_method</td>
+<td><code>password_hash_method</code></td>
 <td>Password Hashing Algorithm</td>
 <td><p>Specifies the Password Hashing Algorithm used to hash the password before storing it in the user store<br />
 Possible values:<br />
@@ -49,62 +49,62 @@ The default value for JDBC user stores is SHA-256.
 </tr>
 <tr class="odd">
 <td>UsernameJavaRegEx</td>
-<td>username_java_regex</td>
-<td>UsernameJavaRegEx</td>
+<td><code>username_java_regex</code></td>
+<td>Username RegEx (Java)</td>
 <td>This is the regular expression used by the back-end components for username validation. By default, strings with non-empty characters having a length of 3 to 30 are allowed. You can provide ranges of alphabets, numbers, and ASCII values in the RegEx properties.<br/>
 <p>Default: ^[\S]{3,30}$</td></p> <br/>
 </tr>
 <tr class="even">
 <td>UsernameJava<br>ScriptRegEx</td>
-<td>username_java_<br>script_regex</td>
-<td>UsernameJavaScriptRegEx</td>
+<td><code>username_java_script_regex</code></td>
+<td>Username RegEx (Javascript)</td>
 <td>The regular expression used by the front-end components for username validation
 <br/><p> Default: ^[\S]{3,30}$  </p></td>
 </tr>
 <tr class="odd">
 <td>UsernameJavaReg<br>ExViolationErrorMsg</td>
-<td>username_java_reg<br>_ex_violation_error_msg</td>
+<td><code>username_java_reg_ex_violation_error_msg</code></td>
 <td>Username RegEx Violation Error Message</td>
 <td>Error message when the username doesn't match with username_java_regex
 <br/><p> Default: Username pattern policy violated  </p></td>
 </tr>
 <tr class="even">
 <td>PasswordJavaRegEx</td>
-<td>password_java_regex</td>
+<td><code>password_java_regex</code></td>
 <td>Password RegEx (Java)</td>
 <td>This is the regular expression used by the back-end components for password validation. By default, strings with non-empty characters having a length of 5 to 30 are allowed. You can provide ranges of alphabets, numbers, and ASCII values in the RegEx properties.<br />
 Default: ^[\S]{5,30}$</td>
 </tr>
 <tr class="odd">
 <td>PasswordJava<br>ScriptRegEx</td>
-<td>password_java_<br>script_regex</td>
+<td><code>password_java_script_regex</code></td>
 <td>Password RegEx (Javascript)</td>
 <td>The regular expression used by the front-end components for password validation<br />
 <p>Default: ^[\S]{5,30}$</p></td>
 </tr>
 <tr class="even">
 <td>PasswordJavaReg<br>ExViolationErrorMsg</td>
-<td>password_java_reg<br>ex_violation_error_msg</td>
+<td><code>password_java_reg<br>ex_violation_error_msg</code></td>
 <td>Password RegEx Violation Error Message</td>
 <td>Error message when the Password is not matched with passwordJavaRegEx<br />
 <p>Default: The password length should be within 5 to 30 characters.</p></td>
 <tr class="odd">
 <td>RolenameJavaRegEx</td>
-<td>rolename_java_regex</td>
+<td><code>rolename_java_regex</code></td>
 <td>Role Name RegEx (Java)</td>
 <td>This is the regular expression used by the back-end components for role name validation. By default, strings with non-empty characters having a length of 3 to 30 are allowed. You can provide ranges of alphabets, numbers, and ASCII values in the RegEx properties.<br />
 <p>Default: [a-zA-Z0-9._-|//]{3,30}$</p></td>
 </tr>
 <tr class="odd">
 <td>MultiAttribute<br>Separator</td>
-<td>multi_attribute<br>_separator</td>
+<td><code>multi_attribute_separator</code></td>
 <td>Multiple Attribute Separator</td>
 <td>This property is used to define a character to separate multiple attributes. This ensures that it will not appear as part of a claim value. Normally “,” is used to separate multiple attributes, but you can define ",,," or "..." or a similar character sequence.<br />
 <p>Default: “,”</p></td>
 </tr>
 <tr class="even">
 <td>MaxUserName<br>ListLength</td>
-<td>max_user_name_<br>list_length</td>
+<td><code>max_user_name_list_length</code></td>
 <td>Maximum User List Length</td>
 <td>This controls the number of users listed in the user store of WSO2 Identity Server. This is useful when you have a large number of users and do not want to list them all. Setting this property to 0 displays all users. (Default: 100)<br />
 <br />
@@ -113,7 +113,7 @@ Eg: Active directory has the MaxPageSize property with the default value of 100.
 </tr>
 <tr class="odd">
 <td>MaxRoleName<br>ListLength</td>
-<td>max_role_name_<br>list_length</td>
+<td><code>max_role_name_list_length</code></td>
 <td>Maximum Role List Length</td>
 <td>This controls the number of roles listed in the user store of WSO2 Identity Server. This is useful when you have a large number of roles and do not want to list them all. Setting this property to 0 displays all roles. (Default: 100)<br />
 <br />
@@ -122,7 +122,7 @@ Eg: Active directory has the MaxPageSize property with the default value of 1000
 </tr>
 <tr class="even">
 <td>UserRolesCacheEnabled</td>
-<td>user_roles_cache_enabled</td>
+<td><code>user_roles_cache_enabled</code></td>
 <td>Enable User Role Cache</td>
 <td>This is to indicate whether to cache the role list of a user. (Default: true)<br />
 <br />
@@ -131,7 +131,7 @@ false: Set it to <code>false</code> if the user roles are changed by external me
 </tr>
 <tr class="odd">
 <td>CaseInsensitiveUsername</td>
-<td>properties.</br>CaseInsensitiveUsername</td>
+<td><code>properties.CaseInsensitiveUsername</code></td>
 <td>Case Insensitive Username</td>
 <td>This enables the case insensitivity of the user's username. Default value is <code>true</code> for this configuration.
 <br />Eg: If a user's username is <code>test</code>, that user can also use the username as <code>TEST</code>.
@@ -139,7 +139,7 @@ false: Set it to <code>false</code> if the user roles are changed by external me
 </tr>
 <tr class="even">
 <td>CaseInsensitiveAttributes</td>
-<td>properties.</br>CaseInsensitiveAttributes</td>
+<td><code>properties.CaseInsensitiveAttributes</code></td>
 <td>Case Insensitive Attributes</td>
 <td>This enables case insensitivity of the user attributes.<br/>
 <p>Default : false </p>
@@ -147,10 +147,21 @@ false: Set it to <code>false</code> if the user roles are changed by external me
 </tr>
 <tr class="odd">
 <td>IsBulkImportSupported</td>
-<td>properties.</br>IsBulkImportSupported</td>
-<td>IsBulkImportSupported</td>
+<td><code>properties.IsBulkImportSupported</code></td>
+<td>Is Bulk Import Supported</td>
 <td>Enables bulk import support for the user store.<br/>
 <p>Default : true </p>
+</td>
+</tr>
+<tr class="even">
+<td>StoreUserAttribute</br>ValueAsUnicode</td>
+<td><code>properties.StoreUserAttribute.ValueAsUnicode</code></td>
+<td>Store User Attribute Value As Unicode</td>
+<td>
+Applicable only to MSSQL user stores.<br/>
+Stores user attributes as Unicode (<code>true</code>) or plain text (<code>false</code>).<br/>
+Use <code>true</code> to support non-ASCII characters.<br/>
+<p>Default : false for primary user store, true for secondary user stores </p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
## Purpose
Mention about the user store property to enable unicode user attributes, in the documentations.

![localhost_8000_en_next_guides_users_user-stores_user-store-properties_properties-jdbc-user-store_](https://github.com/user-attachments/assets/7f2f8c95-c5aa-475b-a24d-7531dd3bbd0d)

![localhost_8000_en_next_deploy_configure_databases_carbon-database_change-to-mssql_](https://github.com/user-attachments/assets/3382c036-31eb-4f46-a3aa-3d355c521a88)

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


