### PR TITLE
[Feature] Application level retry/resend control limits.

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -5,6 +5,9 @@ OAuth2
 IdP
 SAML
 product_name
+product_url_format
+product_url_sample
+asgardeo_auth_script_warning
 keystore
 truststore
 truststores

--- a/en/asgardeo/docs/guides/authentication/conditional-auth/index.md
+++ b/en/asgardeo/docs/guides/authentication/conditional-auth/index.md
@@ -73,6 +73,7 @@ The pre-defined templates are listed below.
 | [New-Device-Based]({{base_path}}/guides/authentication/conditional-auth/new-device-based-template/) | This login flow sends an email notification and/or prompts two-factor authentication for users who are logged in from a previously unused device. |
 | [Group-Based (Adaptive MFA)]({{base_path}}/guides/authentication/conditional-auth/group-based-template/)  | This login flow prompts two-factor authentication (2FA) for users who belong to any of the given set of groups. |
 | [IP-Based]({{base_path}}/guides/authentication/conditional-auth/ip-based-template/) | This login flow prompts two-factor authentication for users who log in from outside the given IP range. |
+| [OTP Retry and Resend Limits]({{base_path}}/guides/authentication/conditional-auth/otp-retry-resend-limits/) | Limit how many times users can resend an OTP or enter a wrong OTP per application using the conditional authentication script. |
 | [Passkey-Progressive-Enrollment-Based]({{base_path}}/guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template/) | This login flow allows users to progressively enroll with passkey authenticator. |
 
 If required, you can also use the script editor to introduce new functions and fields to an authentication script based on your requirement. See the instructions on [writing a custom authentication script]({{base_path}}/guides/authentication/conditional-auth/write-your-first-script/).

--- a/en/asgardeo/docs/guides/authentication/conditional-auth/otp-retry-resend-limits.md
+++ b/en/asgardeo/docs/guides/authentication/conditional-auth/otp-retry-resend-limits.md
@@ -1,0 +1,9 @@
+{% set product_name = "Asgardeo" %}
+{% set product_url_format = "https://api.asgardeo.io/t/{organization_name}" %}
+{% set product_url_sample = "https://api.asgardeo.io/t/bifrost" %}
+{% set asgardeo_auth_script_warning =
+
+'    !!! warning "Important"
+        As a security measure, Asgardeo does not allow the usage of two consecutive periods (`..`) in authentication scripts.'
+%}
+{% include "../../../../../includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md" %}

--- a/en/asgardeo/mkdocs.yml
+++ b/en/asgardeo/mkdocs.yml
@@ -343,6 +343,11 @@ nav:
           - Add conditional authentication:
             - Add conditional authentication: guides/authentication/conditional-auth/index.md
             - Set up conditional authentication: guides/authentication/conditional-auth/configure-conditional-auth.md
+            - Advanced scenarios:
+              - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
+              - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
+              - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
+              - OTP Retry and Resend Limits: guides/authentication/conditional-auth/otp-retry-resend-limits.md
             - Add access control:
               - Add access control: guides/authentication/conditional-auth/access-control.md
               - User Age-based access: guides/authentication/conditional-auth/user-age-based-template.md
@@ -355,9 +360,6 @@ nav:
               - MFA based on user device: guides/authentication/conditional-auth/new-device-based-template.md
               - MFA based on IP address: guides/authentication/conditional-auth/ip-based-template.md
               - MFA based on advanced conditions (using WSO2 Choreo): guides/authentication/conditional-auth/add-authentications-based-on-api-calls.md
-            - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
-            - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
-            - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
             - Write a custom authentication script: guides/authentication/conditional-auth/write-your-first-script.md
           - App-native authentication:
             - App-native authentication: guides/authentication/app-native-authentication/index.md

--- a/en/asgardeo/mkdocs.yml
+++ b/en/asgardeo/mkdocs.yml
@@ -343,11 +343,6 @@ nav:
           - Add conditional authentication:
             - Add conditional authentication: guides/authentication/conditional-auth/index.md
             - Set up conditional authentication: guides/authentication/conditional-auth/configure-conditional-auth.md
-            - Advanced scenarios:
-              - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
-              - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
-              - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
-              - OTP Retry and Resend Limits: guides/authentication/conditional-auth/otp-retry-resend-limits.md
             - Add access control:
               - Add access control: guides/authentication/conditional-auth/access-control.md
               - User Age-based access: guides/authentication/conditional-auth/user-age-based-template.md
@@ -360,6 +355,11 @@ nav:
               - MFA based on user device: guides/authentication/conditional-auth/new-device-based-template.md
               - MFA based on IP address: guides/authentication/conditional-auth/ip-based-template.md
               - MFA based on advanced conditions (using WSO2 Choreo): guides/authentication/conditional-auth/add-authentications-based-on-api-calls.md
+            - Specialized scenarios:
+              - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
+              - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
+              - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
+              - OTP Retry and Resend Limits: guides/authentication/conditional-auth/otp-retry-resend-limits.md
             - Write a custom authentication script: guides/authentication/conditional-auth/write-your-first-script.md
           - App-native authentication:
             - App-native authentication: guides/authentication/app-native-authentication/index.md

--- a/en/identity-server/next/docs/guides/authentication/conditional-auth/index.md
+++ b/en/identity-server/next/docs/guides/authentication/conditional-auth/index.md
@@ -76,6 +76,7 @@ The pre-defined templates are listed below.
 | [Concurrent Session-Based]({{base_path}}/guides/authentication/conditional-auth/concurrent-session-based-template/) | This login flow prompts adaptive authentication for users who have exceeded the maximum number of allowed sessions.|
 | [New-Device-Based]({{base_path}}/guides/authentication/conditional-auth/new-device-based-template/) | This login flow sends an email notification and/or prompts two-factor authentication for users who are logged in from a previously unused device. |
 | [IP-Based]({{base_path}}/guides/authentication/conditional-auth/ip-based-template/) | This login flow prompts two-factor authentication for users who log in from outside the given IP range. |
+| [OTP Retry and Resend Limits]({{base_path}}/guides/authentication/conditional-auth/otp-retry-resend-limits/) | Limit how many times users can resend an OTP or enter a wrong OTP per application using the conditional authentication script. |
 | [Passkey-Progressive-Enrollment-Based]({{base_path}}/guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template/) | This login flow permits users to seamlessly enroll their passkey on-the-fly, when Passkey is designated as the first authentication factor. |
 
 If required, you can also use the script editor to introduce new functions and fields to an authentication script based on your requirement. See the instructions on [writing a custom authentication script]({{base_path}}/guides/authentication/conditional-auth/write-your-first-script/).

--- a/en/identity-server/next/docs/guides/authentication/conditional-auth/otp-retry-resend-limits.md
+++ b/en/identity-server/next/docs/guides/authentication/conditional-auth/otp-retry-resend-limits.md
@@ -1,0 +1,6 @@
+{% set product_name = "WSO2 Identity Server" %}
+{% set product_url = "https://localhost:9443" %}
+{% set product_url_format = "https://localhost:9443" %}
+{% set product_url_sample = "https://localhost:9443" %}
+{% set asgardeo_auth_script_warning = "" %}
+{% include "../../../../../../includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md" %}

--- a/en/identity-server/next/docs/references/troubleshoot/app-native-error-codes.md
+++ b/en/identity-server/next/docs/references/troubleshoot/app-native-error-codes.md
@@ -15,18 +15,12 @@ This document provides a list of error codes for the [authentication API]({{base
 |60008|400|Authentication flow time out.|Authentication flow has timed out as it took too long to complete.|
 |60009|400|Invalid flow identifier.|The provided flowId is invalid.|
 |60010|400|Invalid logout request.|Received logout request is invalid.|
+|60011|400|Application is disabled.|The application is disabled, and access is restricted.|
+|60012|400|Invalid authenticator.|Requested authenticator is invalid.|
+|60013|400|Maximum retry attempts exceeded.|The maximum number of OTP verification failure attempts configured for the application has been exceeded.|
+|60014|400|Maximum resend attempts exceeded.|The maximum number of OTP resend attempts configured for the application has been exceeded.|
 |65001|500|Unable to proceed with authentication.|Server encountered an error while processing the authentication request.|
 |65002|500|Unable to find authenticator.|Authenticator not found for name: \{\{authenticator_name\}\}.|
 |65003|500|Unknown authentication flow status.|Unknown authentication flow status: \{\{flow_status\}\}.|
 |65004|500|Unable to retrieve application.|Server encountered an error while retrieving application for clientId \{\{client_id\}\} in tenant domain \{\{tenant_domain\}\}.|
 |65005|500|Unable to proceed with logout.|Server encountered an error while processing the logout request.|
-
-
-
-
-
-
-
-
-
-

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -663,11 +663,6 @@ nav:
           - Add conditional authentication:
             - Add conditional authentication: guides/authentication/conditional-auth/index.md
             - Set up conditional authentication: guides/authentication/conditional-auth/configure-conditional-auth.md
-            - Advanced scenarios:
-              - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
-              - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
-              - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
-              - OTP Retry and Resend Limits: guides/authentication/conditional-auth/otp-retry-resend-limits.md
             - Add access control:
               - Add access control: guides/authentication/conditional-auth/access-control.md
               - Age-based access: guides/authentication/conditional-auth/user-age-based-template.md
@@ -685,6 +680,11 @@ nav:
               - MFA based on IP address: guides/authentication/conditional-auth/ip-based-template.md
               - MFA based on ELK-risk: guides/authentication/conditional-auth/elk-risk-based-template.md
               - MFA based on TypingDNA: guides/authentication/conditional-auth/typingdna-based-adaptive-auth.md
+            - Specialized scenarios:
+              - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
+              - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
+              - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
+              - OTP Retry and Resend Limits: guides/authentication/conditional-auth/otp-retry-resend-limits.md
             - Write a custom authentication script: guides/authentication/conditional-auth/write-your-first-script.md
           - Configure multi-attribute login: guides/authentication/multi-attribute-login.md
           - App-native authentication:

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -663,6 +663,11 @@ nav:
           - Add conditional authentication:
             - Add conditional authentication: guides/authentication/conditional-auth/index.md
             - Set up conditional authentication: guides/authentication/conditional-auth/configure-conditional-auth.md
+            - Advanced scenarios:
+              - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
+              - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
+              - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
+              - OTP Retry and Resend Limits: guides/authentication/conditional-auth/otp-retry-resend-limits.md
             - Add access control:
               - Add access control: guides/authentication/conditional-auth/access-control.md
               - Age-based access: guides/authentication/conditional-auth/user-age-based-template.md
@@ -680,9 +685,6 @@ nav:
               - MFA based on IP address: guides/authentication/conditional-auth/ip-based-template.md
               - MFA based on ELK-risk: guides/authentication/conditional-auth/elk-risk-based-template.md
               - MFA based on TypingDNA: guides/authentication/conditional-auth/typingdna-based-adaptive-auth.md
-            - Add passkey progressive enrollment: guides/authentication/conditional-auth/passkey-progressive-enrollment-based-template.md
-            - Add push notification device progressive enrollment: guides/authentication/conditional-auth/push-device-progressive-enrollment-based-template.md
-            - Add on-demand silent password migration: guides/authentication/conditional-auth/on-demand-silent-password-migration-template.md
             - Write a custom authentication script: guides/authentication/conditional-auth/write-your-first-script.md
           - Configure multi-attribute login: guides/authentication/multi-attribute-login.md
           - App-native authentication:

--- a/en/includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md
+++ b/en/includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md
@@ -1,37 +1,35 @@
 # Configure OTP retry and resend limits per application
 
-OTP retry and resend limits can be configured per application using the conditional authentication script. These limits define the maximum number of OTP resends and OTP verification failures allowed during a single authentication flow.
+Use conditional authentication to control how many times a user can resend an OTP or fail OTP verification during a single login attempt.
 
 ## Scenario
 
-Consider a login flow that uses SMS OTP or Email OTP with the following requirements:
+Consider a login flow that uses SMS OTP with these requirements:
 
-- Maximum of 3 OTP resends per login.
-- Maximum of 3 incorrect OTP submissions per login.
+- Users can request at most 3 OTP resends per login.
+- Users can submit at most 3 incorrect OTPs per login.
 
-Once a configured limit is reached, OTP resend or retry behavior is restricted.
+Once a user reaches either limit, the login flow blocks further retries or resend requests.
 
 ## Prerequisites
 
-- An application must be [registered in {{ product_name }}]({{base_path}}/guides/applications/).
-- The application login flow must include an OTP authenticator (SMS OTP or Email OTP) in at least one step.
+- [Register an application in {{ product_name }}]({{base_path}}/guides/applications/).
+- Add an SMS OTP authenticator to at least one step in the application's login flow.
 
 ## Configure the login flow
-
-To configure OTP retry and resend limits:
 
 1. On the {{ product_name }} Console, go to **Applications**.
 
 2. Select the application and open the **Login Flow** tab.
 
-3. Open the authentication script and locate the OTP step (the `executeStep(...)` call that runs SMS OTP or Email OTP). In that step, add the `authenticatorParams` block. Set the parameters under the relevant authenticator identifier:
+3. In the authentication script, find the `executeStep(...)` call that runs SMS OTP or Email OTP. Inside that step, add an `authenticatorParams` block. Use the correct authenticator identifier:
 
     - `sms-otp-authenticator` for SMS OTP
     - `email-otp-authenticator` for Email OTP
 
-    The **Example script** section shows the full structure.
+    See the **Example script** section for the full structure.
 
-4. Update the following parameters in the script:
+4. Set the following parameters in the script:
 
     <table>
         <thead>
@@ -43,36 +41,40 @@ To configure OTP retry and resend limits:
         <tbody>
             <tr>
                 <td><code>enableRetryFromAuthenticator</code></td>
-                <td>Set to <code>"true"</code> to apply the limits defined in the script.</td>
+                <td>Set to <code>"true"</code> to enforce the limits defined in the script.</td>
             </tr>
             <tr>
                 <td><code>maximumAllowedResendAttempts</code></td>
-                <td>Maximum number of OTP resend attempts allowed for the flow.</td>
+                <td>Maximum number of OTP resend attempts allowed per login.</td>
             </tr>
             <tr>
                 <td><code>maximumAllowedFailureAttempts</code></td>
-                <td>Maximum number of OTP verification failures allowed before retry is blocked.</td>
+                <td>Maximum number of incorrect OTP submissions allowed before the flow blocks further retries.</td>
             </tr>
             <tr>
                 <td><code>terminateOnResendLimitExceeded</code></td>
-                <td>If <code>"true"</code>, the flow ends immediately when the resend limit is exceeded. If <code>"false"</code>, further resends are blocked but OTP submission is still allowed using the last issued OTP.</td>
+                <td>
+                    Controls what happens when the resend limit is reached.<br><br>
+                    <code>"true"</code> — Ends the authentication flow immediately.<br>
+                    <code>"false"</code> — Blocks further resends but still accepts the last issued OTP.
+                </td>
             </tr>
         </tbody>
     </table>
 
 5. Click **Update** to save the script.
 
-!!! note "Account lock"
-    If the user account is locked (for example, due to tenant-level failed login attempts) before reaching <code>maximumAllowedFailureAttempts</code>, the account lock takes precedence and the authentication flow ends immediately.
+!!! note "Account lock takes precedence"
+    If {{ product_name }} locks the user account (for example, due to too many failed login attempts at the tenant level) before the user reaches <code>maximumAllowedFailureAttempts</code>, the account lock ends the authentication flow immediately.
 
-!!! note "User-based resend block"
-    A user-based resend block can be configured at the connection level (SMS OTP or Email OTP). Use settings such as **Allowed OTP resend attempt count** and **Resend block duration**. If the connection-level resend block is reached before the application-level resend limit (<code>maximumAllowedResendAttempts</code>) is exceeded, resend requests are temporarily blocked for the duration configured in the connection.
+!!! note "Connection-level resend block"
+    You can also configure a resend block at the connection level using settings such as **Allowed OTP resend attempt count** and **Resend block duration**. If the connection-level block triggers before the application-level limit (<code>maximumAllowedResendAttempts</code>), the connection temporarily blocks resend requests for the configured duration.
 
-    See the [SMS OTP]({{base_path}}/guides/authentication/mfa/add-smsotp-login/) and [Email OTP]({{base_path}}/guides/authentication/mfa/add-emailotp-login/) connection documentation for details.
+    See the [SMS OTP]({{base_path}}/guides/authentication/mfa/add-smsotp-login/) and [Email OTP]({{base_path}}/guides/authentication/mfa/add-emailotp-login/) documentation for details.
 
 ## Example script
 
-The following example sets a maximum of 3 resends and 3 OTP verification failures for the **SMS OTP** step. The flow ends when the resend limit is exceeded:
+The following script sets a maximum of 3 resends and 3 OTP verification failures for the **SMS OTP** step. The flow ends when the user exceeds the resend limit:
 
 ```js
 var onLoginRequest = function(context) {
@@ -92,7 +94,7 @@ var onLoginRequest = function(context) {
 };
 ```
 
-For **Email OTP**, use `email-otp-authenticator` with the same parameters inside the `local` block (instead of `sms-otp-authenticator`):
+For **Email OTP**, replace `sms-otp-authenticator` with `email-otp-authenticator` inside the `local` block:
 
 ```js
 "email-otp-authenticator": {
@@ -103,20 +105,20 @@ For **Email OTP**, use `email-otp-authenticator` with the same parameters inside
 }
 ```
 
-If these parameters are not included for an OTP step, the step uses the default behavior (no application-level limits from the script).
+If you omit these parameters, the OTP step uses its default behavior with no application-level limits.
 
 ## API-based flow error responses
 
-When OTP retry and resend limits are enforced in an API-based flow (app-native authentication), the configured limits can trigger the following error responses.
+When you use app-native authentication, reaching either limit returns an error response.
 
 {% if product_name != "Asgardeo" %}
 !!! note
-    See the [App-native error codes]({{base_path}}/references/troubleshoot/app-native-error-codes/) catalog for the complete list of error codes.
+    See the [App-native error codes]({{base_path}}/references/troubleshoot/app-native-error-codes/) catalog for the full list of error codes.
 {% endif %}
 
 ### Retry limit exceeded
 
-The following is an example error response when the maximum OTP verification failure attempts are exceeded:
+{{ product_name }} returns this error when the user exceeds `maximumAllowedFailureAttempts`:
 
 ```json
 {
@@ -129,7 +131,7 @@ The following is an example error response when the maximum OTP verification fai
 
 ### Resend limit exceeded
 
-The following is an example error response when the maximum OTP resend attempts are exceeded:
+{{ product_name }} returns this error when the user exceeds `maximumAllowedResendAttempts`:
 
 ```json
 {
@@ -142,16 +144,14 @@ The following is an example error response when the maximum OTP resend attempts 
 
 ## Try it out
 
-Follow the steps given below.
+1. Open the application and complete the first authentication step (for example, username and password).
 
-1. Access the application and complete the first step (for example, username and password).
+2. When prompted for an OTP, enter an incorrect code repeatedly. After `maximumAllowedFailureAttempts` failures, the flow blocks OTP retries.
 
-2. When prompted for OTP, submit an incorrect code repeatedly. After the number of failures set in `maximumAllowedFailureAttempts`, the flow should no longer allow OTP retries.
+3. Start a new login and request OTP resends repeatedly. After `maximumAllowedResendAttempts` resends:
 
-3. Start a new login and trigger OTP resend repeatedly. After the number of resends set in `maximumAllowedResendAttempts`:
-
-    - If `terminateOnResendLimitExceeded` is `"true"`, the authentication flow should end.
-    - If `terminateOnResendLimitExceeded` is `"false"`, further resends are blocked but OTP submission is still allowed using the last issued OTP.
+    - If `terminateOnResendLimitExceeded` is `"true"`, the authentication flow ends.
+    - If `terminateOnResendLimitExceeded` is `"false"`, the flow blocks further resends but still accepts the last issued OTP.
 
 !!! note
-    For more on the script and <code>executeStep</code>, see the [Conditional Authentication API Reference]({{base_path}}/references/conditional-auth/api-reference/).
+    For more on the authentication script and <code>executeStep</code>, see the [Conditional Authentication API Reference]({{base_path}}/references/conditional-auth/api-reference/).

--- a/en/includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md
+++ b/en/includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md
@@ -1,0 +1,157 @@
+# Configure OTP retry and resend limits per application
+
+OTP retry and resend limits can be configured per application using the conditional authentication script. These limits define the maximum number of OTP resends and OTP verification failures allowed during a single authentication flow.
+
+## Scenario
+
+Consider a login flow that uses SMS OTP or Email OTP with the following requirements:
+
+- Maximum of 3 OTP resends per login.
+- Maximum of 3 incorrect OTP submissions per login.
+
+Once a configured limit is reached, OTP resend or retry behavior is restricted.
+
+## Prerequisites
+
+- An application must be [registered in {{ product_name }}]({{base_path}}/guides/applications/).
+- The application login flow must include an OTP authenticator (SMS OTP or Email OTP) in at least one step.
+
+## Configure the login flow
+
+To configure OTP retry and resend limits:
+
+1. On the {{ product_name }} Console, go to **Applications**.
+
+2. Select the application and open the **Login Flow** tab.
+
+3. Open the authentication script and locate the OTP step (the `executeStep(...)` call that runs SMS OTP or Email OTP). In that step, add the `authenticatorParams` block. Set the parameters under the relevant authenticator identifier:
+
+    - `sms-otp-authenticator` for SMS OTP
+    - `email-otp-authenticator` for Email OTP
+
+    The **Example script** section shows the full structure.
+
+4. Update the following parameters in the script:
+
+    <table>
+        <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>enableRetryFromAuthenticator</code></td>
+                <td>Set to <code>"true"</code> to apply the limits defined in the script.</td>
+            </tr>
+            <tr>
+                <td><code>maximumAllowedResendAttempts</code></td>
+                <td>Maximum number of OTP resend attempts allowed for the flow.</td>
+            </tr>
+            <tr>
+                <td><code>maximumAllowedFailureAttempts</code></td>
+                <td>Maximum number of OTP verification failures allowed before retry is blocked.</td>
+            </tr>
+            <tr>
+                <td><code>terminateOnResendLimitExceeded</code></td>
+                <td>If <code>"true"</code>, the flow ends immediately when the resend limit is exceeded. If <code>"false"</code>, further resends are blocked but OTP submission is still allowed using the last issued OTP.</td>
+            </tr>
+        </tbody>
+    </table>
+
+5. Click **Update** to save the script.
+
+!!! note "Account lock"
+    If the user account is locked (for example, due to tenant-level failed login attempts) before reaching <code>maximumAllowedFailureAttempts</code>, the account lock takes precedence and the authentication flow ends immediately.
+
+!!! note "User-based resend block"
+    A user-based resend block can be configured at the connection level (SMS OTP or Email OTP). Use settings such as **Allowed OTP resend attempt count** and **Resend block duration**. If the connection-level resend block is reached before the application-level resend limit (<code>maximumAllowedResendAttempts</code>) is exceeded, resend requests are temporarily blocked for the duration configured in the connection.
+
+    See the [SMS OTP]({{base_path}}/guides/authentication/mfa/add-smsotp-login/) and [Email OTP]({{base_path}}/guides/authentication/mfa/add-emailotp-login/) connection documentation for details.
+
+## Example script
+
+The following example sets a maximum of 3 resends and 3 OTP verification failures for the **SMS OTP** step. The flow ends when the resend limit is exceeded:
+
+```js
+var onLoginRequest = function(context) {
+    executeStep(1); // Basic Authentication
+    executeStep(2, {
+        authenticatorParams: {
+            local: {
+                "sms-otp-authenticator": {
+                    "enableRetryFromAuthenticator": "true",
+                    "maximumAllowedResendAttempts": "3",
+                    "maximumAllowedFailureAttempts": "3",
+                    "terminateOnResendLimitExceeded": "true"
+                }
+            }
+        }
+    }, {});
+};
+```
+
+For **Email OTP**, use `email-otp-authenticator` with the same parameters inside the `local` block (instead of `sms-otp-authenticator`):
+
+```js
+"email-otp-authenticator": {
+    "enableRetryFromAuthenticator": "true",
+    "maximumAllowedResendAttempts": "3",
+    "maximumAllowedFailureAttempts": "3",
+    "terminateOnResendLimitExceeded": "true"
+}
+```
+
+If these parameters are not included for an OTP step, the step uses the default behavior (no application-level limits from the script).
+
+## API-based flow error responses
+
+When OTP retry and resend limits are enforced in an API-based flow (app-native authentication), the configured limits can trigger the following error responses.
+
+{% if product_name != "Asgardeo" %}
+!!! note
+    See the [App-native error codes]({{base_path}}/references/troubleshoot/app-native-error-codes/) catalog for the complete list of error codes.
+{% endif %}
+
+### Retry limit exceeded
+
+The following is an example error response when the maximum OTP verification failure attempts are exceeded:
+
+```json
+{
+  "code": "ABA-60013",
+  "message": "Maximum retry attempts exceeded.",
+  "description": "Authentication failed. The maximum number of retry attempts has been exceeded.",
+  "traceId": "20260311T060000Z-186b9bdb58cwz52dhC1SG155uc00000005zg000000002m7c"
+}
+```
+
+### Resend limit exceeded
+
+The following is an example error response when the maximum OTP resend attempts are exceeded:
+
+```json
+{
+  "code": "ABA-60014",
+  "message": "Maximum resend attempts exceeded.",
+  "description": "Authentication failed. The maximum number of resend attempts has been exceeded.",
+  "traceId": "20260311T060000Z-186b9bdb58cwz52dhC1SG155uc00000005zg000000002m7c"
+}
+```
+
+## Try it out
+
+Follow the steps given below.
+
+1. Access the application and complete the first step (for example, username and password).
+
+2. When prompted for OTP, submit an incorrect code repeatedly. After the number of failures set in `maximumAllowedFailureAttempts`, the flow should no longer allow OTP retries.
+
+3. Start a new login and trigger OTP resend repeatedly. After the number of resends set in `maximumAllowedResendAttempts`:
+
+    - If `terminateOnResendLimitExceeded` is `"true"`, the authentication flow should end.
+    - If `terminateOnResendLimitExceeded` is `"false"`, further resends are blocked but OTP submission is still allowed using the last issued OTP.
+
+!!! note
+    For more on the script and <code>executeStep</code>, see the [Conditional Authentication API Reference]({{base_path}}/references/conditional-auth/api-reference/).


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/26983

This pull request introduces documentation for configuring OTP retry and resend limits in conditional authentication scripts for both Asgardeo and WSO2 Identity Server. It adds a new guide, updates navigation menus, and references the new template from the list of pre-defined authentication templates. The changes provide clear instructions and examples for setting per-application limits on OTP resends and verification attempts.

**New OTP retry/resend limits documentation:**

* Added a new guide `otp-retry-resend-limits.md` describing how to configure per-application limits for OTP resend and retry attempts in authentication scripts, including parameters, example scripts, and usage notes.
* Integrated the new guide into Asgardeo (`en/asgardeo/docs/guides/authentication/conditional-auth/otp-retry-resend-limits.md`) and WSO2 Identity Server (`en/identity-server/next/docs/guides/authentication/conditional-auth/otp-retry-resend-limits.md`) documentation, with appropriate product-specific variables. [[1]](diffhunk://#diff-66011c9fd024c25874e57fb3b8789b2ee5777ffe590848726b58f06bd4e88b00R1-R5) [[2]](diffhunk://#diff-5837c9414629b57323de000eca7e5e59dc988ceb605689f2c9cbf4e53e826f7aR1-R6)

**Navigation and template references:**

* Added the new guide to the navigation menus in both Asgardeo (`en/asgardeo/mkdocs.yml`) and Identity Server (`en/identity-server/next/mkdocs.yml`) documentation. [[1]](diffhunk://#diff-a325268ca0b4795eee063a30248ca59cbfe240010598191ee99da58ab02a0b29R346) [[2]](diffhunk://#diff-53653710e1f22073d92c59884b21140096c8d2edee68f8d23789ae33e82f1d2dR666)
* Updated the list of pre-defined authentication templates in Asgardeo and Identity Server guides to reference the new OTP retry/resend limits template. [[1]](diffhunk://#diff-be8d96d40266176c3e5c69da43bda4701ea5b81f57e087bf1b970c3822016aa8R76) [[2]](diffhunk://#diff-b8db510a7ea7984671950a5ae10902810583de7a50708d13a3f0881db80a80fbR79)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for configuring per-application OTP retry and resend limits.
  * Updated conditional authentication indexes to include a new "OTP Retry and Resend Limits" entry.
  * Reorganized navigation to consolidate advanced authentication scenarios (the new OTP entry appears in two locations).

* **References**
  * Added four app-native error codes for disabled applications, invalid authenticators, and exceeded retry/resend limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->