### PR TITLE
Fix hyphenation in multi-attribute login sentence

### DIFF
--- a/en/identity-server/next/docs/guides/authentication/multi-attribute-login.md
+++ b/en/identity-server/next/docs/guides/authentication/multi-attribute-login.md
@@ -19,7 +19,7 @@ The following section explains how to configure WSO2 identity server for multi-a
 To configure multi-attribute login, follow the steps below:
 
 1. On the {{product_name}} Console, go to **Login & Registration** > **Login Identifier** > **Multi Attribute Login**.
-2. Toggle the switch to enable multi attribute login.
+2. Toggle the switch to enable multi-attribute login.
 4. Add attribute URIs for attributes that users are allowed to use as login identifiers.
 5. Click **Update** to save the changes.
 


### PR DESCRIPTION
This pull request fixes a small grammatical issue in the multi-attribute login guide by adding the missing hyphen in the phrase "multi-attribute login" for consistency and clarity.

- Original: "multi attribute login"
- Updated: "multi-attribute login"

This improves the readability and aligns with standard usage in technical documentation.



