### PR TITLE
Fix broken link checker to await link validations before closing the browser

### DIFF
--- a/en/check-broken-links.js
+++ b/en/check-broken-links.js
@@ -48,6 +48,29 @@ function logBrokenLink(link, sourceUrl) {
   fs.appendFileSync(logFile, logEntry);
 }
 
+// Checks a single markdown link and returns a promise so caller can await or chain checks
+function checkLink(link, sourceUrl) {
+  return new Promise((resolve, reject) => {
+    markdownLinkCheck(link, { retry: true }, (err, results) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      results.forEach(result => {
+        const { dead, statusCode } = result;
+
+        if (dead || statusCode === 404) {
+          logBrokenLink(link, sourceUrl);
+          console.log(`\n[Broken Link] Found: ${link}\n`);
+        }
+      });
+
+      resolve();
+    });
+  });
+}
+
 // Function to check links on a page and crawl nested links
 async function checkLinksOnPage(url, depth = 2) {
   if (isShuttingDown || depth < 0 || visitedUrls.has(url)) return; // Stop if shutting down, depth limit reached, or already visited

--- a/en/check-broken-links.js
+++ b/en/check-broken-links.js
@@ -77,67 +77,54 @@ async function checkLinksOnPage(url, depth = 2) {
 
   visitedUrls.add(url); // Mark the URL as visited
 
-  return new Promise((resolve) => {
-    // Use Puppeteer to get links from the page
-    (async () => {
-      const browser = await puppeteer.launch();
-      const page = await browser.newPage();
+  // Use Puppeteer to get links from the page
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
 
-      try {
-        spinner.text = `Visiting: ${url}`;
-        await page.goto(url, { waitUntil: 'networkidle2' });
-        const linksWithInfo = await page.evaluate(() => {
-          const anchorTags = Array.from(document.querySelectorAll('a'));
-          return anchorTags.map(tag => tag.href).filter(link => link.startsWith('http'));
-        });
+  try {
+    spinner.text = `Visiting: ${url}`;
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    const linksWithInfo = await page.evaluate(() => {
+      const anchorTags = Array.from(document.querySelectorAll('a'));
+      return anchorTags.map(tag => tag.href).filter(link => link.startsWith('http'));
+    });
+    const linkCheckPromises = [];
 
-        // Check each link
-        for (const link of linksWithInfo) {
-          if (shouldIgnore(link)) {
-            continue; // Skip ignored links
-          }
-
-          // Check if the link is in the same domain
-          const linkDomain = new URL(link).hostname;
-
-          // Increment local or external link count
-          if (linkDomain === baseDomain) {
-            localLinksCount++;
-          } else {
-            externalLinksCount++;
-          }
-
-          // Check the link status
-          markdownLinkCheck(link, { retry: true }, (err, results) => {
-            if (err) {
-              console.error(`Error checking ${link}:`, err);
-              return;
-            }
-
-            results.forEach(result => {
-              const { dead, statusCode } = result;
-
-              if (dead || statusCode === 404) {
-                logBrokenLink(link, url);
-                console.log(`\n[Broken Link] Found: ${link}\n`);
-              }
-            });
-          });
-
-          // Recursively check nested links if they are in the same domain
-          if (linkDomain === baseDomain) {
-            await checkLinksOnPage(link, depth - 1);
-          }
-        }
-      } catch (error) {
-        console.error(`Error visiting ${url}:`, error);
-      } finally {
-        await browser.close(); // Ensure the browser is closed
-
-        resolve();
+    // Check each link
+    for (const link of linksWithInfo) {
+      if (shouldIgnore(link)) {
+        continue; // Skip ignored links
       }
-    })();
-  });
+
+      // Check if the link is in the same domain
+      const linkDomain = new URL(link).hostname;
+
+      // Increment local or external link count
+      if (linkDomain === baseDomain) {
+        localLinksCount++;
+      } else {
+        externalLinksCount++;
+      }
+
+      // Keep page resolution blocked until all link checks finish.
+      linkCheckPromises.push(
+        checkLink(link, url).catch(err => {
+          console.error(`Error checking ${link}:`, err);
+        })
+      );
+
+      // Recursively check nested links if they are in the same domain
+      if (linkDomain === baseDomain) {
+        await checkLinksOnPage(link, depth - 1);
+      }
+    }
+
+    await Promise.all(linkCheckPromises);
+  } catch (error) {
+    console.error(`Error visiting ${url}:`, error);
+  } finally {
+    await browser.close(); // Ensure the browser is closed
+  }
 }
 
 // Function to handle termination


### PR DESCRIPTION
## Purpose
Fix the async flow in the broken link checker so link validations complete before the Puppeteer browser is closed.

Previously, `markdown-link-check` was triggered inside the page crawl loop without being awaited, which could allow the crawl to finish and the browser to close before all link checks had completed. This change extracts link validation into a dedicated `checkLink()` helper and waits for all pending checks before closing the browser.

## Related Issue
No related issue

## Related PRs
No related PRs

## Test environment
- macOS (Darwin 24.6.0)
- Node.js v25.6.1
- No JDK or database applicable for this change
- No manual browser testing performed
- Validation:
	- Hosted a local page containing test links
	- Configured the linked endpoints to respond with `404` after a 3-second delay
	- Ran `node check-broken-links.js`
	- Verified the script reported all broken links and completed link checking before closing the browser


## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the link checking mechanism with improved error handling and optimized concurrent processing for better reliability and efficiency in detecting broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->