### PR TITLE
Update scope required for /configs GET endpoints

### DIFF
--- a/en/identity-server/next/docs/apis/organization-apis/restapis/configs.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/configs.yaml
@@ -16,7 +16,7 @@ paths:
       description: |
         Retrieve server configs of the organization. 
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_org_config_view`
       responses:
         '200':
           description: Successful Response
@@ -61,7 +61,7 @@ paths:
       description: |
         Retrieve SAML2 inbound authentication configurations of the organization.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_org_config_view`
       operationId: getSAMLInboundAuthConfig
       responses:
         '200':
@@ -189,7 +189,7 @@ paths:
       description: |
         Retrieve WS Federation (Passive STS) inbound authentication configurations of the organization.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_org_config_view`
       operationId: getPassiveSTSInboundAuthConfig
       responses:
         '200':

--- a/en/identity-server/next/docs/apis/restapis/configs.yaml
+++ b/en/identity-server/next/docs/apis/restapis/configs.yaml
@@ -17,7 +17,7 @@ paths:
       description: |
         Retrieve Server Configs
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -118,7 +118,7 @@ paths:
       description: |
         Retrieve Server Inbound SCIM Configs
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -216,7 +216,7 @@ paths:
       description: |
         List available local authenticators of the server
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - $ref: '#/components/parameters/typeQueryParam'
       responses:
@@ -270,7 +270,7 @@ paths:
       description: |
         By passing in the appropriate authenticator ID, you can retrieve authenticator details
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - name: authenticator-id
           in: path
@@ -356,7 +356,7 @@ paths:
       description: |
         Retrieve the tenant CORS configuration.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -503,7 +503,7 @@ paths:
       description: |
         Retrieve Schemas supported by Server.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -552,7 +552,7 @@ paths:
       description: |
         By passing in the appropriate schema ID, you can retrieve attributes of a schema supported by the Server.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - name: schema-id
           in: path
@@ -605,7 +605,7 @@ paths:
       description: |
         Retrieve Remote Logging Configurations
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -759,7 +759,7 @@ paths:
       description: |
         Retrieve Remote Logging Configurations by log type.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       parameters:
         - name: log-type
           in: path
@@ -926,7 +926,7 @@ paths:
       description: |
         Retrieve server SAML2 inbound authentication configurations.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       operationId: getSAMLInboundAuthConfig
       responses:
         '200':
@@ -1054,7 +1054,7 @@ paths:
       description: |
         Retrieve WS Federation (Passive STS) inbound authentication configurations.
         
-        <b>Scope(Permission) required:</b> `internal_login`
+        <b>Scope(Permission) required:</b> `internal_config_view`
       operationId: getPassiveSTSInboundAuthConfig
       responses:
         '200':


### PR DESCRIPTION
## Purpose
With [1] the scope required for `/configs/(*)` elevated from `internal_login` to `internal_config_view`. This PR updates the documentation to reflect that change.

[1] - https://github.com/wso2/carbon-identity-framework/pull/7399

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


