### PR TITLE
Update securing-aws-http-apis.md: Fix incorrect JSON syntax in AWS HTTP API documentation

### DIFF
--- a/en/asgardeo/docs/guides/api-security/aws/securing-aws-http-apis.md
+++ b/en/asgardeo/docs/guides/api-security/aws/securing-aws-http-apis.md
@@ -305,7 +305,7 @@ curl -X POST "https://api.asgardeo.io/t/<ORG_NAME>/scim2/Roles" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -d '{
         "displayName": "PharmacyUser",
-        "users": [ { "value": <USER_ID> } ],
+        "users": [ { "value": "<USER_ID>" } ],
         "permissions": [ { "value": "get_pharmacy_user" } ]
       }'
 ```


### PR DESCRIPTION
## Purpose
Fix a minor documentation issue in `en/asgardeo/docs/guides/api-security/aws/securing-aws-http-apis.md`.

The JSON example previously used an invalid value placeholder:

    "users": [ { "value": <USER_ID> } ],

I updated it to:

    "users": [ { "value": "<USER_ID>" } ],

so that the snippet becomes valid JSON while keeping the intended meaning.

## Related PRs
None

## Test environment
N/A - This is a documentation-only change

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected JSON payload formatting in the AWS HTTP APIs security guide, ensuring user identifiers are properly quoted as strings for valid JSON syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->