### PR TITLE
Mark webhooks as a preview feature.

### DIFF
--- a/en/includes/guides/webhooks/setup-webhooks.md
+++ b/en/includes/guides/webhooks/setup-webhooks.md
@@ -1,6 +1,10 @@
-# Setup webhooks
+# Setup webhooks <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div>
 
 This guide provides a step-by-step approach to setting up webhooks in {{product_name}} to integrate external systems.
+
+!!! Note
+      This feature is currently in **Preview**. Functionality and event payloads may change during development.  
+      Expect updates without prior notice.
 
 ## Prerequisites
 

--- a/en/includes/guides/webhooks/understanding-webhooks.md
+++ b/en/includes/guides/webhooks/understanding-webhooks.md
@@ -1,4 +1,4 @@
-# Understanding webhooks
+# Understanding webhooks <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div>
 
 Webhooks enable your applications to receive instant notifications from {{product_name}}, allowing you to respond immediately to important identity-related events. Common use cases for {{product_name}} webhooks include:
 
@@ -8,6 +8,10 @@ Webhooks enable your applications to receive instant notifications from {{produc
 - Integrate with SIEM systems to instantly detect and respond to suspicious login attempts or failed authentications.
 
 Using webhooks, you can seamlessly integrate external systems with {{product_name}}'s identity flows. When an event happens, {{product_name}} immediately sends HTTP callbacks to your configured webhook endpoints. {{product_name}} webhooks use the [WebSubHub](https://websubhub.com/) protocol for secure and reliable event delivery.
+
+!!! Note
+      This feature is currently in **Preview**. Functionality and event payloads may change during development.  
+      Expect updates without prior notice.
 
 ## How webhooks work
 

--- a/en/includes/guides/webhooks/webhook-events-and-payloads.md
+++ b/en/includes/guides/webhooks/webhook-events-and-payloads.md
@@ -1,6 +1,10 @@
-# Webhook events and payloads
+# Webhook events and payloads <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div>
 
 This guide details the webhook event types dispatched by {{product_name}}. For each event, you'll find JSON payload examples and descriptions of their properties.
+
+!!! Note
+      This feature is currently in **Preview**. Functionality and event payloads may change during development.  
+      Expect updates without prior notice.
 
 ## Login events
 


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/24566

This PR labels webhook feature as a preview feature in docs.
As feature is ready for production we will be removing the label.


<img width="1021" height="599" alt="Screenshot 2025-07-21 at 6 29 52 PM" src="https://github.com/user-attachments/assets/f073dbd8-ed11-46c1-b363-1f6ed7c08a5e" />

<img width="945" height="315" alt="Screenshot 2025-07-21 at 6 30 22 PM" src="https://github.com/user-attachments/assets/6cd68838-6dbe-4fb0-b4fd-26d6552885a6" />

<img width="879" height="306" alt="Screenshot 2025-07-21 at 6 30 31 PM" src="https://github.com/user-attachments/assets/46e8a669-a06d-41e6-be5a-4d490ea77ec1" />

