### PR TITLE
[Asgardeo Docs] Remove behavioral change notice for omitting null fields in DCR API response

### DIFF
--- a/en/asgardeo/docs/apis/restapis/oauth-dcr.yaml
+++ b/en/asgardeo/docs/apis/restapis/oauth-dcr.yaml
@@ -3,15 +3,6 @@ info:
   title: Asgardeo - OAuth2 Dynamic Client Registration API
   description: |
     This document specifies an OAuth2 Dynamic Client Registration endpoint for Asgardeo.
-    <div style="border: 1px solid #f4c542; border-left: 6px solid #f4c542; border-radius: 6px; overflow: hidden; margin: 16px 0; background-color: #fffaf0;">
-      <div style="background-color: #fff8e5; padding: 10px 14px; border-bottom: 1px solid #f4c542;">
-        <span style="font-weight: 600; color: #8a6d00; font-size: 15px;">⚠️ NOTE</span>
-      </div>
-      <div style="padding: 14px 16px; color: #1a1a1a; line-height: 1.6;">
-        Starting <b>May&nbsp;1,&nbsp;2026</b>, <code>null</code> fields will no longer appear in the DCR API response to align with REST best practices.
-        We recommend using this grace period to update your integrations and ensure continued functionality.
-      </div>
-    </div>
   version: 1.1.0
 servers:
 - url: https:/api.asgardeo.io/t/{org-name}/api/identity/oauth2/dcr/v1.1


### PR DESCRIPTION
### Purpose
Remove the temporary public notice added in the **OAuth2 Dynamic Client Registration (DCR) API** documentation [[1]](https://wso2.com/asgardeo/docs/apis/dynamic-client-registration-rest-api/) after the grace period has ended.
The note previously informed users about the upcoming behavioral change to omit `null` fields from the DCR API response [2] in alignment with REST best practices.

### Goals
* Remove the temporary grace-period notice from the DCR API documentation.
* Align with the old documentation [[1]](https://wso2.com/asgardeo/docs/apis/dynamic-client-registration-rest-api/) (before the change notice was added via [[3]](https://github.com/wso2-enterprise/asgardeo-product/issues/33411) [[4]](https://github.com/wso2/docs-is/pull/5651)) with no notice in API docs.

### Approach
* Removed the yellow-highlighted HTML note block under the `info.description` section of `oauth-dcr.yaml`.

> **NOTE:**
> The grace period for returning `null` fields ended on **May 1, 2026**.
> With this update, the notice about the grace period on the documentation will be removed after May 1, 2026.
> In parallel, the behaviour of the DCR response should be changed to omit `null` fields in the response as well [[5]](https://github.com/wso2-enterprise/asgardeo-product/issues/33413) [[6]](https://github.com/wso2-enterprise/asgardeo-deployment-helm-is/pull/1360).

---

## Related Issues
  - https://github.com/wso2-enterprise/asgardeo-product/issues/33412

---

  - [1] https://wso2.com/asgardeo/docs/apis/dynamic-client-registration-rest-api/
  - [2] Mail: Handling Null Fields in DCR API Response
  - [3] https://github.com/wso2-enterprise/asgardeo-product/issues/33411
  - [4] https://github.com/wso2/docs-is/pull/5651
  - [5] https://github.com/wso2-enterprise/asgardeo-product/issues/33413
  - [6] https://github.com/wso2-enterprise/asgardeo-deployment-helm-is/pull/1360