### PR TITLE
Add configs in remote log publishing configurations

### DIFF
--- a/en/identity-server/7.0.0/docs/deploy/monitor/remote-log-publishing.md
+++ b/en/identity-server/7.0.0/docs/deploy/monitor/remote-log-publishing.md
@@ -9,6 +9,16 @@ The Remote Log Publishing feature in {{ product_name }} allows organizations to 
     - Ensure that the WSO2 Identity Server is up and running.
     - Have access to an external log storage solution that is reachable over the network.
 
+!!! note "Important"
+
+    Add the following property to the `<IS_HOME>/repository/conf/deployment.toml` file to hide credentials after you configure remote log publishing.
+
+    ```toml
+    [remote_logging]
+    encrypt_secrets=true
+    hide_secrets=true
+    ```
+
 Follow the steps below to configure remote log publishing to an external system:
 
 1. On the {{ product_name }} Console, go to **Server**.

--- a/en/identity-server/7.1.0/docs/deploy/monitor/remote-log-publishing.md
+++ b/en/identity-server/7.1.0/docs/deploy/monitor/remote-log-publishing.md
@@ -9,7 +9,14 @@ The Remote Log Publishing feature in {{ product_name }} allows organizations to 
     - Ensure that the WSO2 Identity Server is up and running.
     - Have access to an external log storage solution that is reachable over the network.
 
-Follow the steps below to configure remote log publishing to an external system:
+!!! note "Important"
+
+    Add the following property to the `<IS_HOME>/repository/conf/deployment.toml` file to hide credentials after you configure remote log publishing.
+
+    ```toml
+    [remote_logging]
+    hide_secrets=true
+    ```
 
 1. On the {{ product_name }} Console, click the **Root Organization** dropdown at the top and click **Manage Root Organizations**.
 2. Click on the gear icon to enter the system settings.

--- a/en/identity-server/next/docs/deploy/monitor/remote-log-publishing.md
+++ b/en/identity-server/next/docs/deploy/monitor/remote-log-publishing.md
@@ -9,6 +9,15 @@ The Remote Log Publishing feature in {{ product_name }} allows organizations to 
     - Ensure that the WSO2 Identity Server is up and running.
     - Have access to an external log storage solution that is reachable over the network.
 
+!!! note "Important"
+
+    Add the following property to the `<IS_HOME>/repository/conf/deployment.toml` file to hide credentials after you configure remote log publishing.
+
+    ```toml
+    [remote_logging]
+    hide_secrets=true
+    ```
+
 Follow the steps below to configure remote log publishing to an external system:
 
 1. On the {{ product_name }} Console, click the **Root Organization** dropdown at the top and click **Manage Root Organizations**.


### PR DESCRIPTION
## Purpose
Add instructions to hide credentials in remote log publishing configuration

<img width="884" height="568" alt="Screenshot 2025-07-21 at 13 58 24" src="https://github.com/user-attachments/assets/2634bb5e-ac65-4f90-99a1-7ce767e28747" />


## Related Issues
- https://github.com/wso2/product-is/issues/24591

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


