### PR TITLE
Add tip linking to sample password validator in pre-update password action documentation

### DIFF
--- a/en/includes/guides/service-extensions/pre-flow-extensions/pre-update-password-action.md
+++ b/en/includes/guides/service-extensions/pre-flow-extensions/pre-update-password-action.md
@@ -488,7 +488,7 @@ Content-Type: application/json
 ```
 
 !!! tip
-    Utilize the [pre-update password extension samples](https://github.com/asgardeo-samples/asgardeo-service-extension-samples/tree/main/pre-update-password-extension-samples) to understand how to validate passwords against a compromised password list and how to handle the response appropriately.
+    Use the [pre-update password extension samples](https://github.com/asgardeo-samples/asgardeo-service-extension-samples/tree/main/pre-update-password-extension-samples) to understand how to check passwords against a compromised password list and how to handle the response appropriately.
 
 !!! note
     Currently, the <code>errorMessage</code> or <code>errorDescription</code> from the external service’s <code>ERROR</code> response doesn't directly include in the error response sent back to the application.


### PR DESCRIPTION
>Resolve issue: https://github.com/asgardeo-samples/asgardeo-service-extension-samples/issues/11

This pull request adds a helpful tip to the documentation for pre-update password extensions, guiding users to a sample repository for better understanding.

Documentation update:
- `en/includes/guides/service-extensions/pre-flow-extensions/pre-update-password-action.md`: Added a tip linking to a sample repository that demonstrates how to validate passwords against a compromised password list and handle responses effectively.
<img width="1038" height="506" alt="Screenshot 2025-07-18 at 2 53 03 PM" src="https://github.com/user-attachments/assets/4edb0a29-4b51-4c4c-88ff-b0f4ef5eace7" />




## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


