### PR TITLE
[Docs-IS] Add token exchange implicit account linking improvements for WSO2 IS documentation

### DIFF
--- a/en/includes/guides/authentication/configure-token-exchange.md
+++ b/en/includes/guides/authentication/configure-token-exchange.md
@@ -95,8 +95,6 @@ To enable token exchange in your application:
 
 4. Click **Update** to save the configurations.
 
-{% if product_name == "Asgardeo" %}
-
 ## Configure token exchange for a local user
 
 {{ product_name }} can exchange a third-party token with a token issued for an existing local user account. This is beneficial if you wish to check for blocked/disabled user accounts or to enforce Role-Based Access Control (RBAC).
@@ -126,8 +124,13 @@ You can configure lookup attributes to search for a matching local user account.
 
 After establishing account links, administrators can't delete them. Users can manage their own accounts links using the <a href="{{base_path}}/guides/user-self-service/manage-linked-accounts">Manage linked accounts</a> capability in the Self-service portal.
 
+!!! important
+    When configuring implicit account linking, select lookup attributes (such as `email`, `username`, or `externalId`) that are unique across all user stores. This prevents failures when multiple accounts match the same attribute.
+
 !!! note
     {{ product_name }} skips implicit account linking when **Require linked local account** is disabled, even if the implicit linking option remains enabled.
+
+{% if product_name == "Asgardeo" %}    
 
 To enable implicit account linking,
 
@@ -154,6 +157,13 @@ To enable implicit account linking,
     - `http://wso2.org/claims/mobile`
 
     {{ product_name }} will look for the <a href="{{base_path}}/guides/users/attributes/manage-oidc-attribute-mappings/#view-openid-connect-attributes">mapped OpenID Connect attribute</a> in the third-party token.
+
+{% else %}
+
+### Implicit account linking
+
+In {{ product_name }}, implicit account linking can be configured via the 
+[Implicit Association API](https://is.docs.wso2.com/en/{{ is_version }}/apis/idp/#tag/Implicit-Association/operation/updateImplicitAssociation).    
 
 {% endif %}
 


### PR DESCRIPTION
### Purpose
To strengthen the **Implicit Account Linking** documentation by addressing critical gaps related to attribute uniqueness, and guidance for implicit account linking in WSO2 Identity Server.

### Goals
* Ensure the documentation highlights essential requirements for reliable implicit account linking.
* Provide version-aware references to the correct WSO2 IS API documentation on implicit account linking.

### Approach
* Introduced a clear note emphasizing uniqueness requirements for lookup attributes.
* Updated the documentation to include version-aware API references.
* Preserved existing content flow while improving clarity and completeness.


### Related PRs
* *Token Exchange implementation changes* → https://github.com/wso2-extensions/identity-oauth2-grant-token-exchange/pull/41
* *Server/config surface & defaults* → https://github.com/wso2/carbon-identity-framework/pull/7242

### Related Issues
* Public Issue: https://github.com/wso2/product-is/issues/24798