### PR TITLE
Update Customize the authentication endpoint URL docs

### DIFF
--- a/en/includes/references/extend/authentication/customize-the-authentication-endpoint.md
+++ b/en/includes/references/extend/authentication/customize-the-authentication-endpoint.md
@@ -11,7 +11,7 @@ The authentication endpoint is the URL used in authentication requests. The foll
 
 The authentication endpoint URL is the location in your web application that contains authentication related pages. To customize these endpoints,
 
-1. Add the following configuration to the `deployment.toml` file found in the `<IS_HOME>/repository/conf/` directory and change the value of the parameters depending on the URL on which the web application should run. Assuming that the web application is running on `https://localhost:8443/authenticationendpoint`, the configuration would look as follows:
+1. Add the following configuration to the `deployment.toml` file found in the `<IS_HOME>/repository/conf/` directory and change the value of the parameters according to your web application's URL. Assuming that the web application is running on `https://localhost:8443/authenticationendpoint`, the configuration would look as follows:
 
     ```toml
     [authentication.endpoints.v2]


### PR DESCRIPTION
## Purpose
This pull request updates the documentation for customizing the authentication endpoint URL, focusing on new configuration options and version-specific availability. The changes clarify support for WSO2 Identity Server 7.0.0 (update level 78) and introduce a more detailed configuration example for customizing multiple authentication-related URLs.

Configuration enhancements:

* Updated instructions to show how to customize multiple authentication endpoint URLs (`login_url`, `retry_url`, and `request_missing_claims_url`) using the `[authentication.endpoints.v2]` section in `deployment.toml`, with example URLs provided.
* Clarified the configuration step to reference multiple parameters instead of just `login_url`.

## Related Issue
- https://github.com/wso2/product-is/issues/25531

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


