### PR TITLE
[next]Update instruction for the AWS ECS schema in Hazelcast clustering

### DIFF
--- a/en/identity-server/next/docs/deploy/deployment-guide.md
+++ b/en/identity-server/next/docs/deploy/deployment-guide.md
@@ -180,6 +180,7 @@ The following configurations need to be done in both the WSO2 Identity Server no
         ??? tip "Click to see the instructions for the AWS ECS membership scheme"  
                       
             1. Create a working AWS ECS Cluster. Note the following when creating a cluster.
+                -   Select the `EC2 instance` type.
                 -   Note the `name` and `VPC CIDR block` of the cluster, as you will require them later for configurations.
                 -   Ensure that the `Container instance IAM role` that you assign to the ECS cluster has the following permission policy attached. 
                         ```
@@ -209,12 +210,17 @@ The following configurations need to be done in both the WSO2 Identity Server no
                     [clustering.properties]
                     region = "us-east-1"
                     clusterName = "ECS-IS-CLUSTER"
+                    hostHeader = "ec2"
                     vpcCidrBlock = "10.0.*.*"
+                    tagValue = "a_tag_value"
                     ```                    
-            Under the `clustering.properties` section, set the `region`, `clusterName`, and `vpcCidrBlock` based on the AWS ECS cluster you created in the previous step.       
+            Under the `clustering.properties` section, set the `region`, `clusterName`, `tagValue` and `vpcCidrBlock` based on the AWS ECS cluster you created in the previous step. The `tagValue` is derived from the auto-generated tag `aws:cloudformation:stack-name` in the AWS cluster. If the `aws:cloudformation:stack-name` tag is not available in the cluster or you prefer to use a custom tag, make sure to specify both the `tagKey` and `tagValue`.
 
             !!! note
-                Once all the configurations are complete, build a docker image including the configurations. You can consume this docker image to create a `Task Definition` and run a new `Service` or a `Task` on the `AWS ECS cluster` you created.
+                As only the `host` network mode is supported, the `hostHeader` value should be set to `"ec2"` in the `clustering.properties` section.
+
+            !!! note
+                Once all the configurations are complete, build a docker image including the configurations. You can use this Docker image to create a `Task Definition`, and make sure to set the network mode to `host` in the definition. Then run a new `Service` or a `Task` on the `AWS ECS cluster` you created.
 
         ??? tip "Click to see the instructions for the AWS EC2 membership scheme"  
 


### PR DESCRIPTION
## Purpose
$note subject. Related to https://github.com/wso2/product-is/issues/24160

Need add information about
- `hostHeader` - this should be set `host`
-  `tagValue` - should be based on the autogenerated tag `aws:cloudformation:stack-name`
-  mention about E2 instance type in the cluster creation
-  network mode should be set to `host` in the task definition.

## Related PRs
- https://github.com/wso2/docs-is/pull/5365
- https://github.com/wso2/docs-is/pull/5374

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


