### PR TITLE
Add missing Group ID related LDAP/AD properties to 7.x Docs

### DIFF
--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-only-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-only-ldap-user-store.md
@@ -379,5 +379,29 @@ will be terminated.
 <p>Sample: 20</p>
 </td>
 </tr>
+<tr class="even">
+<td>GroupIDEnabled</td>
+<td>group_id_enabled</td>
+<td>Enable Group Unique Id</td>
+<td>Enables support for assigning a unique, persistent ID for SCIM groups.</td>
+</tr>
+<tr class="odd">
+<td>GroupIdAttribute</td>
+<td>group_id_attribute</td>
+<td>Group Id Attribute</td>
+<td>Defines which LDAP attribute should be used as the SCIM group ID</td>
+</tr>
+<tr class="even">
+<td>GroupCreated<br>DateAttribute</td>
+<td>group_created_timestamp_attribute</td>
+<td>Group Created Date Attribute</td>
+<td>Specifies the LDAP attribute that represents the group's creation time.</td>
+</tr>
+<tr class="odd">
+<td>GroupLastModified<br>DateAttribute</td>
+<td>group_modified_timestamp_attribute</td>
+<td>Group Last Modified Date Attribute</td>
+<td>Specifies the LDAP attribute that indicates the last modification time of a group.</td>
+</tr>
 </tbody>
 </table>

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-active-directory-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-active-directory-user-store.md
@@ -409,5 +409,29 @@ conversion when reading from/writing to a user store.
 <p>Default : true </p>
 </td>
 </tr>
+<tr class="even">
+<td>GroupIDEnabled</td>
+<td>group_id_enabled</td>
+<td>Enable Group Unique Id</td>
+<td>Enables support for assigning a unique, persistent ID for SCIM groups.</td>
+</tr>
+<tr class="odd">
+<td>GroupIdAttribute</td>
+<td>group_id_attribute</td>
+<td>Group Id Attribute</td>
+<td>Defines which LDAP attribute should be used as the SCIM group ID</td>
+</tr>
+<tr class="even">
+<td>GroupCreated<br>DateAttribute</td>
+<td>group_created_timestamp_attribute</td>
+<td>Group Created Date Attribute</td>
+<td>Specifies the LDAP attribute that represents the group's creation time.</td>
+</tr>
+<tr class="odd">
+<td>GroupLastModified<br>DateAttribute</td>
+<td>group_modified_timestamp_attribute</td>
+<td>Group Last Modified Date Attribute</td>
+<td>Specifies the LDAP attribute that indicates the last modification time of a group.</td>
+</tr>
 </tbody>
 </table>

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
@@ -389,5 +389,29 @@ will be terminated.
 <p>Default : true </p>
 </td>
 </tr>
+<tr class="even">
+<td>GroupIDEnabled</td>
+<td>group_id_enabled</td>
+<td>Enable Group Unique Id</td>
+<td>Enables support for assigning a unique, persistent ID for SCIM groups.</td>
+</tr>
+<tr class="odd">
+<td>GroupIdAttribute</td>
+<td>group_id_attribute</td>
+<td>Group Id Attribute</td>
+<td>Defines which LDAP attribute should be used as the SCIM group ID</td>
+</tr>
+<tr class="even">
+<td>GroupCreated<br>DateAttribute</td>
+<td>group_created_timestamp_attribute</td>
+<td>Group Created Date Attribute</td>
+<td>Specifies the LDAP attribute that represents the group's creation time.</td>
+</tr>
+<tr class="odd">
+<td>GroupLastModified<br>DateAttribute</td>
+<td>group_modified_timestamp_attribute</td>
+<td>Group Last Modified Date Attribute</td>
+<td>Specifies the LDAP attribute that indicates the last modification time of a group.</td>
+</tr>
 </tbody>
 </table>

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
@@ -411,7 +411,7 @@ will be terminated.
 <td>GroupLastModified<br>DateAttribute</td>
 <td>group_modified_timestamp_attribute</td>
 <td>Group Last Modified Date Attribute</td>
-<td>Specifies the LDAP attribute that indicates the last modification time of a group.</td>
+<td>LDAP attribute that specifies the timestamp when a group was last modified. </td>
 </tr>
 </tbody>
 </table>

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
@@ -399,7 +399,7 @@ will be terminated.
 <td>GroupIdAttribute</td>
 <td>group_id_attribute</td>
 <td>Group Id Attribute</td>
-<td>Defines which LDAP attribute should be used as the SCIM group ID</td>
+<td>LDAP attribute that should be used as the SCIM group ID</td>
 </tr>
 <tr class="even">
 <td>GroupCreated<br>DateAttribute</td>

--- a/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
+++ b/en/includes/guides/users/user-stores/user-store-properties/properties-read-write-ldap-user-store.md
@@ -405,7 +405,7 @@ will be terminated.
 <td>GroupCreated<br>DateAttribute</td>
 <td>group_created_timestamp_attribute</td>
 <td>Group Created Date Attribute</td>
-<td>Specifies the LDAP attribute that represents the group's creation time.</td>
+<td>LDAP attribute that specifies the timestamp when a group was created.</td>
 </tr>
 <tr class="odd">
 <td>GroupLastModified<br>DateAttribute</td>


### PR DESCRIPTION
Add missing Group ID related LDAP/AD properties.

Issue : https://github.com/wso2/product-is/issues/24351