### PR TITLE
Remove LDAP References for Consistency in Active Directory Documentation

### DIFF
--- a/en/includes/guides/users/user-stores/configure-active-directory-user-stores-for-scim2.md
+++ b/en/includes/guides/users/user-stores/configure-active-directory-user-stores-for-scim2.md
@@ -2,7 +2,7 @@
 
 WSO2 Identity Server can act both as a SCIM Provider and a SCIM consumer at the same time. You can test the WSO2 Identity Server's SCIM 2.0 Provider API as described here.
 
-When the WSO2 Identity Server is connected to an external LDAP or an Active Directory instance, they might not have these mandatory SCIM attributes in their schema. So the option is to map the SCIM attributes to the existing attributes of the Active Directory.
+When the WSO2 Identity Server is connected to an Active Directory instance, they might not have these mandatory SCIM attributes in their schema. So the option is to map the SCIM attributes to the existing attributes of the Active Directory.
 
 Add a user with the username "Alex" and password "Wso2@123". Here we have to map the **userName** (urn:ietf:params:scim:schemas:core:2.0:User) SCIM attribute to an existing attribute in the Active Directory (e.g.: cn).
 


### PR DESCRIPTION
## Purpose

The documentation [1] specifically mentions claim configuration for Active Directory. However, the LDAP reference present in this document causes ambiguity. To maintain consistency, this PR removes the LDAP references.

[1] https://is.docs.wso2.com/en/5.11.0/learn/configuring-active-directory-user-stores-for-scim-2.0-based-inbound-provisioning/

Related issue: 

- https://github.com/wso2/product-is/issues/23053

Related PR:
- https://github.com/wso2/docs-is/pull/5092

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


