### PR TITLE
[Docs-IS] Clarify Attribute Configurations Scope

### DIFF
--- a/en/includes/guides/users/attributes/manage-attributes.md
+++ b/en/includes/guides/users/attributes/manage-attributes.md
@@ -196,11 +196,11 @@ To configure properties of user attributes:
 
     To display an attribute in the user creation form, select the **both** **Display** and **Required** checkboxes for the **Administrator Console** entity.
 
-7. Go to the **Attribute Mappings** tab and enter the attribute from each user store that you need to map.
+6. Go to the **Attribute Mappings** tab and enter the attribute from each user store that you need to map.
 
     ![Edit attribute mappings]({{base_path}}/assets/img/guides/organization/attributes/edit-attribute-mappings.png){: width="500" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
-8. Optionally, you may use the **Additional Properties** tab to add additional properties that can be used when writing an extension.
+7. Optionally, you may use the **Additional Properties** tab to add additional properties that can be used when writing an extension.
 
     ![Edit additional properties]({{base_path}}/assets/img/guides/organization/attributes/edit-attributes-additional-properties.png){: width="500" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 


### PR DESCRIPTION
### Purpose
Make the scope of **Attribute Configurations** unambiguous in docs to prevent assumptions that these settings enforce backend/API validation.

### Goals
* State clearly that Attribute Configuration settings are **UI-only** (Admin Console, End-User Profile/My Account, Self-Registration).
* Reduce admin/operator misinterpretation without altering product behavior.

### Approach
* Add an **Important → Scope** callout under **Attribute Configurations** step, clarifying UI-only behavior and that custom UIs can read these configs and apply them to their forms.

### Related PRs

* https://github.com/wso2/identity-apps/pull/9046
* https://github.com/wso2/docs-is/pull/5573
* https://github.com/wso2/docs-is/pull/5574

## Related Issue

* Public: [https://github.com/wso2/product-is/issues/25559](https://github.com/wso2/product-is/issues/25559)
