### PR TITLE
[bug-fix] Email Templates V2 Management API example issues

### DIFF
--- a/en/identity-server/7.0.0/docs/apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/email-templates-v2.yaml
@@ -61,9 +61,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     post:
       tags:
         - Email Template Types
@@ -167,9 +167,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     delete:
       tags:
         - Email Template Types
@@ -199,9 +199,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
   '/email/template-types/{template-type-id}/org-templates':
     get:
       tags:
@@ -241,9 +241,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     post:
       tags:
         - Email Templates
@@ -295,7 +295,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -346,9 +346,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     post:
       tags:
         - Application Email Templates
@@ -402,7 +402,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -451,9 +451,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     put:
       tags:
         - Email Templates
@@ -497,7 +497,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PUT' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -537,9 +537,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
   '/email/template-types/{template-type-id}/app-templates/{app-uuid}/{locale}':
     get:
       tags:
@@ -579,9 +579,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     put:
       tags:
         - Application Email Templates
@@ -626,7 +626,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PUT' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -663,17 +663,17 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-      x-extension-1:
+      x-codeSamples:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
 servers:
-  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v2'
+  - url: 'https://{serverUrl}/t/{tenantDomain}/api/server/v2'
     variables:
-      tenant-domain:
+      tenantDomain:
         default: carbon.super
 components:
   parameters:

--- a/en/identity-server/7.1.0/docs/apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.1.0/docs/apis/restapis/email-templates-v2.yaml
@@ -61,9 +61,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     post:
       tags:
         - Email Template Types
@@ -167,9 +167,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     delete:
       tags:
         - Email Template Types
@@ -199,9 +199,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
   '/email/template-types/{template-type-id}/org-templates':
     get:
       tags:
@@ -241,9 +241,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     post:
       tags:
         - Email Templates
@@ -295,7 +295,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -347,9 +347,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     post:
       tags:
         - Application Email Templates
@@ -403,7 +403,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'POST' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -452,9 +452,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     put:
       tags:
         - Email Templates
@@ -498,7 +498,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PUT' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -538,9 +538,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/org-templates/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
   '/email/template-types/{template-type-id}/app-templates/{app-uuid}/{locale}':
     get:
       tags:
@@ -581,9 +581,9 @@ paths:
         - lang: Curl
           source: |
             curl -X 'GET' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
     put:
       tags:
         - Application Email Templates
@@ -628,7 +628,7 @@ paths:
         - lang: Curl
           source: |
             curl -X 'PUT' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
             -H 'accept: application/json' \
             -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
             -H 'Content-Type: application/json' \
@@ -665,17 +665,17 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-      x-extension-1:
+      x-codeSamples:
         - lang: Curl
           source: |
             curl -X 'DELETE' \
-            'https://localhost:9443/t/carbon.super/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
-          '-H ''accept': application/json' \
-          '-H ''Authorization': Basic YWRtaW46YWRtaW4='
+            'https://localhost:9443/api/server/v2/email/template-types/YWNjb3VudGNvbmZpcm1hdGlvbg/app-templates/351262e3-1331-498a-bf2b-344b451ebb3a/en_US' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4='
 servers:
-  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v2'
+  - url: 'https://{serverUrl}/t/{tenantDomain}/api/server/v2'
     variables:
-      tenant-domain:
+      tenantDomain:
         default: carbon.super
 components:
   parameters:


### PR DESCRIPTION
## Purpose
In Email Templates V2 API in Management API section, example GET curls don't have proper headers. Also /t/carbon.super/ path is used which is not consistent with other docs.

## Related Issues
- https://github.com/wso2/product-is/issues/22870

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


