### PR TITLE
[IS]Fix token introspection doc

### DIFF
--- a/en/includes/guides/authentication/oidc/token-validation-resource-server.md
+++ b/en/includes/guides/authentication/oidc/token-validation-resource-server.md
@@ -30,6 +30,8 @@ Unlike JWT tokens, opaque tokens are non-transparent. This means that the author
 ``` 
 {{product_url_format}}/oauth2/introspect
 ```
+
+{% if product_name == 'Asgardeo' %}
 === "Request format"
 
     ```bash
@@ -48,6 +50,64 @@ Unlike JWT tokens, opaque tokens are non-transparent. This means that the author
     --header 'Authorization: Basic V3NvcTh0NG5IVzgwZ1NuUGZ5RHZSYmlDX19FYTp6MEM3OXpsb3B4OGk3QnlPdzhLMTVBOWRwbFlh' \
     --data-urlencode 'token=94e325b7-77c8-32c2-a6ff-d7be430bf785'
     ```
+
+{% endif %}
+
+{% if product_name == "WSO2 Identity Server" %}
+=== "Request format"
+
+    ```bash
+    curl --location --request POST {{product_url_format}}/oauth2/introspect \
+    --header 'Content-Type: application/x-www-form-urlencoded' \
+    --header 'Authorization: Basic <Base64Encoded(Username:Password)>' \
+    --data-urlencode 'token={access_token}'
+    ```
+
+=== "Request sample"
+
+    ```bash
+    curl --location --request POST '{{ product_url_sample }}/oauth2/introspect' \
+    --header 'Content-Type: application/x-www-form-urlencoded' \
+    --header 'Authorization: Basic YWRtaW46YWRtaW4=' \
+    --data-urlencode 'token=94e325b7-77c8-32c2-a6ff-d7be430bf785'
+    ```
+
+{% endif %}
+
+{% if product_name == "WSO2 Identity Server" %}
+
+!!! note
+    Enable the following in `<IS_HOME>/repository/conf/deployment.toml` to use client ID- client secret based authentication for this endpoint.
+    By default, the endpoint uses username-password authentication.
+
+    ``` toml
+    [[resource.access_control]]
+    context="(.*)/oauth2/introspect(.*)"
+    http_method = "all"
+    secure = true
+    allowed_auth_handlers="BasicClientAuthentication"
+    ```
+
+    === "Request format"
+
+        ```bash
+        curl --location --request POST {{product_url_format}}/oauth2/introspect \
+        --header 'Content-Type: application/x-www-form-urlencoded' \
+        --header 'Authorization: Basic <Base64Encoded(ClientID:ClientSecret)>' \
+        --data-urlencode 'token={access_token}'
+        ```
+
+    === "Request sample"
+
+        ```bash
+        curl --location --request POST '{{ product_url_sample }}/oauth2/introspect' \
+        --header 'Content-Type: application/x-www-form-urlencoded' \
+        --header 'Cookie: atbv=646b0ed2-c501-4b17-9251-94112013a718' \
+        --header 'Authorization: Basic V3NvcTh0NG5IVzgwZ1NuUGZ5RHZSYmlDX19FYTp6MEM3OXpsb3B4OGk3QnlPdzhLMTVBOWRwbFlh' \
+        --data-urlencode 'token=94e325b7-77c8-32c2-a6ff-d7be430bf785'
+        ```
+
+{% endif %}
 
 ### User access token response
 


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/25520

## WSO2 IS

Bydefault, WSO2 IS uses username-password for token introspection. We need to include a deployment.toml configuration to support clientid-clientsecret based authentication
<br>
**Before the fix:**
<img width="923" height="388" alt="Screenshot 2025-10-02 at 20 58 10" src="https://github.com/user-attachments/assets/8cf28feb-943c-49b1-a9ba-e5c50dcfc77f" />

<br>

**After the fix:**
<img width="908" height="665" alt="Screenshot 2025-10-02 at 20 56 56" src="https://github.com/user-attachments/assets/8a5eeee6-8307-4646-a525-c559fe127ba6" />

<br>

## Asgardeo

**After the fix**

No change in the Asgardeo doc content
<img width="936" height="619" alt="Screenshot 2025-10-02 at 20 54 55" src="https://github.com/user-attachments/assets/96b9e505-913c-4cd3-bcb6-29961116b33a" />


## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


