### PR TITLE
Add the required scope missing in GET /me/organizations  #25777

### DIFF
--- a/en/asgardeo/docs/apis/restapis/user-organization.yaml
+++ b/en/asgardeo/docs/apis/restapis/user-organization.yaml
@@ -30,6 +30,8 @@ paths:
         This API is used to search and retrieve child organizations which are authorized for the user.
       description:
         Retrieve authorized organizations which matches the defined search criteria, if any.
+
+        <b>Scope(Permission) required:</b> `internal_login`
       parameters:
         - $ref: '#/components/parameters/filterQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'

--- a/en/identity-server/7.0.0/docs/apis/restapis/user-organization.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/user-organization.yaml
@@ -35,6 +35,8 @@ paths:
         This API is used to search and retrieve child organizations which are authorized for the user.
       description:
         Retrieve authorized organizations which matches the defined search criteria, if any.
+
+        <b>Scope(Permission) required:</b> `internal_login`
       parameters:
         - $ref: '#/components/parameters/filterQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'

--- a/en/identity-server/7.1.0/docs/apis/restapis/user-organization.yaml
+++ b/en/identity-server/7.1.0/docs/apis/restapis/user-organization.yaml
@@ -35,6 +35,8 @@ paths:
         This API is used to search and retrieve child organizations which are authorized for the user.
       description:
         Retrieve authorized organizations which matches the defined search criteria, if any.
+
+        <b>Scope(Permission) required:</b> `internal_login`
       parameters:
         - $ref: '#/components/parameters/filterQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'

--- a/en/identity-server/next/docs/apis/restapis/user-organization.yaml
+++ b/en/identity-server/next/docs/apis/restapis/user-organization.yaml
@@ -35,6 +35,8 @@ paths:
         This API is used to search and retrieve child organizations which are authorized for the user.
       description:
         Retrieve authorized organizations which matches the defined search criteria, if any.
+
+        <b>Scope(Permission) required:</b> `internal_login`
       parameters:
         - $ref: '#/components/parameters/filterQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'


### PR DESCRIPTION
## Purpose
This pull request is for adding the missing scope (internal_login) in the User Organization API `/me/organizations` endpoint documentation.

## Approach
- Added `internal_login` scope in the description for the '/' path.
- Applied updates across:
  - Asgardeo
  - Identity Server 7.0.0
  - Identity Server 7.1.0
  - Identity Server next

## Related Issue
Fixes #25777


