### PR TITLE
Fix SDK broken link on landing page

### DIFF
--- a/en/identity-server/7.0.0/mkdocs.yml
+++ b/en/identity-server/7.0.0/mkdocs.yml
@@ -829,7 +829,7 @@ nav:
         - Work with product observability: deploy/monitor/work-with-product-observability.md
       - Upgrade WSO2 Identity Server: deploy/upgrade/upgrade-wso2-is.md
   - SDKs:
-    - Integrate Asgardeo into your application: sdks/index.md
+    - Integrate WSO2 IS into your application: sdks/index.md
   - SDK Documentation:
     - React SDK:
       - Overview: sdks/react/overview.md

--- a/en/identity-server/7.1.0/mkdocs.yml
+++ b/en/identity-server/7.1.0/mkdocs.yml
@@ -903,7 +903,7 @@ nav:
           - Work with product observability: deploy/monitor/work-with-product-observability.md
       - Upgrade WSO2 Identity Server: deploy/upgrade/upgrade-wso2-is.md
   - SDKs:
-    - Integrate Asgardeo into your application: sdks/index.md
+    - Integrate WSO2 IS into your application: sdks/index.md
   - SDK Documentation:
     - React SDK:
       - Overview: sdks/react/overview.md


### PR DESCRIPTION
## Purpose
This pull request updates the documentation navigation in both the 7.0.0 and 7.1.0 versions to clarify the integration target in the SDKs section. The main change is to update the wording from "Integrate Asgardeo into your application" to "Integrate WSO2 IS into your application" for consistency and accuracy.

Documentation navigation improvements:

* Changed the SDKs section label from "Integrate Asgardeo into your application" to "Integrate WSO2 IS into your application" in both `en/identity-server/7.0.0/mkdocs.yml` [[1]](diffhunk://#diff-53d566d2f42b1619af541b8ba38136618995a2c5f458b5b1136e78d679f03bc5L832-R832) and `en/identity-server/7.1.0/mkdocs.yml` [[2]](diffhunk://#diff-71d2c63b1d274304548b90d0971d7d6fed984c91c4eae68de82de3fe735c6d92L906-R906).

## Related Issue
https://github.com/wso2/product-is/issues/25720