### PR TITLE
Add feature docs for inheriting login and reg configs to sub-orgs.

### DIFF
--- a/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
+++ b/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md" %}

--- a/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/index.md
+++ b/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/index.md
@@ -1,0 +1,1 @@
+{% include "../../../../../includes/guides/organization-management/inheritance-in-organizations/index.md" %}

--- a/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
+++ b/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md" %}

--- a/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/asgardeo/docs/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md" %}

--- a/en/asgardeo/mkdocs.yml
+++ b/en/asgardeo/mkdocs.yml
@@ -445,6 +445,10 @@ nav:
         - Share user profiles with organizations: guides/organization-management/share-user-profiles.md
         - Try a B2B use case: guides/organization-management/try-a-b2b-use-case.md
         - API authorization for organizations: guides/organization-management/api-authorization-for-b2b.md
+        - Inheritance in organizations:
+            - Inheritance in organizations: guides/organization-management/inheritance-in-organizations/index.md
+            - UI branding inheritance: guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+            - Email and SMS template inheritance: guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
         - Organization discovery:
             - Organization discovery: guides/organization-management/organization-discovery/index.md
             - Email domain based organization discovery: guides/organization-management/organization-discovery/email-domain-based-organization-discovery.md

--- a/en/identity-server/7.1.0/docs/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
+++ b/en/identity-server/7.1.0/docs/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md" %}

--- a/en/identity-server/7.1.0/docs/guides/organization-management/inheritance-in-organizations/index.md
+++ b/en/identity-server/7.1.0/docs/guides/organization-management/inheritance-in-organizations/index.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/index.md" %}

--- a/en/identity-server/7.1.0/docs/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/identity-server/7.1.0/docs/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md" %}

--- a/en/identity-server/7.1.0/mkdocs.yml
+++ b/en/identity-server/7.1.0/mkdocs.yml
@@ -722,6 +722,10 @@ nav:
           - Onboard users: guides/organization-management/onboard-users.md
           - Share user profiles with organizations: guides/organization-management/share-user-profiles.md
           - API authorization for organizations: guides/organization-management/api-authorization-for-b2b.md
+          - Inheritance in organizations:
+            - Inheritance in organizations: guides/organization-management/inheritance-in-organizations/index.md
+            - UI branding inheritance: guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+            - Email and SMS template inheritance: guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
           - Organization discovery:
             - Organization discovery: guides/organization-management/organization-discovery/index.md
             - Email domain based organization discovery: guides/organization-management/organization-discovery/email-domain-based-organization-discovery.md

--- a/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
+++ b/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md" %}

--- a/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/index.md
+++ b/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/index.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/index.md" %}

--- a/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
+++ b/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md" %}

--- a/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/identity-server/next/docs/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -1,0 +1,1 @@
+{% include "../../../../../../includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md" %}

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -709,6 +709,11 @@ nav:
           - Onboard users: guides/organization-management/onboard-users.md
           - Share user profiles with organizations: guides/organization-management/share-user-profiles.md
           - API authorization for organizations: guides/organization-management/api-authorization-for-b2b.md
+          - Inheritance in organizations:
+            - Inheritance in organizations: guides/organization-management/inheritance-in-organizations/index.md
+            - Login & registration configuration inheritance: guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
+            - UI branding inheritance: guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+            - Email and SMS template inheritance: guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
           - Organization discovery:
             - Organization discovery: guides/organization-management/organization-discovery/index.md
             - Email domain based organization discovery: guides/organization-management/organization-discovery/email-domain-based-organization-discovery.md

--- a/en/includes/guides/branding/configure-ui-branding.md
+++ b/en/includes/guides/branding/configure-ui-branding.md
@@ -12,21 +12,7 @@ Customizations take effect at two levels:
 By branding these interfaces, your users will experience a familiar and consistent look and feel that aligns with your organizational or application-specific themes.
 
 !!! note "UI Branding for B2B applications"
-
-    If you have implemented [B2B organizations]({{base_path}}/guides/organization-management/), the behavior of each branding levels will work as follows:
-
-    **For organization-specific branding**:
-
-    - You may configure separate UI branding for each organization. 
-    - If you have not configured UI branding for your organization, the UI branding of your immediate parent  organization will be applied to the organization. If your parent organization has no branding, the  grand-parent organization's branding will apply. This will continue all the way until the root organization.  If the root organization has no branding, the default {{product_name}} branding will apply.
-     
-    **For application-specific branding**:
-
-    - If you configure application-specific branding, it will override the organization’s branding for that  application.
-    - If no application-specific branding is set, the UI branding of the organization will be applied. If the  organization has no branding, the application-specific branding of the immediate parent's organization will  apply. This will continue all the way until the root organization. If the root organization has no branding, the default {{product_name}} branding will apply.
-
-
-    ![{{ product_name }} branding path resolver]({{base_path}}/assets/img/guides/branding/generic-app-branding-resolver-path.png)
+    If you have implemented [B2B organizations]({{base_path}}/guides/organization-management/), refer [UI branding inheritance]({{base_path}}/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance) to see how branding configurations are inherited.
 
 !!! note
     See the complete list of [UI branding options](#ui-branding-preferences) currently available in {{ product_name }}.

--- a/en/includes/guides/branding/customize-email-templates.md
+++ b/en/includes/guides/branding/customize-email-templates.md
@@ -20,11 +20,7 @@ Once you publish your [branding preferences]({{base_path}}/guides/branding/confi
 
 !!! note "Email templates for B2B applications"
 
-    If you have set up [organizations]({{base_path}}/guides/organization-management/manage-organizations/),
-    you can customize email templates to fit the branding needs of each organization. If you do not customize an 
-    email template for an organization, it will inherit the design from the closest ancestor organization with a
-    customized email template. If no ancestor has customized the particular email template, the default email template
-    will be applied.
+    If you have set up [organizations]({{base_path}}/guides/organization-management/manage-organizations/), refer [email template inheritance]({{base_path}}/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance) to see how email templates are inherited.
 
 {% endif %}
 

--- a/en/includes/guides/branding/customize-sms-templates.md
+++ b/en/includes/guides/branding/customize-sms-templates.md
@@ -5,10 +5,7 @@ The following topics explain how you can customize SMS notifications that are se
 !!! note "SMS templates for B2B applications"
 
     If you have set up [organizations]({{base_path}}/guides/organization-management/manage-organizations/),
-    you can customize sms templates to fit the branding needs of each organization. If you do not customize an 
-    sms template for an organization, it will be inherit the design from the closest ancestor organization with
-    a customized sms template. If no ancestor has customized the particular sms template, the default sms template
-    will be applied.
+    refer [SMS template inheritance]({{base_path}}/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance) to see how SMS templates are inherited.
 
 You can tailor the **body** of SMS notifications to your preferences by following the steps below.
 

--- a/en/includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
@@ -1,0 +1,10 @@
+# Email and SMS template inheritance
+
+ You can customize email and sms templates to fit the branding needs of each organization. If you do not customize a template for an organization, it will be inherit the design from the closest ancestor organization with a customized template. If no ancestor has customized the particular template, the default template will be applied.
+
+## Customize templates
+
+To learn how to customize email and SMS templates, refer to the following guides:
+
+- [Customize email templates]({{base_path}}/guides/branding/customize-email-templates/)
+- [Customize SMS templates]({{base_path}}/guides/branding/customize-sms-templates/)

--- a/en/includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
@@ -1,6 +1,6 @@
 # Email and SMS template inheritance
 
- You can customize email and sms templates to fit the branding needs of each organization. If you do not customize a template for an organization, it will be inherit the design from the closest ancestor organization with a customized template. If no ancestor has customized the particular template, the default template will be applied.
+You can customize email and sms templates to fit the branding needs of each organization. If you do not customize a template for an organization, it will inherit the design from the closest ancestor organization with a customized template. If no ancestor has customized the particular template, the default template will be applied.
 
 ## Customize templates
 

--- a/en/includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance.md
@@ -1,6 +1,6 @@
 # Email and SMS template inheritance
 
-You can customize email and sms templates to fit the branding needs of each organization. If you do not customize a template for an organization, it will inherit the design from the closest ancestor organization with a customized template. If no ancestor has customized the particular template, the default template will be applied.
+You can customize email and sms templates to fit the branding needs of each organization. If you don't customize a template for an organization, it will inherit the design from the closest ancestor organization with a customized template. If no ancestor has customized the particular template, the default template will apply.
 
 ## Customize templates
 

--- a/en/includes/guides/organization-management/inheritance-in-organizations/index.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/index.md
@@ -1,0 +1,18 @@
+# Inheritance in organizations
+
+In a B2B scenario, a primary organization offers services to other businesses, which function as **child organizations**.
+
+Parent organizations often need to define common behaviors for their child organizations. However, child organizations also require their own unique identity and configurations.
+
+{{product_name}} allows child organizations to **inherit** and **override** configurations from their parent organization. This model simplifies administration by letting parent organizations set baseline configurations. It also gives child organizations the flexibility to customize their settings.
+
+The following guides explain how inheritance works for different features:
+
+{% if product_name != "Asgardeo" and (product_name == "WSO2 Identity Server" and is_version != "7.0.0" and is_version != "7.1.0") %}
+
+- **[Login & registration configuration inheritance]({{base_path}}/guides/organization-management/inheritance-in-organizations/login-registration-inheritance/)**: Learn how login and registration configurations can be inherited and customized.
+
+{% endif %}
+
+- **[UI branding inheritance]({{base_path}}/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance/)**: Discover how organizations can inherit or define their own look and feel.
+- **[Email and SMS template inheritance]({{base_path}}/guides/organization-management/inheritance-in-organizations/email-sms-templates-inheritance/)**: See how Email and SMS templates can be managed in an organizational hierarchy.

--- a/en/includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
@@ -10,7 +10,7 @@ The inheritance for login and registration configurations is as follows:
 - Any organization can override an inherited value. This new setting will then be inherited by all of its descendant organizations. An override can be reverted at any time to restore the inherited configuration.
 
 !!! note
-    Child organizations cannot override `Idle Session Timeout` and `Remember Me Period` configurations related to session management. 
+    Child organizations can't override `Idle Session Timeout` and `Remember Me Period` configurations related to session management. 
 
 ## Configure login and registration flows
 

--- a/en/includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
@@ -9,6 +9,9 @@ The inheritance for login and registration configurations is as follows:
 - Configuration settings are inherited hierarchically. An organization receives its settings from the nearest ancestor with a custom configuration. If no ancestor has a custom setting, the default value is applied.
 - Any organization can override an inherited value. This new setting will then be inherited by all of its descendant organizations. An override can be reverted at any time to restore the inherited configuration.
 
+!!! note
+    Child organizations cannot override `Idle Session Timeout` and `Remember Me Period` configurations related to session management. 
+
 ## Configure login and registration flows
 
 To learn how to configure login and registration flows, see the following guides:

--- a/en/includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/login-registration-inheritance.md
@@ -1,0 +1,24 @@
+# Login and registration configuration inheritance
+
+In {{product_name}}, login and registration settings are managed at the organization level. Child organizations inherit these configurations from their parent, while still allowing for organization-specific customizations.
+
+## How it works
+
+The inheritance for login and registration configurations is as follows:
+
+- Configuration settings are inherited hierarchically. An organization receives its settings from the nearest ancestor with a custom configuration. If no ancestor has a custom setting, the default value is applied.
+- Any organization can override an inherited value. This new setting will then be inherited by all of its descendant organizations. An override can be reverted at any time to restore the inherited configuration.
+
+## Configure login and registration flows
+
+To learn how to configure login and registration flows, see the following guides:
+
+- [Admin initiated password reset]({{base_path}}/guides/account-configurations/account-recovery/admin-initiated-password-reset)
+- [Password recovery]({{base_path}}/guides/account-configurations/account-recovery/password-recovery)
+- [Username recovery]({{base_path}}/guides/account-configurations/account-recovery/username-recovery)
+- [Bot detection]({{base_path}}/guides/account-configurations/login-security/bot-detection)
+- [Login attempts security]({{base_path}}/guides/account-configurations/login-security/login-attempts)
+- [Password validation]({{base_path}}/guides/account-configurations/login-security/password-validation)
+- [Session management]({{base_path}}/guides/account-configurations/login-security/session-management)
+- [Account disabling]({{base_path}}/guides/account-configurations/account-disabling)
+- [Notification settings]({{base_path}}/guides/account-configurations/notification-settings)

--- a/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -5,12 +5,12 @@ UI branding customizations take effect at two levels; organization-wide branding
 ### Organization-wide branding
 
 - You may configure separate UI branding for each organization. 
-- If you have not configured UI branding for your organization, the UI branding of your immediate parent  organization will be applied to the organization. If your parent organization has no branding, the  grand-parent organization's branding will apply. This will continue all the way until the root organization.  If the root organization has no branding, the default {{product_name}} branding will apply.
+- If you haven't configured UI branding for your organization, the UI branding of your immediate parent organization will be applied to the organization. If your parent organization has no branding, the grand-parent organization's branding will apply. This will continue all the way until the root organization. If the root organization has no branding, the default {{product_name}} branding will apply.
 
 ### Application-specific branding
 
 - If you configure application-specific branding, it will override the organization’s branding for that  application.
-- If no application-specific branding is set, the UI branding of the organization will be applied. If the  organization has no branding, the application-specific branding of the immediate parent's organization will  apply. This will continue all the way until the root organization. If the root organization has no branding, the default {{product_name}} branding will apply.
+- If no application-specific branding is set, the UI branding of the organization will be applied. If the organization has no branding, the application-specific branding of the immediate parent's organization will apply. This will continue all the way until the root organization. If the root organization has no branding, the default {{product_name}} branding will apply.
 
 ![{{ product_name }} branding path resolver]({{base_path}}/assets/img/guides/branding/generic-app-branding-resolver-path.png)
 

--- a/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -1,0 +1,20 @@
+# UI branding inheritance
+
+UI branding customizations take effect at two levels; organization-wide branding and application-specific branding. The inheritance of each branding level is as follows.
+
+### Organization-wide branding
+
+- You may configure separate UI branding for each organization. 
+- If you have not configured UI branding for your organization, the UI branding of your immediate parent  organization will be applied to the organization. If your parent organization has no branding, the  grand-parent organization's branding will apply. This will continue all the way until the root organization.  If the root organization has no branding, the default {{product_name}} branding will apply.
+
+### Application-specific branding
+
+- If you configure application-specific branding, it will override the organization’s branding for that  application.
+- If no application-specific branding is set, the UI branding of the organization will be applied. If the  organization has no branding, the application-specific branding of the immediate parent's organization will  apply. This will continue all the way until the root organization. If the root organization has no branding, the default {{product_name}} branding will apply.
+
+![{{ product_name }} branding path resolver]({{base_path}}/assets/img/guides/branding/generic-app-branding-resolver-path.png)
+
+
+## Configure UI branding
+
+To learn how to configure UI branding for an organization, see the [Configure UI branding]({{base_path}}/guides/branding/configure-ui-branding/) guide.


### PR DESCRIPTION
## Purpose
This pr adds the documentation for the feature: inherit login and registration configurations to sub-organizations
<img width="2942" height="2304" alt="Inheritance-in-organizations-WSO2-Identity-Server" src="https://github.com/user-attachments/assets/8e1f0fc2-8cd9-4c76-8d20-a739e7c7e6d0" />
<img width="2942" height="2784" alt="Login-registration-configuration-inheritance-WSO2-Identity-Server" src="https://github.com/user-attachments/assets/b4ed1367-eb6a-485d-9da1-e5fa4f8d0d27" />
<img width="2942" height="3388" alt="UI-branding-inheritance-WSO2-Identity-Server" src="https://github.com/user-attachments/assets/0e71d9ed-8bee-46e0-8329-4ede1c33ccb1" />
<img width="2942" height="2304" alt="Email-and-SMS-template-inheritance-WSO2-Identity-Server" src="https://github.com/user-attachments/assets/4eb06a2c-39d6-44eb-8e39-27cba721ca93" />



### Related issue
- https://github.com/wso2/product-is/issues/25107