### PR TITLE
Fix numbering issue in 5.11.0 OpenTelemetry documentation

### DIFF
--- a/en/identity-server/5.11.0/docs/setup/working-with-product-observability.md
+++ b/en/identity-server/5.11.0/docs/setup/working-with-product-observability.md
@@ -326,7 +326,6 @@ To configure the Datadog Java Agent with WSO2 Identity Server, follow these step
     -Ddd.trace.agent.host=localhost \
     -Ddd.trace.otel.enabled=true \
     ```
-
    Refer to the [Datadog Java Agent configuration documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/#configuration-options) for the full set of options.
 
 5. Restart WSO2 Identity Server and confirm that traces appear in the [Datadog APM dashboard](https://docs.datadoghq.com/tracing/).


### PR DESCRIPTION
## Purpose
Fix numbering issues in the 5.11.0 OpenTelemetry documentation to ensure proper sequencing and readability.

## Related PRs
https://github.com/wso2/docs-is/pull/5472

## Test environment
JDK: OpenJDK 11
OS: macOS Sonoma 14.4
Browsers: Firefox 142.0.1

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


