### PR TITLE
Fix broken links to js and nodejs quickstart guides

### DIFF
--- a/en/identity-server/7.1.0/mkdocs.yml
+++ b/en/identity-server/7.1.0/mkdocs.yml
@@ -43,11 +43,11 @@ extra:
             - title: Connect Angular App
               url: Get started|Connect App|Angular|Quickstart
             - title: Connect Javascript App
-              url: Get started|Connect App|Javascript Quickstart
+              url: Get started|Connect App|Javascript|Quickstart
             - title: Connect Next.js App
               url: Get started|Connect App|Next.js Quickstart
             - title: Connect Node.js App
-              url: Get started|Connect App|Node.js Quickstart
+              url: Get started|Connect App|Node.js|Quickstart
             - title: Connect Spring Boot App
               url: Get started|Connect App|Spring Boot Quickstart
         - title: Community and Support


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/24562

The issue is reproducible only in IS-7.1.0 docs
