### PR TITLE
[Docs-IS] Restructure Attribute Configurations Warning Placement and Content

### DIFF
--- a/en/includes/guides/users/attributes/manage-attributes.md
+++ b/en/includes/guides/users/attributes/manage-attributes.md
@@ -159,9 +159,6 @@ To configure properties of user attributes:
 
 5. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
-    !!! Danger "Warning"
-        These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation. If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.
-
     ![Edit attributes]({{base_path}}/assets/img/guides/organization/attributes/configure-attribute-profiles.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
     The table contains the following entities:
@@ -188,6 +185,11 @@ To configure properties of user attributes:
         </tr>
         </tbody>
     </table>
+
+    !!! Danger "Warning"
+        These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation.
+
+    If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.    
 
     !!! note
         Using the attribute configurations, you can also configure which attributes are displayed in the user creation form when
@@ -333,14 +335,6 @@ To configure properties of user attributes:
 
 7. Under **Attribute Configurations**, use the table to configure how attributes are handled for each entity.
 
-    {% if product_name == "WSO2 Identity Server" %}
-    !!! Danger "Warning"
-        These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation. If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms.
-    {% else %}
-    !!! Danger "Warning"
-        These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation.
-    {% endif %}    
-
     ![Edit attributes]({{base_path}}/assets/img/guides/organization/attributes/configure-attribute-profiles.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 
     The table contains the following entities:
@@ -367,6 +361,11 @@ To configure properties of user attributes:
         </tr>
         </tbody>
     </table>
+
+    !!! Danger "Warning"
+        These settings only control how the attributes behave in WSO2-managed UIs (Administrator Console, End-User Profile (i.e. My Account), Self-Registration). They **do not** affect backend or API validation.
+
+    If you create a custom end-user profile UI, you can reference these configurations to apply the same rules (Display, Required, Read-only) in your own forms. 
 
     !!! note
         Using the attribute configurations, you can also configure which attributes are displayed in the user creation form when


### PR DESCRIPTION
### Purpose
Enhance clarity and consistency of **Attribute Configurations** documentation by refining admonition placement/content and ensuring the same guidance is available in both IS and Asgardeo docs.

### Goals
* Position the **Warning** box where it is most relevant (after the attribute properties table).
* Keep the Warning content focused only on the UI-only scope and backend/API clarification.
* Move the custom end-user profile UI guidance outside the Warning for better readability.
* Ensure consistency by adding the same custom UI guidance line to **Asgardeo docs**.

### Approach
* Repositioned the **Warning admonition** below the attribute properties table.
* Trimmed Warning content to emphasize only that configurations are **UI-only** and do **not** affect backend/API validation.
* Pulled out the custom end-user profile UI guidance into its own paragraph above the Note admonition.
* Updated **Asgardeo docs** to include the same custom UI guidance for alignment with IS docs.

**Related PRs**

* https://github.com/wso2/identity-apps/pull/9046
* https://github.com/wso2/docs-is/pull/5554
* https://github.com/wso2/docs-is/pull/5573

**Related Issue**

* Public: [https://github.com/wso2/product-is/issues/25559](https://github.com/wso2/product-is/issues/25559)