### PR TITLE
Add product_name placeholder for required places

### DIFF
--- a/en/includes/guides/authentication/user-attributes/enable-attributes-for-oidc-app.md
+++ b/en/includes/guides/authentication/user-attributes/enable-attributes-for-oidc-app.md
@@ -35,7 +35,7 @@ To add user attributes to the app:
 
 ### Select an alternate subject attribute
 
-The subject attribute is used for exchanging information about the user. The subject is represented by the **subject** attribute in the ID token. By default, Asgardeo shares **User ID** as the subject. You can define any user attribute as the subject.
+The subject attribute is used for exchanging information about the user. The subject is represented by the **subject** attribute in the ID token. By default, {{ product_name }} shares **User ID** as the subject. You can define any user attribute as the subject.
 
 To define a different attribute as the subject:
 

--- a/en/includes/guides/branding/customize-email-templates.md
+++ b/en/includes/guides/branding/customize-email-templates.md
@@ -101,7 +101,7 @@ You can tailor the **subject**, **body**, and **footer** of email notifications 
 2. Select the email template and the relevant locale that you wish to modify.
 
     !!! note
-        Asgardeo gives you the option to automatically copy a template from one locale to another so that you do not have to create email templates from scratch. To do so, select a locale with an existing email template, switch over to the new locale and click confirm when the **Replicate content?** prompt appears.
+        {{ product_name }} gives you the option to automatically copy a template from one locale to another so that you do not have to create email templates from scratch. To do so, select a locale with an existing email template, switch over to the new locale and click confirm when the **Replicate content?** prompt appears.
 
     ![Select email template]({{base_path}}/assets/img/guides/branding/select-email-template.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 


### PR DESCRIPTION
## Purpose
This pull request updates documentation to use a generic product name variable instead of a hardcoded product name, improving maintainability and consistency across guides.

Documentation updates for branding and authentication guides:

* Replaced the hardcoded product name "Asgardeo" with the `{{ product_name }}` variable in the explanation of the subject attribute for OIDC apps in `user-attributes/enable-attributes-for-oidc-app.md`.
* Updated the email template customization guide in `branding/customize-email-templates.md` to use `{{ product_name }}` instead of "Asgardeo", ensuring the documentation is product-agnostic.


Fix for: https://github.com/wso2/product-is/issues/25192