### PR TITLE
[Docs] Remove the invalid URL displayed on the Branding docs #25845

### DIFF
--- a/en/includes/guides/branding/index.md
+++ b/en/includes/guides/branding/index.md
@@ -10,7 +10,11 @@ By default, your organization's business applications in {{ product_name }} are 
 
 {% endif %}
 
+{% if product_name == "Asgardeo" or (product_name == "WSO2 Identity Server" and is_version != "7.0.0" and is_version != "7.1.0") %}
+
 - [Use the editor to customize layouts]({{base_path}}/guides/branding/customize-layouts-with-editor/) for user login, sign-up, and account recovery flows. <sup>`Paid subscription required`</sup>
+
+{% endif %}
 
 {% if product_name == "Asgardeo" %}
 

--- a/en/includes/guides/branding/index.md
+++ b/en/includes/guides/branding/index.md
@@ -10,7 +10,7 @@ By default, your organization's business applications in {{ product_name }} are 
 
 {% endif %}
 
-{% if product_name == "Asgardeo" or (product_name == "WSO2 Identity Server" and is_version != "7.0.0" and is_version != "7.1.0") %}
+{% if product_name == "Asgardeo" or (product_name == "WSO2 Identity Server" and is_version > "7.1.0" ) %}
 
 - [Use the editor to customize layouts]({{base_path}}/guides/branding/customize-layouts-with-editor/) for user login, sign-up, and account recovery flows. <sup>`Paid subscription required`</sup>
 


### PR DESCRIPTION
## Purpose
This pull request updates the branding documentation by removing the invalid URL in the custom layouts editor list item for WSO2 Identity Server versions 7.0.0 and 7.1.0. It's now displayed only for Asgardeo and future releases of Identity Server.
Resolves: Invalid URL displayed in Branding Docs under editing custom layouts in Identity Server 7.0.0 and 7.1.0. 

## Related PRs
None

## Related PRs

- Added a if-condition in en/includes/guides/branding/index.md file 
- Updates are appplied across:
    - Asgardeo
    - Identity Server 7.0.0
    - Identity Server 7.1.0
   - Identity Server next

## Test environment
- Firefox 143+ (Windows 11)
- Tested with local build. Changes shown in the images below.

<img width="1912" height="1025" alt="PR 7 0 0 " src="https://github.com/user-attachments/assets/e1b676ce-d026-4bd8-8cca-a76b218870c3" />Changes appllied to Identity Server 7.0.0
<img width="1918" height="1022" alt="PR 7 1 0" src="https://github.com/user-attachments/assets/24eaa5c4-f0fc-4ac8-bd80-f646eeac2094" />Changes applied to Identity Server 7.1.0
<img width="1918" height="890" alt="PR asgardeo" src="https://github.com/user-attachments/assets/6f4795bf-3405-4cc3-a1c7-04ad112de00e" />Changes applied to Asgardeo

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?