### PR TITLE
Add Custom authenticator related REST API docs

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -134,6 +134,137 @@ paths:
             curl --location 'https://api.asgardeo.io/t/{root-organization-name}/o/api/server/v1/authenticators/{authenticator-id}/connected-apps' \
             -H 'Accept: application/json' \
             -H 'Authorization: Bearer {bearer_token}'
+  /authenticators/custom:
+    post:
+      tags:
+        - User defined local authenticators
+      summary: |
+        Create a new user defined local authenticator.
+      description: |
+        This API provides the capability to create a new user defined local authenticator.
+
+        <b>Scope(Permission) required: </b> `internal_org_custom_authenticator_create`
+      operationId: addUserDefinedLocalAuthenticator
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+              examples:
+                example:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserDefinedLocalAuthenticatorCreation'
+        description: This represents the user defined local authenticator to be created.
+        required: true
+  /authenticators/custom/{authenticator-id}:
+    put:
+      tags:
+        - User defined local authenticators
+      summary: |
+        Update a user defined local authenticator.
+      description: |
+        This API provides the capability to update a user defined local authenticator configurations.
+        
+        <b>Scope(Permission) required:</b> `internal_org_custom_authenticator_update`
+      operationId: updateUserDefinedLocalAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+              examples:
+                example:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserDefinedLocalAuthenticatorUpdate'
+        description: This represents the user defined local authenticator to be created.
+        required: true
+    delete:
+      tags:
+        - User defined local authenticators
+      summary: |
+        Delete a user defined local authenticator.
+      description: |
+        This API provides the capability to delete a user defined local authenticators.
+
+        <b>Scope required:</b> `internal_org_custom_authenticator_delete`
+      operationId: deleteUserDefinedLocalAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   parameters:
@@ -210,6 +341,7 @@ components:
         id:
           type: string
           example: QmFzaWNBdXRoZW50aWNhdG9y
+          readOnly: true
         name:
           type: string
           example: BasicAuthenticator
@@ -219,11 +351,18 @@ components:
         isEnabled:
           type: boolean
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
+          readOnly: true
         type:
           type: string
           enum:
             - LOCAL
             - FEDERATED
+          readOnly: true
         image:
           type: string
           example: basic-authenticator-logo-url
@@ -235,9 +374,142 @@ components:
           items:
             type: string
           example: [2FA, MFA]
+          readOnly: true
         self:
           type: string
           example: /t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
+    UserDefinedLocalAuthenticatorCreation:
+      description: This represents the configuration for creating a user defined local authenticator.
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the user defined local authenticator. It must be started with 'custom-'.
+          example: custom-authenticator
+        id:
+          type: string
+          example: Y3VzdG9tLWF1dGhlbnRpY2F0b3I
+        displayName:
+          type: string
+          example: Custom Local Authenticator
+        isEnabled:
+          type: boolean
+          example: true
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION
+        image:
+          type: string
+          example: https://custom-authenticator-logo-url
+        description:
+          type: string
+          example: The user defined custom local authenticator.
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+        - isEnabled
+        - endpoint
+    UserDefinedLocalAuthenticatorUpdate:
+      description: This represents the configuration for updating a user defined local authenticator.
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: Custom Local Authenticator
+        isEnabled:
+          type: boolean
+          example: true
+        image:
+          type: string
+          example: https://custom-authenticator-logo-url-new
+        description:
+          type: string
+          example: The user defined custom local authenticator.
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+        - isEnabled
+        - endpoint
+    Endpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
+    AuthenticationType:
+      type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
+      required:
+        - type
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     ConnectedApps:
       type: object
       properties:
@@ -333,3 +605,15 @@ components:
           authorizationUrl: 'https://api.asgardeo.io/t/{root-organization-name}/oauth2/authorize'
           tokenUrl: 'https://api.asgardeo.io/t/{root-organization-name}/oauth2/token'
           scopes: {}
+  examples:
+    UserDefinedAuthenticatorExample:
+      summary: "Response for user defined authenticator"
+      value:
+        id: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        name: "custom-authenticator"
+        displayName: "Custom Local Authenticator"
+        definedBy: "USER"
+        type: "LOCAL"
+        isEnabled: true
+        tags: [ Custom ]
+        self: "/o/api/server/v1/configs/authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I="

--- a/en/asgardeo/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -235,7 +235,7 @@ paths:
       summary: |
         Delete a user defined local authenticator.
       description: |
-        This API provides the capability to delete a user defined local authenticators.
+        This API provides the capability to delete a user defined local authenticator.
 
         <b>Scope required:</b> `internal_org_custom_authenticator_delete`
       operationId: deleteUserDefinedLocalAuthenticator
@@ -432,7 +432,6 @@ components:
         endpoint:
           $ref: '#/components/schemas/Endpoint'
       required:
-        - name
         - displayName
         - isEnabled
         - endpoint

--- a/en/asgardeo/docs/apis/organization-apis/restapis/idp.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/idp.yaml
@@ -89,6 +89,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
+              examples:
+                identityProviderWithSystemDefinedAuthenticator:
+                  $ref: '#/components/examples/SystemDefinedIdentityProviderResponseExample'
+                identityProviderWithUserDefineAuthenticator:
+                  $ref: '#/components/examples/UserDefinedIdentityProviderResponseExample'
             application/xml:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
@@ -213,6 +218,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IdentityProviderPOSTRequest'
+            examples:
+              identityProviderWithSystemDefinedAuthenticator:
+                $ref: '#/components/examples/IdentityProviderWithSystemDefinedAuthenticatorPOSTRequestExample'
+              identityProviderWithUserDefineAuthenticator:
+                $ref: '#/components/examples/IdentityProviderWithUserDefinedAuthenticatorPOSTRequestExample'
           application/xml:
             schema:
               $ref: '#/components/schemas/IdentityProviderPOSTRequest'
@@ -450,6 +460,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
+              examples:
+                identityProviderWithSystemDefinedAuthenticator:
+                  $ref: '#/components/examples/SystemDefinedIdentityProviderResponseExample'
+                identityProviderWithUserDefineAuthenticator:
+                  $ref: '#/components/examples/UserDefinedIdentityProviderResponseExample'
             application/xml:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
@@ -830,6 +845,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorListResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorListResponseExample'
         '400':
           description: Bad Request
           content:
@@ -883,6 +903,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorListResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorListResponseExample'
         '400':
           description: Bad Request
           content:
@@ -934,6 +959,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/FederatedAuthenticatorRequest'
+            examples:
+              systemDefinedAuthenticatorsExample:
+                $ref: '#/components/examples/SystemDefinedAuthenticatorsListPUTRequestExample'
+              userDefinedAuthenticators:
+                $ref: '#/components/examples/UserDefinedAuthenticatorsListPUTRequestExample'
         description: This represents the federated authenticators to be updated
         required: true
   /identity-providers/{identity-provider-id}/federated-authenticators/{federated-authenticator-id}:
@@ -966,6 +996,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticator'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorResponseExample'
         '400':
           description: Bad Request
           content:
@@ -1030,6 +1065,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticator'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorResponseExample'
         '400':
           description: Bad Request
           content:
@@ -2126,6 +2166,11 @@ components:
         name:
           type: string
           example: SAML2Authenticator
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         self:
           type: string
           example: /t/{root-organization-name}/o/api/server/v1/identity-providers/meta/federated-authenticators/U0FNTFNTT0F1dGhlbnRpY2F0b3I
@@ -2141,6 +2186,11 @@ components:
         displayName:
           type: string
           example: 'SAML2 Web SSO Configuration'
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         properties:
           type: array
           items:
@@ -2180,6 +2230,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         isDefault:
           type: boolean
           default: false
@@ -2187,6 +2242,84 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+    Endpoint:
+      type: object
+      required:
+        - uri
+        - authentication
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
+    AuthenticationType:
+      type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     FederatedAuthenticatorPUTRequest:
       type: object
       properties:
@@ -2206,10 +2339,17 @@ components:
           type: boolean
           default: false
           example: false
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         properties:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorListResponse:
       type: object
       properties:
@@ -2612,3 +2752,356 @@ components:
           type: string
           format: binary
           description: file to upload
+  examples:
+    UserDefinedAuthenticatorPUTRequestExample:
+      summary: Put request for user defined authenticators
+      value:
+        authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        name: "custom-authenticator"
+        default: true
+        definedBy: "USER"
+        endpoint:
+          uri: "https://abc.com/token"
+          authentication:
+            type: "BASIC"
+            properties:
+              username: "auth_username"
+              password: "auth_password"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
+    SystemDefinedAuthenticatorPUTRequestExample:
+      summary: "Put request for system defined authenticators"
+      value:
+        authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        isEnabled:  true
+        isDefault:  true
+        properties:
+          - key: "somePropertyKey"
+            value: "somePropertyValue"
+    UserDefinedAuthenticatorsListPUTRequestExample:
+      summary: "Put request for user defined authenticators list"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+            name: "custom-authenticator"
+            default: true
+            definedBy: "USER"
+            endpoint:
+              uri: "https://abc.com/token"
+              authentication:
+                type: "BASIC"
+                properties:
+                  username: "auth_username"
+                  password: "auth_password"
+              allowedHeaders:
+                - x-geo-location
+                - host
+              allowedParameters:
+                - device-id
+    SystemDefinedAuthenticatorsListPUTRequestExample:
+      summary: "Put request for system defined authenticators list"
+      value:
+        defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        authenticators:
+          - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+            isEnabled:  true
+            isDefault:  true
+            properties:
+              - key: "somePropertyKey"
+                value: "somePropertyValue"
+    IdentityProviderWithSystemDefinedAuthenticatorPOSTRequestExample:
+      summary: "POST request for an identity provider with a system defined authenticator"
+      value:
+        name: "google"
+        description: "IdP for Google Federation"
+        image: "google-logo-url"
+        templateId: "8ea23303-49c0-4253-b81f-82c0fe6fb4a0"
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: "localhost"
+        certificate:
+          certificates:
+            - "string"
+          jwksUri: "https://api.asgardeo.io/t/{root-organization-name}/o/oauth2/jwks"
+        alias: "https://localhost:9444/api.asgardeo.io/t/{root-organization-name}/o/oauth2/token"
+        idpIssuerName: "https://www.idp.com"
+        claims:
+          userIdClaim:
+            uri: "http://wso2.org/claims/username"
+          roleClaim:
+            uri: "http://wso2.org/claims/username"
+          mappings:
+            - idpClaim: "country"
+              localClaim:
+                uri: "http://wso2.org/claims/username"
+          provisioningClaims:
+            - claim:
+                uri: "http://wso2.org/claims/username"
+              defaultValue: "sathya"
+        roles:
+          mappings:
+            - idpRole: "google-manager"
+              localRole: "manager"
+          outboundProvisioningRoles:
+            - "manager"
+            - "hr-admin"
+        groups:
+          - name: "google-admin"
+            id: "6b1f8513-3de0-4f28-9cad-b7400dbc94ae"
+        federatedAuthenticators:
+          defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+          authenticators:
+            - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+              isEnabled: true
+              isDefault: true
+              properties:
+                - key: "somePropertyKey"
+                  value: "somePropertyValue"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            defaultConnectorId: "U0NJTQ"
+            connectors:
+              - connectorId: "U0NJTQ"
+                isEnabled: true
+                isDefault: true
+                blockingEnabled: false
+                rulesEnabled: false
+                properties:
+                  - key: "somePropertyKey"
+                    value: "somePropertyValue"
+        implicitAssociation:
+          isEnabled: false
+          lookupAttribute:
+            - "email"
+    IdentityProviderWithUserDefinedAuthenticatorPOSTRequestExample:
+      summary: "POST request for an identity provider with a user defined authenticator"
+      value:
+        name: "Custom IDP"
+        description: "IDP with custom federated authenticator"
+        image: "https://custom-authenticator-logo-url"
+        templateId: "external-custom-authenticator"
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: ""
+        certificate:
+          certificates:
+            - ""
+          jwksUri: ""
+        claims:
+          userIdClaim:
+            uri: "http://wso2.org/claims/username"
+          roleClaim:
+            uri: ""
+          mappings: []
+          provisioningClaims: []
+        roles:
+          mappings: [ ]
+          outboundProvisioningRoles: [ ]
+        federatedAuthenticators:
+          defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+          authenticators:
+            - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+              isEnabled: true
+              isDefault: true
+              definedBy: "USER"
+              endpoint:
+                uri: "https://abc.com/token"
+                authentication:
+                  type: "BASIC"
+                  properties:
+                    username: "auth_username"
+                    password: "auth_password"
+                allowedHeaders:
+                  - x-geo-location
+                  - host
+                allowedParameters:
+                  - device-id
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+    SystemDefinedIdentityProviderResponseExample:
+      summary: "Response for identity provider creation with system defined authenticator"
+      value:
+        id: "123e4567-e89b-12d3-a456-556642440000"
+        name: "google"
+        description: "string"
+        isEnabled: true
+        isPrimary: false
+        image: "google-logo-url"
+        isFederationHub: false
+        homeRealmIdentifier: "localhost"
+        certificate:
+          certificates:
+            - "string"
+          jwksUri: "https://api.asgardeo.io/t/{root-organization-name}/o/oauth2/jwks"
+        alias: "https://api.asgardeo.io/t/{root-organization-name}/o/oauth2/token"
+        claims:
+          userIdClaim:
+            id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+            uri: "http://wso2.org/claims/username"
+            displayName: "Username"
+          roleClaim:
+            id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+            uri: "http://wso2.org/claims/username"
+            displayName: "Username"
+          mappings:
+            - idpClaim: "country"
+              localClaim:
+                id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                uri: "http://wso2.org/claims/username"
+                displayName: "Username"
+          provisioningClaims:
+            - claim:
+                id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                uri: "http://wso2.org/claims/username"
+                displayName: "Username"
+              defaultValue: "sathya"
+        roles:
+          mappings:
+            - idpRole: "google-manager"
+              localRole: "manager"
+          outboundProvisioningRoles:
+            - "manager"
+            - "hr-admin"
+        federatedAuthenticators:
+          defaultAuthenticatorId: "U0FNTFNTT0F1dGhlbnRpY2F0b3I"
+          authenticators:
+            - authenticatorId: "U0FNTFNTT0F1dGhlbnRpY2F0b3I"
+              name: "SAML2Authenticator"
+              isEnabled: true
+              definedBy: "SYSTEM"
+              tags:
+                - "Social Login"
+                - "OIDC"
+              self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROMPT_USERNAME_PASSWORD_CONSENT"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            defaultConnectorId: "U0NJTQ"
+            connectors:
+              - connectorId: "U0NJTQ"
+                name: "SCIM"
+                isEnabled: true
+                self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/provisioning/outbound-connectors/U0NJTQ"
+    UserDefinedIdentityProviderResponseExample:
+      summary: "Response for identity provider creation with user defined authenticator"
+      value:
+        name: "Custom IDP"
+        description: "IDP with custom federated authenticator"
+        image: "https://custom-authenticator-logo-url"
+        templateId: "external-custom-authenticator"
+        isEnabled: true
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: ""
+        alias: ""
+        idpIssuerName: ""
+        claims:
+          userIdClaim:
+            id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+            uri: "http://wso2.org/claims/username"
+            displayName: "Username"
+          roleClaim:
+            uri: ""
+          mappings: [ ]
+          provisioningClaims: [ ]
+        roles:
+          mappings: [ ]
+        groups: [ ]
+        federatedAuthenticators:
+          defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+          authenticators:
+            - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+              name: "custom-authenticator"
+              isEnabled: true
+              definedBy: "USER"
+              tags:
+                - "Custom"
+              self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "DEFAULT"
+            associateLocalUser: false
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            connectors: [ ]
+        implicitAssociation:
+          isEnabled: false
+          lookupAttribute: [ ]
+    SystemDefinedAuthenticatorResponseExample:
+      summary: "System defined federated authenticator"
+      value:
+        authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        isEnabled: true
+        isDefault: true
+        definedBy: "SYSTEM"
+        tags:
+          - "Social Login"
+          - "OIDC"
+        properties:
+          - key: "somePropertyKey"
+            value: "somePropertyValue"
+    UserDefinedAuthenticatorResponseExample:
+      summary: "User defined federated authenticator"
+      value:
+        authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        isEnabled: true
+        isDefault: true
+        definedBy: "USER"
+        tags:
+          - "Custom"
+        endpoint:
+          uri: "https://abc.com/token"
+          authentication:
+            type: "BASIC"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
+    SystemDefinedAuthenticatorListResponseExample:
+      summary: "List of authenticators with system defined authenticator"
+      value:
+        defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        authenticators:
+          - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+            isEnabled: true
+            isDefault: true
+            definedBy: "SYSTEM"
+            tags:
+              - "Social Login"
+              - "OIDC"
+            self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y"
+    UserDefinedAuthenticatorListResponseExample:
+      summary: "List of authenticators with user defined authenticator"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+            name: "custom-authenticator"
+            isEnabled: true
+            definedBy: "USER"
+            tags:
+              - "Custom"
+            self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I"

--- a/en/asgardeo/docs/apis/restapis/authenticators.yaml
+++ b/en/asgardeo/docs/apis/restapis/authenticators.yaml
@@ -233,7 +233,7 @@ paths:
       summary: |
         Delete a user defined local authenticator.
       description: |
-        This API provides the capability to delete a user defined local authenticators.
+        This API provides the capability to delete a user defined local authenticator.
 
         <b>Scope(Permission) required:</b> `internal_custom_authenticator_delete`
       operationId: deleteUserDefinedLocalAuthenticator
@@ -430,7 +430,6 @@ components:
         endpoint:
           $ref: '#/components/schemas/Endpoint'
       required:
-        - name
         - displayName
         - isEnabled
         - endpoint

--- a/en/asgardeo/docs/apis/restapis/authenticators.yaml
+++ b/en/asgardeo/docs/apis/restapis/authenticators.yaml
@@ -233,11 +233,9 @@ paths:
       summary: |
         Delete a user defined local authenticator.
       description: |
-        This API provides the capability to delete a user defined local authenticator. <br>
-        <b>Permission required:</b> <br>
-            * /permission/admin/manage/custom_authenticator/delete <br>
-        <b>Scope required:</b> <br>
-            * internal_custom_authenticator_delete <br>
+        This API provides the capability to delete a user defined local authenticators.
+
+        <b>Scope(Permission) required:</b> `internal_custom_authenticator_delete`
       operationId: deleteUserDefinedLocalAuthenticator
       parameters:
         - name: authenticator-id
@@ -374,6 +372,7 @@ components:
           items:
             type: string
           example: [2FA, MFA]
+          readOnly: true
         self:
           type: string
           example: /t/{organization-name}/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
@@ -444,8 +443,53 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
       required:
         - type
         - properties

--- a/en/asgardeo/docs/apis/restapis/idp.yaml
+++ b/en/asgardeo/docs/apis/restapis/idp.yaml
@@ -2507,6 +2507,11 @@ components:
           type: string
           example: SAML2Authenticator
           description: The name of the authenticator
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         self:
           type: string
           example: /t/{org_name}/api/server/v1/identity-providers/meta/federated-authenticators/U0FNTFNTT0F1dGhlbnRpY2F0b3I
@@ -2523,6 +2528,11 @@ components:
         displayName:
           type: string
           example: 'SAML2 Web SSO Configuration'
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         properties:
           type: array
           items:
@@ -2562,6 +2572,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         isDefault:
           type: boolean
           default: false
@@ -2569,6 +2584,84 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+    Endpoint:
+      type: object
+      required:
+        - uri
+        - authentication
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
+    AuthenticationType:
+      type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     FederatedAuthenticatorPUTRequest:
       type: object
       properties:
@@ -2588,10 +2681,17 @@ components:
           type: boolean
           default: false
           example: false
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         properties:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorListResponse:
       type: object
       properties:
@@ -2617,6 +2717,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         self:
           type: string
           example: /t/{org_name}/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y
@@ -3165,6 +3270,11 @@ components:
             properties:
               username: "auth_username"
               password: "auth_password"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
     SystemDefinedAuthenticatorPUTRequestExample:
       summary: "Put request for system defined authenticators"
       value:
@@ -3190,6 +3300,11 @@ components:
                 properties:
                   username: "auth_username"
                   password: "auth_password"
+              allowedHeaders:
+                - x-geo-location
+                - host
+              allowedParameters:
+                - device-id
     SystemDefinedAuthenticatorsListPUTRequestExample:
       summary: "Put request for system defined authenticators list"
       value:
@@ -3309,6 +3424,11 @@ components:
                   properties:
                     username: "auth_username"
                     password: "auth_password"
+                allowedHeaders:
+                  - x-geo-location
+                  - host
+                allowedParameters:
+                  - device-id
         provisioning:
           jit:
             isEnabled: true
@@ -3458,6 +3578,11 @@ components:
           uri: "https://abc.com/token"
           authentication:
             type: "BASIC"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
     SystemDefinedAuthenticatorListResponseExample:
       summary: "List of authenticators with system defined authenticator"
       value:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -137,6 +137,137 @@ paths:
             curl --location 'https://localhost:9443/o/api/server/v1/authenticators/{authenticator-id}/connected-apps' \
             -H 'Accept: application/json' \
             -H 'Authorization: Bearer {bearer_token}'
+  /authenticators/custom:
+    post:
+      tags:
+        - User defined local authenticators
+      summary: |
+        Create a new user defined local authenticator.
+      description: |
+        This API provides the capability to create a new user defined local authenticator.
+
+        <b>Scope(Permission) required: </b> `internal_org_custom_authenticator_create`
+      operationId: addUserDefinedLocalAuthenticator
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+              examples:
+                example:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserDefinedLocalAuthenticatorCreation'
+        description: This represents the user defined local authenticator to be created.
+        required: true
+  /authenticators/custom/{authenticator-id}:
+    put:
+      tags:
+        - User defined local authenticators
+      summary: |
+        Update a user defined local authenticator.
+      description: |
+        This API provides the capability to update a user defined local authenticator configurations.
+        
+        <b>Scope(Permission) required:</b> `internal_org_custom_authenticator_update`
+      operationId: updateUserDefinedLocalAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+              examples:
+                example:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserDefinedLocalAuthenticatorUpdate'
+        description: This represents the user defined local authenticator to be created.
+        required: true
+    delete:
+      tags:
+        - User defined local authenticators
+      summary: |
+        Delete a user defined local authenticator.
+      description: |
+        This API provides the capability to delete a user defined local authenticators.
+
+        <b>Scope required:</b> `internal_org_custom_authenticator_delete`
+      operationId: deleteUserDefinedLocalAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   parameters:
@@ -213,6 +344,7 @@ components:
         id:
           type: string
           example: QmFzaWNBdXRoZW50aWNhdG9y
+          readOnly: true
         name:
           type: string
           example: BasicAuthenticator
@@ -222,11 +354,18 @@ components:
         isEnabled:
           type: boolean
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
+          readOnly: true
         type:
           type: string
           enum:
             - LOCAL
             - FEDERATED
+          readOnly: true
         image:
           type: string
           example: basic-authenticator-logo-url
@@ -238,9 +377,142 @@ components:
           items:
             type: string
           example: [2FA, MFA]
+          readOnly: true
         self:
           type: string
           example: /t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
+    UserDefinedLocalAuthenticatorCreation:
+      description: This represents the configuration for creating a user defined local authenticator.
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the user defined local authenticator. It must be started with 'custom-'.
+          example: custom-authenticator
+        id:
+          type: string
+          example: Y3VzdG9tLWF1dGhlbnRpY2F0b3I
+        displayName:
+          type: string
+          example: Custom Local Authenticator
+        isEnabled:
+          type: boolean
+          example: true
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION
+        image:
+          type: string
+          example: https://custom-authenticator-logo-url
+        description:
+          type: string
+          example: The user defined custom local authenticator.
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+        - isEnabled
+        - endpoint
+    UserDefinedLocalAuthenticatorUpdate:
+      description: This represents the configuration for updating a user defined local authenticator.
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: Custom Local Authenticator
+        isEnabled:
+          type: boolean
+          example: true
+        image:
+          type: string
+          example: https://custom-authenticator-logo-url-new
+        description:
+          type: string
+          example: The user defined custom local authenticator.
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+        - isEnabled
+        - endpoint
+    Endpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
+    AuthenticationType:
+      type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
+      required:
+        - type
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     ConnectedApps:
       type: object
       properties:
@@ -336,3 +608,15 @@ components:
           authorizationUrl: 'https://localhost:9443/oauth2/authorize'
           tokenUrl: 'https://localhost:9443/oauth2/token'
           scopes: {}
+  examples:
+    UserDefinedAuthenticatorExample:
+      summary: "Response for user defined authenticator"
+      value:
+        id: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        name: "custom-authenticator"
+        displayName: "Custom Local Authenticator"
+        definedBy: "USER"
+        type: "LOCAL"
+        isEnabled: true
+        tags: [ Custom ]
+        self: "/o/api/server/v1/configs/authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I="

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/authenticators.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/authenticators.yaml
@@ -238,7 +238,7 @@ paths:
       summary: |
         Delete a user defined local authenticator.
       description: |
-        This API provides the capability to delete a user defined local authenticators.
+        This API provides the capability to delete a user defined local authenticator.
 
         <b>Scope required:</b> `internal_org_custom_authenticator_delete`
       operationId: deleteUserDefinedLocalAuthenticator
@@ -435,7 +435,6 @@ components:
         endpoint:
           $ref: '#/components/schemas/Endpoint'
       required:
-        - name
         - displayName
         - isEnabled
         - endpoint

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/idp.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/idp.yaml
@@ -89,6 +89,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
+              examples:
+                identityProviderWithSystemDefinedAuthenticator:
+                  $ref: '#/components/examples/SystemDefinedIdentityProviderResponseExample'
+                identityProviderWithUserDefineAuthenticator:
+                  $ref: '#/components/examples/UserDefinedIdentityProviderResponseExample'
             application/xml:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
@@ -229,6 +234,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IdentityProviderPOSTRequest'
+            examples:
+              identityProviderWithSystemDefinedAuthenticator:
+                $ref: '#/components/examples/IdentityProviderWithSystemDefinedAuthenticatorPOSTRequestExample'
+              identityProviderWithUserDefineAuthenticator:
+                $ref: '#/components/examples/IdentityProviderWithUserDefinedAuthenticatorPOSTRequestExample'
           application/xml:
             schema:
               $ref: '#/components/schemas/IdentityProviderPOSTRequest'
@@ -466,6 +476,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
+              examples:
+                identityProviderWithSystemDefinedAuthenticator:
+                  $ref: '#/components/examples/SystemDefinedIdentityProviderResponseExample'
+                identityProviderWithUserDefineAuthenticator:
+                  $ref: '#/components/examples/UserDefinedIdentityProviderResponseExample'
             application/xml:
               schema:
                 $ref: '#/components/schemas/IdentityProviderResponse'
@@ -846,6 +861,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorListResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorListResponseExample'
         '400':
           description: Bad Request
           content:
@@ -899,6 +919,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorListResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorListResponseExample'
         '400':
           description: Bad Request
           content:
@@ -950,6 +975,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/FederatedAuthenticatorRequest'
+            examples:
+              systemDefinedAuthenticatorsExample:
+                $ref: '#/components/examples/SystemDefinedAuthenticatorsListPUTRequestExample'
+              userDefinedAuthenticators:
+                $ref: '#/components/examples/UserDefinedAuthenticatorsListPUTRequestExample'
         description: This represents the federated authenticators to be updated
         required: true
   /identity-providers/{identity-provider-id}/federated-authenticators/{federated-authenticator-id}:
@@ -982,6 +1012,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticator'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorResponseExample'
         '400':
           description: Bad Request
           content:
@@ -1046,6 +1081,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticator'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorResponseExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorResponseExample'
         '400':
           description: Bad Request
           content:
@@ -1091,6 +1131,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/FederatedAuthenticatorPUTRequest'
+            examples:
+              systemDefinedAuthenticatorsExample:
+                $ref: '#/components/examples/SystemDefinedAuthenticatorPUTRequestExample'
+              userDefinedAuthenticators:
+                $ref: '#/components/examples/UserDefinedAuthenticatorPUTRequestExample'
         description: This represents the federated authenticator to be updated
         required: true
   '/identity-providers/{identity-provider-id}/provisioning':
@@ -2146,6 +2191,11 @@ components:
         name:
           type: string
           example: SAML2Authenticator
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         self:
           type: string
           example: /api/server/v1/identity-providers/meta/federated-authenticators/U0FNTFNTT0F1dGhlbnRpY2F0b3I
@@ -2161,6 +2211,11 @@ components:
         displayName:
           type: string
           example: 'SAML2 Web SSO Configuration'
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         properties:
           type: array
           items:
@@ -2200,6 +2255,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         isDefault:
           type: boolean
           default: false
@@ -2207,6 +2267,84 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+    Endpoint:
+      type: object
+      required:
+        - uri
+        - authentication
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
+    AuthenticationType:
+      type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     FederatedAuthenticatorPUTRequest:
       type: object
       properties:
@@ -2226,10 +2364,17 @@ components:
           type: boolean
           default: false
           example: false
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         properties:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorListResponse:
       type: object
       properties:
@@ -2253,6 +2398,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         self:
           type: string
           example: /api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y
@@ -2632,3 +2782,356 @@ components:
           type: string
           format: binary
           description: file to upload
+  examples:
+    UserDefinedAuthenticatorPUTRequestExample:
+      summary: Put request for user defined authenticators
+      value:
+        authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        name: "custom-authenticator"
+        default: true
+        definedBy: "USER"
+        endpoint:
+          uri: "https://abc.com/token"
+          authentication:
+            type: "BASIC"
+            properties:
+              username: "auth_username"
+              password: "auth_password"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
+    SystemDefinedAuthenticatorPUTRequestExample:
+      summary: "Put request for system defined authenticators"
+      value:
+        authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        isEnabled:  true
+        isDefault:  true
+        properties:
+          - key: "somePropertyKey"
+            value: "somePropertyValue"
+    UserDefinedAuthenticatorsListPUTRequestExample:
+      summary: "Put request for user defined authenticators list"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+            name: "custom-authenticator"
+            default: true
+            definedBy: "USER"
+            endpoint:
+              uri: "https://abc.com/token"
+              authentication:
+                type: "BASIC"
+                properties:
+                  username: "auth_username"
+                  password: "auth_password"
+              allowedHeaders:
+                - x-geo-location
+                - host
+              allowedParameters:
+                - device-id
+    SystemDefinedAuthenticatorsListPUTRequestExample:
+      summary: "Put request for system defined authenticators list"
+      value:
+        defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        authenticators:
+          - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+            isEnabled:  true
+            isDefault:  true
+            properties:
+              - key: "somePropertyKey"
+                value: "somePropertyValue"
+    IdentityProviderWithSystemDefinedAuthenticatorPOSTRequestExample:
+      summary: "POST request for an identity provider with a system defined authenticator"
+      value:
+        name: "google"
+        description: "IdP for Google Federation"
+        image: "google-logo-url"
+        templateId: "8ea23303-49c0-4253-b81f-82c0fe6fb4a0"
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: "localhost"
+        certificate:
+          certificates:
+            - "string"
+          jwksUri: "https://localhost:9444/t/{tenantDomain}/o/oauth2/jwks"
+        alias: "https://localhost:9444/t/{tenantDomain}/o/oauth2/token"
+        idpIssuerName: "https://www.idp.com"
+        claims:
+          userIdClaim:
+            uri: "http://wso2.org/claims/username"
+          roleClaim:
+            uri: "http://wso2.org/claims/username"
+          mappings:
+            - idpClaim: "country"
+              localClaim:
+                uri: "http://wso2.org/claims/username"
+          provisioningClaims:
+            - claim:
+                uri: "http://wso2.org/claims/username"
+              defaultValue: "sathya"
+        roles:
+          mappings:
+            - idpRole: "google-manager"
+              localRole: "manager"
+          outboundProvisioningRoles:
+            - "manager"
+            - "hr-admin"
+        groups:
+          - name: "google-admin"
+            id: "6b1f8513-3de0-4f28-9cad-b7400dbc94ae"
+        federatedAuthenticators:
+          defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+          authenticators:
+            - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+              isEnabled: true
+              isDefault: true
+              properties:
+                - key: "somePropertyKey"
+                  value: "somePropertyValue"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            defaultConnectorId: "U0NJTQ"
+            connectors:
+              - connectorId: "U0NJTQ"
+                isEnabled: true
+                isDefault: true
+                blockingEnabled: false
+                rulesEnabled: false
+                properties:
+                  - key: "somePropertyKey"
+                    value: "somePropertyValue"
+        implicitAssociation:
+          isEnabled: false
+          lookupAttribute:
+            - "email"
+    IdentityProviderWithUserDefinedAuthenticatorPOSTRequestExample:
+      summary: "POST request for an identity provider with a user defined authenticator"
+      value:
+        name: "Custom IDP"
+        description: "IDP with custom federated authenticator"
+        image: "https://custom-authenticator-logo-url"
+        templateId: "external-custom-authenticator"
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: ""
+        certificate:
+          certificates:
+            - ""
+          jwksUri: ""
+        claims:
+          userIdClaim:
+            uri: "http://wso2.org/claims/username"
+          roleClaim:
+            uri: ""
+          mappings: []
+          provisioningClaims: []
+        roles:
+          mappings: [ ]
+          outboundProvisioningRoles: [ ]
+        federatedAuthenticators:
+          defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+          authenticators:
+            - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+              isEnabled: true
+              isDefault: true
+              definedBy: "USER"
+              endpoint:
+                uri: "https://abc.com/token"
+                authentication:
+                  type: "BASIC"
+                  properties:
+                    username: "auth_username"
+                    password: "auth_password"
+                allowedHeaders:
+                  - x-geo-location
+                  - host
+                allowedParameters:
+                  - device-id
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+    SystemDefinedIdentityProviderResponseExample:
+      summary: "Response for identity provider creation with system defined authenticator"
+      value:
+        id: "123e4567-e89b-12d3-a456-556642440000"
+        name: "google"
+        description: "string"
+        isEnabled: true
+        isPrimary: false
+        image: "google-logo-url"
+        isFederationHub: false
+        homeRealmIdentifier: "localhost"
+        certificate:
+          certificates:
+            - "string"
+          jwksUri: "https://localhost:9444/t/{tenantDomain}/o/oauth2/jwks"
+        alias: "https://localhost:9444/t/{tenantDomain}/o/oauth2/token"
+        claims:
+          userIdClaim:
+            id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+            uri: "http://wso2.org/claims/username"
+            displayName: "Username"
+          roleClaim:
+            id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+            uri: "http://wso2.org/claims/username"
+            displayName: "Username"
+          mappings:
+            - idpClaim: "country"
+              localClaim:
+                id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                uri: "http://wso2.org/claims/username"
+                displayName: "Username"
+          provisioningClaims:
+            - claim:
+                id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+                uri: "http://wso2.org/claims/username"
+                displayName: "Username"
+              defaultValue: "sathya"
+        roles:
+          mappings:
+            - idpRole: "google-manager"
+              localRole: "manager"
+          outboundProvisioningRoles:
+            - "manager"
+            - "hr-admin"
+        federatedAuthenticators:
+          defaultAuthenticatorId: "U0FNTFNTT0F1dGhlbnRpY2F0b3I"
+          authenticators:
+            - authenticatorId: "U0FNTFNTT0F1dGhlbnRpY2F0b3I"
+              name: "SAML2Authenticator"
+              isEnabled: true
+              definedBy: "SYSTEM"
+              tags:
+                - "Social Login"
+                - "OIDC"
+              self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROMPT_USERNAME_PASSWORD_CONSENT"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            defaultConnectorId: "U0NJTQ"
+            connectors:
+              - connectorId: "U0NJTQ"
+                name: "SCIM"
+                isEnabled: true
+                self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/provisioning/outbound-connectors/U0NJTQ"
+    UserDefinedIdentityProviderResponseExample:
+      summary: "Response for identity provider creation with user defined authenticator"
+      value:
+        name: "Custom IDP"
+        description: "IDP with custom federated authenticator"
+        image: "https://custom-authenticator-logo-url"
+        templateId: "external-custom-authenticator"
+        isEnabled: true
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: ""
+        alias: ""
+        idpIssuerName: ""
+        claims:
+          userIdClaim:
+            id: "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"
+            uri: "http://wso2.org/claims/username"
+            displayName: "Username"
+          roleClaim:
+            uri: ""
+          mappings: [ ]
+          provisioningClaims: [ ]
+        roles:
+          mappings: [ ]
+        groups: [ ]
+        federatedAuthenticators:
+          defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+          authenticators:
+            - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+              name: "custom-authenticator"
+              isEnabled: true
+              definedBy: "USER"
+              tags:
+                - "Custom"
+              self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "DEFAULT"
+            associateLocalUser: false
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            connectors: [ ]
+        implicitAssociation:
+          isEnabled: false
+          lookupAttribute: [ ]
+    SystemDefinedAuthenticatorResponseExample:
+      summary: "System defined federated authenticator"
+      value:
+        authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        isEnabled: true
+        isDefault: true
+        definedBy: "SYSTEM"
+        tags:
+          - "Social Login"
+          - "OIDC"
+        properties:
+          - key: "somePropertyKey"
+            value: "somePropertyValue"
+    UserDefinedAuthenticatorResponseExample:
+      summary: "User defined federated authenticator"
+      value:
+        authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        isEnabled: true
+        isDefault: true
+        definedBy: "USER"
+        tags:
+          - "Custom"
+        endpoint:
+          uri: "https://abc.com/token"
+          authentication:
+            type: "BASIC"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
+    SystemDefinedAuthenticatorListResponseExample:
+      summary: "List of authenticators with system defined authenticator"
+      value:
+        defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        authenticators:
+          - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+            isEnabled: true
+            isDefault: true
+            definedBy: "SYSTEM"
+            tags:
+              - "Social Login"
+              - "OIDC"
+            self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y"
+    UserDefinedAuthenticatorListResponseExample:
+      summary: "List of authenticators with user defined authenticator"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+            name: "custom-authenticator"
+            isEnabled: true
+            definedBy: "USER"
+            tags:
+              - "Custom"
+            self: "/o/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I"

--- a/en/identity-server/next/docs/apis/restapis/authenticators.yaml
+++ b/en/identity-server/next/docs/apis/restapis/authenticators.yaml
@@ -237,11 +237,9 @@ paths:
       summary: |
         Delete a user defined local authenticator.
       description: |
-        This API provides the capability to delete a user defined local authenticator. <br>
-        <b>Permission required:</b> <br>
-            * /permission/admin/manage/custom_authenticator/delete <br>
-        <b>Scope required:</b> <br>
-            * internal_custom_authenticator_delete <br>
+        This API provides the capability to delete a user defined local authenticators.
+
+        <b>Scope required:</b> `internal_custom_authenticator_delete`
       operationId: deleteUserDefinedLocalAuthenticator
       parameters:
         - name: authenticator-id
@@ -378,6 +376,7 @@ components:
           items:
             type: string
           example: [2FA, MFA]
+          readOnly: true
         self:
           type: string
           example: /t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
@@ -448,8 +447,53 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
       required:
         - type
         - properties

--- a/en/identity-server/next/docs/apis/restapis/authenticators.yaml
+++ b/en/identity-server/next/docs/apis/restapis/authenticators.yaml
@@ -237,7 +237,7 @@ paths:
       summary: |
         Delete a user defined local authenticator.
       description: |
-        This API provides the capability to delete a user defined local authenticators.
+        This API provides the capability to delete a user defined local authenticator.
 
         <b>Scope required:</b> `internal_custom_authenticator_delete`
       operationId: deleteUserDefinedLocalAuthenticator
@@ -434,7 +434,6 @@ components:
         endpoint:
           $ref: '#/components/schemas/Endpoint'
       required:
-        - name
         - displayName
         - isEnabled
         - endpoint

--- a/en/identity-server/next/docs/apis/restapis/configs.yaml
+++ b/en/identity-server/next/docs/apis/restapis/configs.yaml
@@ -313,6 +313,11 @@ paths:
                       uri: "https://abc.com/authenticate"
                       authentication:
                         type: "BASIC"
+                      allowedHeaders:
+                        - x-geo-location
+                        - host
+                      allowedParameters:
+                        - device-id
         '400':
           description: Bad Request
           content:
@@ -1321,6 +1326,18 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
       required:

--- a/en/identity-server/next/docs/apis/restapis/idp.yaml
+++ b/en/identity-server/next/docs/apis/restapis/idp.yaml
@@ -3246,8 +3246,53 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
+      description: >
+            The type of authentication required by the action's endpoint. The following options are supported:
+            
+            - NONE: No authentication is required. <br>
+              ``{
+                "type": "NONE"
+              }``
+              
+            - BASIC: Basic authentication with a username and password.<br>
+              ``{
+                "type": "BASIC",
+                "properties": {
+                  "username": "auth_username",
+                  "password": "auth_password"
+                }
+              }``
+              
+            - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>
+              ``{
+                "type": "API_KEY",
+                "properties": {
+                  "header": "X-API-Key",
+                  "value": "12345-abcde-67890"
+                }
+              }``
+            
+            - BEARER: Bearer token-based authentication.<br/>
+              ``{
+                "type": "BEARER",
+                "properties": {
+                  "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
+                }
+              }``
       required:
         - type
       properties:
@@ -3856,6 +3901,11 @@ components:
             properties:
               username: "auth_username"
               password: "auth_password"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
     SystemDefinedAuthenticatorPUTRequestExample:
       summary: "Put request for system defined authenticators"
       value:
@@ -3881,6 +3931,11 @@ components:
                 properties:
                   username: "auth_username"
                   password: "auth_password"
+              allowedHeaders:
+                - x-geo-location
+                - host
+              allowedParameters:
+                - device-id
     SystemDefinedAuthenticatorsListPUTRequestExample:
       summary: "Put request for system defined authenticators list"
       value:
@@ -4000,6 +4055,11 @@ components:
                   properties:
                     username: "auth_username"
                     password: "auth_password"
+                allowedHeaders:
+                  - x-geo-location
+                  - host
+                allowedParameters:
+                  - device-id
         provisioning:
           jit:
             isEnabled: true
@@ -4149,6 +4209,11 @@ components:
           uri: "https://abc.com/token"
           authentication:
             type: "BASIC"
+          allowedHeaders:
+            - x-geo-location
+            - host
+          allowedParameters:
+            - device-id
     SystemDefinedAuthenticatorListResponseExample:
       summary: "List of authenticators with system defined authenticator"
       value:
@@ -4163,14 +4228,14 @@ components:
               - "OIDC"
             self: "/t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y"
     UserDefinedAuthenticatorListResponseExample:
-        summary: "List of authenticators with user defined authenticator"
-        value:
-          defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
-          authenticators:
-            - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
-              name: "custom-authenticator"
-              isEnabled: true
-              definedBy: "USER"
-              tags:
-                - "Custom"
-              self: "/t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+      summary: "List of authenticators with user defined authenticator"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tLWF1dGhlbnRpY2F0b3I"
+            name: "custom-authenticator"
+            isEnabled: true
+            definedBy: "USER"
+            tags:
+              - "Custom"
+            self: "/t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/Y3VzdG9tLWF1dGhlbnRpY2F0b3I"


### PR DESCRIPTION
## Purpose
This PR updates,
1. Identity Provider REST API with allowed headers and params information
2. Organization Identity Provider REST API for custom authenticators with allowed headers and params information.
3. Authenticators REST API with allowed headers and params information
4. Organization Authenticators REST API for custom authenticators with allowed headers and params information.

## Related Issue
- https://github.com/wso2/product-is/issues/25214