### PR TITLE
[Docs] Correct HSTS configuration steps for Console and web applications

### DIFF
--- a/en/identity-server/7.1.0/docs/deploy/security/enable-hsts.md
+++ b/en/identity-server/7.1.0/docs/deploy/security/enable-hsts.md
@@ -10,7 +10,7 @@ Enable HTTP Strict Transport Security (HSTS) headers for the applications deploy
 To enable HSTS for the WSO2 Identity Server Console, update the `web.xml` file located at
 `<IS_HOME>/repository/deployment/server/webapps/console/WEB-INF` and add the following filter configuration:
 
-```
+```xml
 <!-- Tomcat HTTP header security filter -->
 <filter>
     <filter-name>HttpHeaderSecurityFilter</filter-name>
@@ -36,7 +36,7 @@ To enable HSTS for other web applications deployed in WSO2 Identity Server, upda
 
 Add the same filter configuration used for the Console:
 
-```
+```xml
 <filter>
     <filter-name>HttpHeaderSecurityFilter</filter-name>        
     <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>

--- a/en/identity-server/next/docs/deploy/security/enable-hsts.md
+++ b/en/identity-server/next/docs/deploy/security/enable-hsts.md
@@ -10,7 +10,7 @@ Enable HTTP Strict Transport Security (HSTS) headers for the applications deploy
 To enable HSTS for the WSO2 Identity Server Console, update the `web.xml` file located at
 `<IS_HOME>/repository/deployment/server/webapps/console/WEB-INF` and add the following filter configuration:
 
-```
+```xml
 <!-- Tomcat HTTP header security filter -->
 <filter>
     <filter-name>HttpHeaderSecurityFilter</filter-name>
@@ -36,7 +36,7 @@ To enable HSTS for other web applications deployed in WSO2 Identity Server, upda
 
 Add the same filter configuration used for the Console:
 
-```
+```xml
 <filter>
     <filter-name>HttpHeaderSecurityFilter</filter-name>        
     <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>


### PR DESCRIPTION
## Purpose
This PR fixes inaccuracies in the documentation related to enabling HSTS in WSO2 Identity Server.

Console steps incorrect: The documentation refers to `<IS_HOME>/repository/conf/tomcat/console/WEB-INF/web.xml`, which does not exist in IS 7.1.0. Updated instructions to point to the correct location.

Web application steps unclear: The documentation incorrectly implies that the `HttpHeaderSecurityFilter` is available by default in web.xml files. Clarified the instructions to show how to manually add the filter configuration.

Fixes: https://github.com/wso2/product-is/issues/24674. 

## Related PRs
N/A

## Test environment
- WSO2 IS version: 7.1.0 and latest
- JDK: OpenJDK 11
- OS: MacOS Sonoma 14.4
- Browser: Firefox

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


