### PR TITLE
Fix the Doc Issue related with  deployment.toml configuration missing under "Send email with TOTP"

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/configuring-totp.md
+++ b/en/identity-server/5.10.0/docs/learn/configuring-totp.md
@@ -316,6 +316,11 @@ the authentication flow.
 
 -  Enable the email sending configurations of the WSO2 Identity Server
     as explained [here](../../setup/configuring-email-sending)
+-  Add the following configuration to the `deployment.toml` file.
+    ```toml
+    [authentication.authenticator.totp.parameters]
+    AllowSendingVerificationCodeByEmail = true
+    ```
 
     !!! tip 
         The email template used to send this email notification is

--- a/en/identity-server/5.11.0/docs/learn/configuring-totp.md
+++ b/en/identity-server/5.11.0/docs/learn/configuring-totp.md
@@ -317,6 +317,11 @@ the authentication flow.
 
 -  Enable the email sending configurations of the WSO2 Identity Server
     as explained [here](../../setup/configuring-email-sending)
+-  Add the following configuration to the `deployment.toml` file.
+    ```toml
+    [authentication.authenticator.totp.parameters]
+    AllowSendingVerificationCodeByEmail = true
+    ```
 
     !!! tip 
         The email template used to send this email notification is


### PR DESCRIPTION
## Purpose
The documentation for WSO2 Identity Server versions 5.10.0 and 5.11.0 is missing the AllowSendingVerificationCodeByEmail = true configuration under the TOTP section in deployment.toml. This setting, available in version 6.x, enables sending TOTP codes via email. This PR updates the documentation to include the missing configuration for consistency and to support deployments using email-based TOTP in earlier versions.

## Related Issues
- https://github.com/wso2/product-is/issues/24173