### PR TITLE
[7.1] Fix broken link in next js quick start guide

### DIFF
--- a/en/identity-server/7.1.0/mkdocs.yml
+++ b/en/identity-server/7.1.0/mkdocs.yml
@@ -45,7 +45,7 @@ extra:
             - title: Connect Javascript App
               url: Get started|Connect App|Javascript|Quickstart
             - title: Connect Next.js App
-              url: Get started|Connect App|Next.js Quickstart
+              url: Get started|Connect App|Next.js|Quickstart
             - title: Connect Node.js App
               url: Get started|Connect App|Node.js|Quickstart
             - title: Connect Spring Boot App


### PR DESCRIPTION
## Purpose
This pull request updates the navigation structure for the Next.js quickstart documentation link to improve consistency with other framework links.

* Documentation navigation update:
  * In `en/identity-server/7.1.0/mkdocs.yml`, the `url` for "Connect Next.js App" was changed from `Get started|Connect App|Next.js Quickstart` to `Get started|Connect App|Next.js|Quickstart`, aligning its format with other app quickstart links.


Fix: https://github.com/wso2/product-is/issues/25191