### PR TITLE
[Docs-IS] Document driver-level DB timeouts and clarify pool semantics in database configuration guides

### DIFF
--- a/en/identity-server/5.10.0/docs/setup/changing-to-ibm-db2.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-ibm-db2.md
@@ -281,4 +281,31 @@ The elements in the above configuration are described below:
  | **rollbackOnReturn** | If `                defaultAutoCommit               ` =false, then you can set `                rollbackOnReturn               ` =true so that the pool can terminate the transaction by calling rollback on the connection as it is returned to the pool. The default value is false.                                                                                                     |
 
 
-    
+### Driver-Level Timeouts (Recommended for Production)
+
+When the database becomes unresponsive, WSO2 IS threads may remain stuck while waiting for a JDBC connection. This happens because the Tomcat JDBC Pool cannot abort connection creation by itself ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L693-L702)).
+
+To mitigate this, configure **driver-level timeouts** in the JDBC URL:
+
+- **`connectTimeout`** → time to wait while establishing a DB connection.  
+- **`socketTimeout`** (or driver-equivalent) → time to wait for responses on an established connection.  
+- **`tcpKeepAlive=true`** (if supported) → helps detect dead peers.
+
+Also note the distinction:
+
+- **`maxWait`** (Tomcat pool) → how long to wait for a **free** pool connection when all are busy.  
+- **`connectTimeout` / `socketTimeout`** (driver) → how long to connect/read at the DB level.
+
+> **Note:** The WARN for `PoolExhaustedException` is logged only when `maxWait` elapses ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L739-L741)). This does not cover waits inside the driver’s connect/read paths; hence driver timeouts are required.
+
+#### Example (IBM DB2)
+
+```toml
+[database.identity_db]
+url = "jdbc:db2://DB_HOST:50000/WSO2_IDENTITY_DB:loginTimeout=10;queryTimeout=60;"
+username = "..."
+password = "..."
+driver = "com.ibm.db2.jcc.DB2Driver"
+```
+
+Reference: [IBM DB2 JDBC properties](https://www.ibm.com/docs/en/db2/11.5?topic=client-jdbc-properties)

--- a/en/identity-server/5.10.0/docs/setup/changing-to-mssql.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-mssql.md
@@ -269,4 +269,32 @@ The elements in the above configuration are described below:
  | **rollbackOnReturn** | If `                defaultAutoCommit               ` =false, then you can set `                rollbackOnReturn               ` =true so that the pool can terminate the transaction by calling rollback on the connection as it is returned to the pool. The default value is false.                                                                                                     |
 
 
-    
+### Driver-Level Timeouts (Recommended for Production)
+
+When the database becomes unresponsive, WSO2 IS threads may remain stuck while waiting for a JDBC connection. This happens because the Tomcat JDBC Pool cannot abort connection creation by itself ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L693-L702)).
+
+To mitigate this, configure **driver-level timeouts** in the JDBC URL:
+
+- **`connectTimeout`** → time to wait while establishing a DB connection.  
+- **`socketTimeout`** (or driver-equivalent) → time to wait for responses on an established connection.  
+- **`tcpKeepAlive=true`** (if supported) → helps detect dead peers.
+
+Also note the distinction:
+
+- **`maxWait`** (Tomcat pool) → how long to wait for a **free** pool connection when all are busy.  
+- **`connectTimeout` / `socketTimeout`** (driver) → how long to connect/read at the DB level.
+
+> **Note:** The WARN for `PoolExhaustedException` is logged only when `maxWait` elapses ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L739-L741)). This does not cover waits inside the driver’s connect/read paths; hence driver timeouts are required.
+
+#### Example (MSSQL)
+
+```toml
+[database.identity_db]
+url = "jdbc:sqlserver://DB_HOST:1433;databaseName=WSO2_IDENTITY_DB;loginTimeout=10;socketTimeout=60000"
+username = "..."
+password = "..."
+driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+```
+
+Reference: [Microsoft JDBC driver properties](https://learn.microsoft.com/sql/connect/jdbc/setting-the-connection-properties)
+

--- a/en/identity-server/5.10.0/docs/setup/changing-to-oracle.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-oracle.md
@@ -267,4 +267,31 @@ The elements in the above configuration are described below:
  | **rollbackOnReturn** | If `                defaultAutoCommit               ` =false, then you can set `                rollbackOnReturn               ` =true so that the pool can terminate the transaction by calling rollback on the connection as it is returned to the pool. The default value is false.                                                                                                     |
 
 
-    
+### Driver-Level Timeouts (Recommended for Production)
+
+When the database becomes unresponsive, WSO2 IS threads may remain stuck while waiting for a JDBC connection. This happens because the Tomcat JDBC Pool cannot abort connection creation by itself ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L693-L702)).
+
+To mitigate this, configure **driver-level timeouts** in the JDBC URL:
+
+- **`connectTimeout`** → time to wait while establishing a DB connection.  
+- **`socketTimeout`** (or driver-equivalent) → time to wait for responses on an established connection.  
+- **`tcpKeepAlive=true`** (if supported) → helps detect dead peers.
+
+Also note the distinction:
+
+- **`maxWait`** (Tomcat pool) → how long to wait for a **free** pool connection when all are busy.  
+- **`connectTimeout` / `socketTimeout`** (driver) → how long to connect/read at the DB level.
+
+> **Note:** The WARN for `PoolExhaustedException` is logged only when `maxWait` elapses ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L739-L741)). This does not cover waits inside the driver’s connect/read paths; hence driver timeouts are required.
+
+#### Example (Oracle)
+
+```toml
+[database.identity_db]
+url = "jdbc:oracle:thin:@//DB_HOST:1521/WSO2_IDENTITY_DB?oracle.net.CONNECT_TIMEOUT=10000&oracle.jdbc.ReadTimeout=60000"
+username = "..."
+password = "..."
+driver = "oracle.jdbc.OracleDriver"
+```
+
+Reference: [Oracle JDBC data sources & URLs](https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/data-sources-and-URLs.html)

--- a/en/identity-server/5.10.0/docs/setup/changing-to-postgresql.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-postgresql.md
@@ -267,4 +267,31 @@ The elements in the above configuration are described below:
 | **rollbackOnReturn** | If `                defaultAutoCommit               ` =false, then you can set `                rollbackOnReturn               ` =true so that the pool can terminate the transaction by calling rollback on the connection as it is returned to the pool. The default value is false.                                                                                                     |
 
 
-    
+### Driver-Level Timeouts (Recommended for Production)
+
+When the database becomes unresponsive, WSO2 IS threads may remain stuck while waiting for a JDBC connection. This happens because the Tomcat JDBC Pool cannot abort connection creation by itself ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L693-L702)).
+
+To mitigate this, configure **driver-level timeouts** in the JDBC URL:
+
+- **`connectTimeout`** → time to wait while establishing a DB connection.  
+- **`socketTimeout`** (or driver-equivalent) → time to wait for responses on an established connection.  
+- **`tcpKeepAlive=true`** (if supported) → helps detect dead peers.
+
+Also note the distinction:
+
+- **`maxWait`** (Tomcat pool) → how long to wait for a **free** pool connection when all are busy.  
+- **`connectTimeout` / `socketTimeout`** (driver) → how long to connect/read at the DB level.
+
+> **Note:** The WARN for `PoolExhaustedException` is logged only when `maxWait` elapses ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L739-L741)). This does not cover waits inside the driver’s connect/read paths; hence driver timeouts are required.
+
+#### Example (PostgreSQL)
+
+```toml
+[database.identity_db]
+url = "jdbc:postgresql://DB_HOST:5432/WSO2_IDENTITY_DB?connectTimeout=10&socketTimeout=60&tcpKeepAlive=true"
+username = "..."
+password = "..."
+driver = "org.postgresql.Driver"
+```
+
+Reference: [PostgreSQL JDBC connection parameters](https://jdbc.postgresql.org/documentation/use/#connection-parameters)

--- a/en/identity-server/5.10.0/docs/setup/changing-to-remote-h2.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-remote-h2.md
@@ -286,4 +286,31 @@ The elements in the above configuration are described below:
  | **rollbackOnReturn** | If `                defaultAutoCommit               ` =false, then you can set `                rollbackOnReturn               ` =true so that the pool can terminate the transaction by calling rollback on the connection as it is returned to the pool. The default value is false.                                                                                                     |
 
 
-    
+### Driver-Level Timeouts (Recommended for Production)
+
+When the database becomes unresponsive, WSO2 IS threads may remain stuck while waiting for a JDBC connection. This happens because the Tomcat JDBC Pool cannot abort connection creation by itself ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L693-L702)).
+
+To mitigate this, configure **driver-level timeouts** in the JDBC URL:
+
+- **`connectTimeout`** → time to wait while establishing a DB connection.  
+- **`socketTimeout`** (or driver-equivalent) → time to wait for responses on an established connection.  
+- **`tcpKeepAlive=true`** (if supported) → helps detect dead peers.
+
+Also note the distinction:
+
+- **`maxWait`** (Tomcat pool) → how long to wait for a **free** pool connection when all are busy.  
+- **`connectTimeout` / `socketTimeout`** (driver) → how long to connect/read at the DB level.
+
+> **Note:** The WARN for `PoolExhaustedException` is logged only when `maxWait` elapses ([reference](https://github.com/apache/tomcat/blob/9.0.82/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java#L739-L741)). This does not cover waits inside the driver’s connect/read paths; hence driver timeouts are required.
+
+#### Example (Remote H2)
+
+```toml
+[database.identity_db]
+url = "jdbc:h2:tcp://localhost/~/WSO2_IDENTITY_DB;QUERY_TIMEOUT=60000"
+username = "..."
+password = "..."
+driver = "org.h2.Driver"
+```
+
+Reference: [H2 connection settings](http://www.h2database.com/html/features.html#connection_settings)


### PR DESCRIPTION
### Purpose
Ensure users configure connection **driver-level timeouts** alongside JDBC pool options to prevent stuck threads during DB outages and enable clean recovery without manual restarts.

### Goals

* Add a concise, reusable section on **driver-level timeouts** to every database configuration page.
* Provide per-RDBMS **example JDBC URLs** with timeout parameters.
* Clarify the difference between **pool wait (`maxWait`)** and **driver connect/read timeouts**.
* Keep wording and snippets consistent so the same change can be **ported to newer doc versions** with minimal edits.

### Approach

* Add a subsection in each database configuration guide explaining the need for driver-level timeouts.
* Clearly distinguish between pool parameters and driver-level parameters.
* Provide per-database example connection strings with recommended timeout settings.
* Maintain a consistent structure across all database pages to allow easy reuse in future versions.

## Related Issues
Public Issue: https://github.com/wso2/product-is/issues/25321
