### PR TITLE
[Docs-IS] Change Admonition from Important-Scope to Danger-Warning for Attribute Configuration

### DIFF
--- a/en/includes/guides/users/attributes/manage-attributes.md
+++ b/en/includes/guides/users/attributes/manage-attributes.md
@@ -160,7 +160,6 @@ To configure properties of user attributes:
 5. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
     !!! Danger "Warning"
-
         These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation. If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.
 
     ![Edit attributes]({{base_path}}/assets/img/guides/organization/attributes/configure-attribute-profiles.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
@@ -334,9 +333,13 @@ To configure properties of user attributes:
 
 7. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
-
+    {% if product_name == "WSO2 Identity Server" %}
+    !!! Danger "Warning"
+        These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation. If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.
+    {% else %}
     !!! Danger "Warning"
         These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation.
+    {% endif %}    
 
     ![Edit attributes]({{base_path}}/assets/img/guides/organization/attributes/configure-attribute-profiles.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 

--- a/en/includes/guides/users/attributes/manage-attributes.md
+++ b/en/includes/guides/users/attributes/manage-attributes.md
@@ -159,7 +159,7 @@ To configure properties of user attributes:
 
 5. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
-    !!! Important "Scope"
+    !!! Warning "Warning"
 
         These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation. If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.
 
@@ -335,7 +335,7 @@ To configure properties of user attributes:
 7. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
 
-    !!! Important "Scope"
+    !!! Warning "Warning"
         These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation.
 
     ![Edit attributes]({{base_path}}/assets/img/guides/organization/attributes/configure-attribute-profiles.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}

--- a/en/includes/guides/users/attributes/manage-attributes.md
+++ b/en/includes/guides/users/attributes/manage-attributes.md
@@ -159,7 +159,7 @@ To configure properties of user attributes:
 
 5. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
-    !!! Warning "Warning"
+    !!! Danger "Warning"
 
         These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation. If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.
 
@@ -335,7 +335,7 @@ To configure properties of user attributes:
 7. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
 
-    !!! Warning "Warning"
+    !!! Danger "Warning"
         These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation.
 
     ![Edit attributes]({{base_path}}/assets/img/guides/organization/attributes/configure-attribute-profiles.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}


### PR DESCRIPTION
### Purpose
Highlight the UI-only nature of **Attribute Configurations** more strongly in docs to prevent assumptions that these settings enforce backend or API validation.

### Goals
* Make it explicitly clear that Attribute Configuration settings are **UI-only** (Admin Console, End-User Profile/My Account, Self-Registration).
* Reduce the risk of admins/operators misinterpreting the configs as affecting backend/API behavior.

### Approach
* Updated admonition type from **Scope** to **Warning** under the *Attribute Configurations* section.
* The stronger admonition style emphasizes that these settings apply only to WSO2-managed UIs and do **not** alter backend or API validation.
* Content remains the same, ensuring clarity while increasing visibility of the warning.

**Related PRs**

* https://github.com/wso2/identity-apps/pull/9046
* https://github.com/wso2/docs-is/pull/5554

**Related Issue**

* Public: [https://github.com/wso2/product-is/issues/25559](https://github.com/wso2/product-is/issues/25559)
