### PR TITLE
Add MCP Quick Start Documentation for both typeScript and python and Add Agent QuickStart doc to Identity Server 7.2.0 and next branch

### DIFF
--- a/en/asgardeo/docs/quick-starts/mcp-auth-server.md
+++ b/en/asgardeo/docs/quick-starts/mcp-auth-server.md
@@ -5,7 +5,7 @@ template: templates/quick-start.html
 <script>
   const meta = {
     what_you_will_learn: [
-      "Create a new MCP server in Typescript",
+      "Create a new MCP server in TypeScript",
       "Defines an MCP tool that adds two numbers",
       "Install <a href='https://www.npmjs.com/package/@asgardeo/mcp-express' target='_blank' rel='noopener noreferrer'>Asgardeo MCP SDK</a>",
       "Set up MCP authorization with {{ product_name }}"

--- a/en/identity-server/7.2.0/docs/quick-starts/agent-auth-py.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/agent-auth-py.md
@@ -15,8 +15,8 @@ template: templates/quick-start.html
       "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
       "Python 3.10 or later installed on your system",
       "pip or another Python package manager",
-      "A favorite text editor or IDE",
-      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+      "A text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the <a href='{{ base_path }}/quick-starts/mcp-auth-server-py/'>MCP Server Auth quickstart</a>)"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/python' target='_blank' class='github-icon'>Agent-Auth Python Sample</a>"
   };

--- a/en/identity-server/7.2.0/docs/quick-starts/agent-auth-py.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/agent-auth-py.md
@@ -1,0 +1,25 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Authenticate AI agents with {{ product_name }}",
+      "Use agent credentials or On-Behalf-Of (OBO) authentication flows",
+      "Connect authenticated agents to secure MCP servers",
+      "Invoke MCP tools safely from modern AI agent frameworks"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
+      "Python 3.10 or later installed on your system",
+      "pip or another Python package manager",
+      "A favorite text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/python' target='_blank' class='github-icon'>Agent-Auth Python Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/agent-auth-py.md" %}

--- a/en/identity-server/7.2.0/docs/quick-starts/agent-auth-ts.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/agent-auth-ts.md
@@ -15,8 +15,8 @@ template: templates/quick-start.html
       "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
       "Node.js installed on your system",
       "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
-      "A favorite text editor or IDE",
-      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+      "A text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the <a href='{{ base_path }}/quick-starts/mcp-auth-server/'>MCP Server Auth quickstart</a>)"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/typescript' target='_blank' class='github-icon'>Agent-Auth TypeScript Sample</a>"
   };

--- a/en/identity-server/7.2.0/docs/quick-starts/agent-auth-ts.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/agent-auth-ts.md
@@ -1,0 +1,25 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Authenticate AI agents with {{ product_name }}",
+      "Use agent credentials or On-Behalf-Of (OBO) authentication flows",
+      "Connect authenticated agents to secure MCP servers",
+      "Invoke MCP tools safely from modern AI agent frameworks"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
+      "Node.js installed on your system",
+      "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
+      "A favorite text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/typescript' target='_blank' class='github-icon'>Agent-Auth TypeScript Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/agent-auth-ts.md" %}

--- a/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
@@ -1,0 +1,23 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Set up a secure MCP server using Python",
+      "Connect your server to {{ product_name }} for authentication",
+      "Access MCP tools and resources securely"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "Install Python 3.10 or later on your system",
+      "Python package installer like pip installed",
+      "A favorite text editor or IDE"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/python' target='_blank' class='github-icon'>MCP-Auth Python Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/mcp-auth-server-py.md" %}

--- a/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
@@ -11,7 +11,7 @@ template: templates/quick-start.html
     ],
     prerequisites: [
       "About 15 minutes",
-      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Python 3.10 or later on your system",
       "Python package installer like pip installed",
       "A favorite text editor or IDE"

--- a/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
@@ -6,15 +6,15 @@ template: templates/quick-start.html
   const meta = {
     what_you_will_learn: [
       "Set up a secure MCP server using Python",
-      "Connect your server to {{ product_name }} for authentication",
+      "Connect your MCP server to {{ product_name }} for authentication",
       "Access MCP tools and resources securely"
     ],
     prerequisites: [
       "About 15 minutes",
       "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Python 3.10 or later on your system",
-      "Python package installer like pip installed",
-      "A favorite text editor or IDE"
+      "Python package manager (e:g.: pip) installed",
+      "A text editor or IDE"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/python' target='_blank' class='github-icon'>MCP-Auth Python Sample</a>"
   };

--- a/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
@@ -1,0 +1,24 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Create a new MCP server in Typescript",
+      "Defines an MCP tool that adds two numbers",
+      "Install <a href='https://www.npmjs.com/package/@asgardeo/mcp-express' target='_blank' rel='noopener noreferrer'>Asgardeo MCP SDK</a>",
+      "Set up MCP authorization with {{ product_name }}"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "Install Node.js on your system",
+      "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
+      "A favorite text editor or IDE"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/typescript' target='_blank' class='github-icon'>MCP-Auth Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/mcp-auth-server.md" %}

--- a/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
@@ -5,14 +5,14 @@ template: templates/quick-start.html
 <script>
   const meta = {
     what_you_will_learn: [
-      "Create a new MCP server in Typescript",
+      "Create a new MCP server in TypeScript",
       "Defines an MCP tool that adds two numbers",
       "Install <a href='https://www.npmjs.com/package/@asgardeo/mcp-express' target='_blank' rel='noopener noreferrer'>Asgardeo MCP SDK</a>",
       "Set up MCP authorization with {{ product_name }}"
     ],
     prerequisites: [
       "About 15 minutes",
-      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Node.js on your system",
       "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
       "A favorite text editor or IDE"

--- a/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
@@ -15,7 +15,7 @@ template: templates/quick-start.html
       "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Node.js on your system",
       "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
-      "A favorite text editor or IDE"
+      "A text editor or IDE"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/typescript' target='_blank' class='github-icon'>MCP-Auth Sample</a>"
   };

--- a/en/identity-server/7.2.0/mkdocs.yml
+++ b/en/identity-server/7.2.0/mkdocs.yml
@@ -575,6 +575,12 @@ nav:
           - OIDC Java EE: get-started/try-samples/qsg-oidc-webapp-java-ee.md
           - SAML Java EE: get-started/try-samples/qsg-saml-webapp-java-ee.md
           - WS-Federation: get-started/try-samples/ws-federation-webapp.md
+      - Secure MCP Servers:
+          - TypeScript: quick-starts/mcp-auth-server.md
+          - Python: quick-starts/mcp-auth-server-py.md
+      - Secure Your AI Agents:
+          - Python: quick-starts/agent-auth-py.md
+          - TypeScript: quick-starts/agent-auth-ts.md
       - Subscribe to AI features: get-started/subscribe-to-ai-features.md
       - About this release: get-started/about-this-release.md
   - Guides:

--- a/en/identity-server/next/docs/quick-starts/agent-auth-py.md
+++ b/en/identity-server/next/docs/quick-starts/agent-auth-py.md
@@ -15,8 +15,8 @@ template: templates/quick-start.html
       "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
       "Python 3.10 or later installed on your system",
       "pip or another Python package manager",
-      "A favorite text editor or IDE",
-      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+      "A text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the [MCP Auth Server quickstart]({{base_path}}/quick-starts/mcp-auth-server-py))"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/python' target='_blank' class='github-icon'>Agent-Auth Python Sample</a>"
   };

--- a/en/identity-server/next/docs/quick-starts/agent-auth-py.md
+++ b/en/identity-server/next/docs/quick-starts/agent-auth-py.md
@@ -1,0 +1,25 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Authenticate AI agents with {{ product_name }}",
+      "Use agent credentials or On-Behalf-Of (OBO) authentication flows",
+      "Connect authenticated agents to secure MCP servers",
+      "Invoke MCP tools safely from modern AI agent frameworks"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
+      "Python 3.10 or later installed on your system",
+      "pip or another Python package manager",
+      "A favorite text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/python' target='_blank' class='github-icon'>Agent-Auth Python Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/agent-auth-py.md" %}

--- a/en/identity-server/next/docs/quick-starts/agent-auth-ts.md
+++ b/en/identity-server/next/docs/quick-starts/agent-auth-ts.md
@@ -1,0 +1,25 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Authenticate AI agents with {{ product_name }}",
+      "Use agent credentials or On-Behalf-Of (OBO) authentication flows",
+      "Connect authenticated agents to secure MCP servers",
+      "Invoke MCP tools safely from modern AI agent frameworks"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
+      "Node.js installed on your system",
+      "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
+      "A favorite text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/typescript' target='_blank' class='github-icon'>Agent-Auth TypeScript Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/agent-auth-ts.md" %}

--- a/en/identity-server/next/docs/quick-starts/agent-auth-ts.md
+++ b/en/identity-server/next/docs/quick-starts/agent-auth-ts.md
@@ -15,8 +15,8 @@ template: templates/quick-start.html
       "A <a href='{{ base_path }}/get-started/quick-set-up/'>{{ product_name }} setup</a>",
       "Node.js installed on your system",
       "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
-      "A favorite text editor or IDE",
-      "An MCP server secured with {{ product_name }} (you may use your own or follow the MCP Auth Server quickstart)"
+      "A text editor or IDE",
+      "An MCP server secured with {{ product_name }} (you may use your own or follow the [MCP Auth Server quickstart]({{base_path}}/quick-starts/mcp-auth-server))"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/agent-identity/typescript' target='_blank' class='github-icon'>Agent-Auth TypeScript Sample</a>"
   };

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
@@ -1,0 +1,23 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Set up a secure MCP server using Python",
+      "Connect your server to {{ product_name }} for authentication",
+      "Access MCP tools and resources securely"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "Install Python 3.10 or later on your system",
+      "Python package installer like pip installed",
+      "A favorite text editor or IDE"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/python' target='_blank' class='github-icon'>MCP-Auth Python Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/mcp-auth-server-py.md" %}

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
@@ -11,7 +11,7 @@ template: templates/quick-start.html
     ],
     prerequisites: [
       "About 15 minutes",
-      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Python 3.10 or later on your system",
       "Python package installer like pip installed",
       "A favorite text editor or IDE"

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
@@ -6,15 +6,15 @@ template: templates/quick-start.html
   const meta = {
     what_you_will_learn: [
       "Set up a secure MCP server using Python",
-      "Connect your server to {{ product_name }} for authentication",
+      "Connect your MCP server to {{ product_name }} for authentication",
       "Access MCP tools and resources securely"
     ],
     prerequisites: [
       "About 15 minutes",
       "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Python 3.10 or later on your system",
-      "Python package installer like pip installed",
-      "A favorite text editor or IDE"
+      "Python package manager (e:g.: pip) installed",
+      "A text editor or IDE"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/python' target='_blank' class='github-icon'>MCP-Auth Python Sample</a>"
   };

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
@@ -1,0 +1,24 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Create a new MCP server in Typescript",
+      "Defines an MCP tool that adds two numbers",
+      "Install <a href='https://www.npmjs.com/package/@asgardeo/mcp-express' target='_blank' rel='noopener noreferrer'>Asgardeo MCP SDK</a>",
+      "Set up MCP authorization with {{ product_name }}"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "Install Node.js on your system",
+      "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
+      "A favorite text editor or IDE"
+    ],
+    source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/typescript' target='_blank' class='github-icon'>MCP-Auth Sample</a>"
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/mcp-auth-server.md" %}

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
@@ -15,7 +15,7 @@ template: templates/quick-start.html
       "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Node.js on your system",
       "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
-      "A favorite text editor or IDE"
+      "A text editor or IDE"
     ],
     source_code: "<a href='https://github.com/wso2/iam-ai-samples/tree/main/mcp-auth/typescript' target='_blank' class='github-icon'>MCP-Auth Sample</a>"
   };

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
@@ -12,7 +12,7 @@ template: templates/quick-start.html
     ],
     prerequisites: [
       "About 15 minutes",
-      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set up {{ product_name }}</a>",
       "Install Node.js on your system",
       "Make sure you have a JavaScript package manager like npm, yarn, or pnpm",
       "A favorite text editor or IDE"

--- a/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
+++ b/en/identity-server/next/docs/quick-starts/mcp-auth-server.md
@@ -5,7 +5,7 @@ template: templates/quick-start.html
 <script>
   const meta = {
     what_you_will_learn: [
-      "Create a new MCP server in Typescript",
+      "Create a new MCP server in TypeScript",
       "Defines an MCP tool that adds two numbers",
       "Install <a href='https://www.npmjs.com/package/@asgardeo/mcp-express' target='_blank' rel='noopener noreferrer'>Asgardeo MCP SDK</a>",
       "Set up MCP authorization with {{ product_name }}"

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -584,6 +584,12 @@ nav:
           - OIDC Java EE: get-started/try-samples/qsg-oidc-webapp-java-ee.md
           - SAML Java EE: get-started/try-samples/qsg-saml-webapp-java-ee.md
           - WS-Federation: get-started/try-samples/ws-federation-webapp.md
+      - Secure MCP Servers:
+          - TypeScript: quick-starts/mcp-auth-server.md
+          - Python: quick-starts/mcp-auth-server-py.md
+      - Secure Your AI Agents:
+          - Python: quick-starts/agent-auth-py.md
+          - TypeScript: quick-starts/agent-auth-ts.md
       - Subscribe to AI features: get-started/subscribe-to-ai-features.md
       - About this release: get-started/about-this-release.md
   - Guides:

--- a/en/includes/quick-starts/agent-auth-py.md
+++ b/en/includes/quick-starts/agent-auth-py.md
@@ -130,13 +130,19 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
@@ -144,7 +150,7 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     async def main():
         # Scenario 1: AI agent acting on its own using its own credentials to authenticate
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             # Get agent token
             agent_token = await auth_manager.get_agent_token(["openid"])
 
@@ -205,20 +211,26 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
     )
     
     async def build_toolset():
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             # Get agent token
             agent_token = await auth_manager.get_agent_token(["openid"])
     
@@ -292,13 +304,19 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}   
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
@@ -306,7 +324,7 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     async def get_agent_token():
         # Asynchronously fetches the agent token from Asgardeo.
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             return await auth_manager.get_agent_token(["openid"])
     
     def main():
@@ -368,13 +386,19 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
@@ -393,7 +417,7 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
     
     
     async def main():
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             agent_token = await auth_manager.get_agent_token(["openid"])
         
             google_key = os.getenv("GOOGLE_API_KEY", "")
@@ -429,6 +453,7 @@ Create `main.py` that implements an AI agent which first obtains a valid access 
 Add environment configuration by creating a `.env` file at the project root to hold the {{ product_name }} configuration:
 
 ```properties title=".env"
+{% if product_name == "Asgardeo" %}
 # Asgardeo OAuth2 Configuration
 ASGARDEO_BASE_URL=https://api.asgardeo.io/t/<your-tenant>
 CLIENT_ID=<your-client-id>
@@ -437,6 +462,16 @@ REDIRECT_URI=http://localhost:6274/oauth/callback
 # Asgardeo Agent Credentials
 AGENT_ID=<agent_id>
 AGENT_SECRET=<agent_secret>
+{% else %}
+# Identity Server OAuth2 Configuration
+IDENTITY_SERVER_BASE_URL=https://localhost:9443/t/<your-tenant>
+CLIENT_ID=<your-client-id>
+REDIRECT_URI=http://localhost:6274/oauth/callback
+
+# Identity Server Agent Credentials
+AGENT_ID=<agent_id>
+AGENT_SECRET=<agent_secret>
+{% endif %}
 
 # Google Gemini API Key
 GOOGLE_API_KEY=<google_api_key>
@@ -451,7 +486,7 @@ MODEL_NAME="gemini-2.5-flash"
 !!! Important
 
     - Replace `<your-tenant>`, `<your-client-id>`and the redirect URL with the values obtained from the {{ product_name }} console.
-      The tenant name is visible in the console URL path (e.g., `https://console.asgardeo.io/t/<your-tenant>`), and the `client ID` can be found in the application's **Protocol** tab.
+      The tenant name is visible in the console URL path (e.g., {% if product_name == "Asgardeo" %}`https://console.asgardeo.io/t/<your-tenant>` {% else %}`https://localhost:9443/t/<your-tenant>`{% endif %}), and the `client ID` can be found in the application's **Protocol** tab.
 
     - Add the `Agent ID` and `Agent Secret` from the [Agent Registration](#register-an-ai-agent) step.
 
@@ -664,23 +699,28 @@ Here is the updated implementation:
     
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
     )
     
-    
     async def main():
     
         # Perform OBO flow (authenticating on behalf of the user)
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             # Get agent token
             agent_token = await auth_manager.get_agent_token(["openid"])
     
@@ -767,13 +807,19 @@ Here is the updated implementation:
 
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
@@ -781,7 +827,7 @@ Here is the updated implementation:
     
     # Perform OBO flow (authenticating on behalf of the user)
     async def build_toolset():
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             # Get agent token
             agent_token = await auth_manager.get_agent_token(["openid"])
     
@@ -896,17 +942,25 @@ Here is the updated implementation:
      
     async def get_obo_token():
         # Handles the OAuth/OBO flow to get the user token.
+        {% if product_name == "Asgardeo" %}       
         ASGARDEO_CONFIG = AsgardeoConfig(
             base_url=os.getenv("ASGARDEO_BASE_URL"),
             client_id=os.getenv("CLIENT_ID"),
             redirect_uri=os.getenv("REDIRECT_URI")
         )
+        {% else %}
+        IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+            base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+            client_id=os.getenv("CLIENT_ID"),
+            redirect_uri=os.getenv("REDIRECT_URI")
+        )
+        {% endif %}
         AGENT_CONFIG = AgentConfig(
             agent_id=os.getenv("AGENT_ID"),
             agent_secret=os.getenv("AGENT_SECRET")
         )
     
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             agent_token = await auth_manager.get_agent_token(["openid", "email"])
             auth_url, state, code_verifier = auth_manager.get_authorization_url_with_pkce(["openid", "email"])
     
@@ -1007,13 +1061,19 @@ Here is the updated implementation:
     
     # Load environment variables from .env file
     load_dotenv()
-    
+    {% if product_name == "Asgardeo" %}
     ASGARDEO_CONFIG = AsgardeoConfig(
         base_url=os.getenv("ASGARDEO_BASE_URL"),
         client_id=os.getenv("CLIENT_ID"),
         redirect_uri=os.getenv("REDIRECT_URI")
     )
-    
+    {% else %}
+    IDENTITY_SERVER_CONFIG = AsgardeoConfig(
+        base_url=os.getenv("IDENTITY_SERVER_BASE_URL"),
+        client_id=os.getenv("CLIENT_ID"),
+        redirect_uri=os.getenv("REDIRECT_URI")
+    )
+    {% endif %}
     AGENT_CONFIG = AgentConfig(
         agent_id=os.getenv("AGENT_ID"),
         agent_secret=os.getenv("AGENT_SECRET")
@@ -1035,7 +1095,7 @@ Here is the updated implementation:
     
     
     async def main():
-        async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        async with AgentAuthManager({% if product_name == "Asgardeo" %}ASGARDEO_CONFIG{% else %}IDENTITY_SERVER_CONFIG{% endif %}, AGENT_CONFIG) as auth_manager:
             agent_token = await auth_manager.get_agent_token(["openid", "email"])
     
             auth_url, state, code_verifier = auth_manager.get_authorization_url_with_pkce(["openid", "email"])

--- a/en/includes/quick-starts/agent-auth-ts.md
+++ b/en/includes/quick-starts/agent-auth-ts.md
@@ -133,13 +133,19 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
     
     // Load environment variables from .env file
     dotenv.config();
-    
+    {% if product_name == "Asgardeo" %}
     const asgardeoConfig = {
         afterSignInUrl: process.env.REDIRECT_URI || "",
         clientId: process.env.CLIENT_ID || "",
         baseUrl: process.env.ASGARDEO_BASE_URL || "",
     };
-    
+    {% else %}
+    const identityServerConfig = {
+        afterSignInUrl: process.env.REDIRECT_URI || "",
+        clientId: process.env.CLIENT_ID || "",
+        baseUrl: process.env.IDENTITY_SERVER_BASE_URL || "",
+    };
+    {% endif %}
     const agentConfig = {
         agentID: process.env.AGENT_ID || "",
         agentSecret: process.env.AGENT_SECRET || "",
@@ -151,8 +157,13 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
     });
     
     async function runAgent() {
+        {% if product_name == "Asgardeo" %}
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
         const agentToken = await asgardeoJavaScriptClient.getAgentToken(agentConfig);
+        {% else %}
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServerConfig);
+        const agentToken = await identityServerJavaScriptClient.getAgentToken(agentConfig);
+        {% endif %}
     
         const client = new MultiServerMCPClient({
             math: {
@@ -215,13 +226,19 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
     
     // Load environment variables from .env file
     dotenv.config();
-    
+    {% if product_name == "Asgardeo" %}
     const asgardeoConfig = {
         afterSignInUrl: process.env.REDIRECT_URI,
         clientId: process.env.CLIENT_ID,
         baseUrl: process.env.ASGARDEO_BASE_URL,
     };
-    
+    {% else %}
+    const identityServerConfig = {
+        afterSignInUrl: process.env.REDIRECT_URI,
+        clientId: process.env.CLIENT_ID,
+        baseUrl: process.env.IDENTITY_SERVER_BASE_URL,
+    };
+    {% endif %}
     const agentConfig = {
         agentID: process.env.AGENT_ID,
         agentSecret: process.env.AGENT_SECRET,
@@ -231,9 +248,14 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
     
     async function runAgent() {
         silenceADK();
+        {% if product_name == "Asgardeo" %}
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
         const agentToken = await asgardeoJavaScriptClient.getAgentToken(agentConfig);
-    
+        {% else %}
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServerConfig);
+        const agentToken = await identityServerJavaScriptClient.getAgentToken(agentConfig);
+        {% endif %}
+
         const rootAgent = new LlmAgent({
             name: "example_agent",
             model: process.env.MODEL_NAME || "gemini-2.5-flash",
@@ -339,13 +361,19 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
     
     // Load environment variables from .env file
     dotenv.config();
-    
+    {% if product_name == "Asgardeo" %}
     const asgardeoConfig = {
         afterSignInUrl: process.env.REDIRECT_URI || "",
         clientId: process.env.CLIENT_ID || "",
         baseUrl: process.env.ASGARDEO_BASE_URL || "",
     };
-    
+    {% else %}
+    const identityServerConfig = {
+        afterSignInUrl: process.env.REDIRECT_URI || "",
+        clientId: process.env.CLIENT_ID || "",
+        baseUrl: process.env.IDENTITY_SERVER_BASE_URL || "",
+    };
+    {% endif %}
     const agentConfig = {
         agentID: process.env.AGENT_ID || "",
         agentSecret: process.env.AGENT_SECRET || "",
@@ -400,8 +428,13 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
     }
     
     async function runAgent() {
+        {% if product_name == "Asgardeo" %}
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
         const agentToken = await asgardeoJavaScriptClient.getAgentToken(agentConfig);
+        {% else %}
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServerConfig);
+        const agentToken = await identityServerJavaScriptClient.getAgentToken(agentConfig);
+        {% endif %}
     
         process.env.GOOGLE_GENERATIVE_AI_API_KEY = process.env.GOOGLE_API_KEY || "";
     
@@ -458,6 +491,7 @@ Create `agent.ts` that implements an AI agent which first obtains a valid access
 Add environment configuration by creating a `.env` file at the project root to hold the {{ product_name }} configuration:
 
 ```properties title=".env"
+{% if product_name == "Asgardeo" %}
 # Asgardeo OAuth2 Configuration
 ASGARDEO_BASE_URL=https://api.asgardeo.io/t/<organization-name>
 CLIENT_ID=<your-client-id>
@@ -466,6 +500,16 @@ REDIRECT_URI=http://localhost:3001/callback
 # Asgardeo Agent Credentials
 AGENT_ID=<agent_id>
 AGENT_SECRET=<agent_secret>
+{% else %}
+# Identity Server OAuth2 Configuration
+IDENTITY_SERVER_BASE_URL=https://localhost:9443/t/<tenant-name>
+CLIENT_ID=<your-client-id>
+REDIRECT_URI=http://localhost:3001/callback
+
+# Identity Server Agent Credentials
+AGENT_ID=<agent_id>
+AGENT_SECRET=<agent_secret>
+{% endif %}
 
 # Google Gemini API Key
 GOOGLE_API_KEY=<google_api_key>
@@ -478,9 +522,13 @@ MODEL_NAME="gemini-2.5-flash"
 ```
 
 !!! Important
-
+    {% if product_name == "Asgardeo" %}
     - Replace `<organization-name>` and `<client-id>` with the values obtained from the {{ product_name }} console.
-      The organization name is visible in the console URL path (e.g., `https://console.asgardeo.io/t/<your-tenant>`), and the `client ID` can be found in the application's **Protocol** tab.
+      The organization name is visible in the console URL path (e.g., `https://console.asgardeo.io/t/<organization-name>`), and the `client ID` can be found in the application's **Protocol** tab.
+    {% else %}
+    - Replace `<tenant-name>` and `<client-id>` with the values obtained from the {{ product_name }} console.
+      The tenant name is visible in the console URL path (e.g., `https://localhost:9443/t/<your-tenant>`), and the `client ID` can be found in the application's **Protocol** tab.
+      {% endif %}
 
     - Add the `<agent-id>` and `<agent-secret>` from the [Agent Registration](#register-an-ai-agent) step.
 
@@ -590,13 +638,19 @@ Here is the updated implementation:
     
     // Load environment variables from .env file
     dotenv.config();
-    
+    {% if product_name == "Asgardeo" %}   
     const asgardeoConfig = {
         afterSignInUrl: process.env.REDIRECT_URI || "",
         clientId: process.env.CLIENT_ID || "",
         baseUrl: process.env.ASGARDEO_BASE_URL || "",
     };
-    
+    {% else %}
+    const identityServerConfig = {
+        afterSignInUrl: process.env.REDIRECT_URI || "",
+        clientId: process.env.CLIENT_ID || "",
+        baseUrl: process.env.IDENTITY_SERVER_BASE_URL || "",
+    };
+    {% endif %}
     const agentConfig = {
         agentID: process.env.AGENT_ID || "",
         agentSecret: process.env.AGENT_SECRET || "",
@@ -608,9 +662,14 @@ Here is the updated implementation:
     });
     
     async function runAgent() {
+        {% if product_name == "Asgardeo" %}
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
-    
         const authURL = await asgardeoJavaScriptClient.getOBOSignInURL(agentConfig);
+        {% else %}
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServerConfig );
+        const authURL = await identityServerJavaScriptClient.getOBOSignInURL(agentConfig);
+        {% endif %}
+    
         console.log("Opening authentication URL in your browser...");
         await open(authURL);
     
@@ -659,8 +718,11 @@ Here is the updated implementation:
             });
     
         authCodeResponse = await authCodePromise;
-    
+        {% if product_name == "Asgardeo" %}
         const oboToken = await asgardeoJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
+        {% else %}
+        const oboToken = await identityServerJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
+        {% endif %}
     
         const client = new MultiServerMCPClient({
             math: {
@@ -737,12 +799,19 @@ Here is the updated implementation:
     
     // Load environment variables from .env file
     dotenv.config();
-    
+    {% if product_name == "Asgardeo" %}
     const asgardeoConfig = {
         afterSignInUrl: process.env.REDIRECT_URI || "",
         clientId: process.env.CLIENT_ID || "",
         baseUrl: process.env.ASGARDEO_BASE_URL || "",
     };
+    {% else %}
+    const identityServerConfig = {
+        afterSignInUrl: process.env.REDIRECT_URI || "",
+        clientId: process.env.CLIENT_ID || "",
+        baseUrl: process.env.IDENTITY_SERVER_BASE_URL || "",
+    };
+    {% endif %}
     
     const agentConfig = {
         agentID: process.env.AGENT_ID || "",
@@ -753,9 +822,13 @@ Here is the updated implementation:
     
     async function runAgent() {
         silenceADK();
+        {% if product_name == "Asgardeo" %}
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
-    
         const authURL = await asgardeoJavaScriptClient.getOBOSignInURL(agentConfig);
+        {% else %}
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServerConfig);
+        const authURL = await identityServerJavaScriptClient.getOBOSignInURL(agentConfig);
+        {% endif %}
         console.log("Opening authentication URL in your browser...");
         await open(authURL);
     
@@ -804,9 +877,11 @@ Here is the updated implementation:
             });
     
         authCodeResponse = await authCodePromise;
-    
+        {% if product_name == "Asgardeo" %}
         const oboToken = await asgardeoJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
-    
+        {% else %}
+        const oboToken = await idenityServerJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
+        {% endif %}
         const rootAgent = new LlmAgent({
             name: "example_agent",
             model: process.env.MODEL_NAME || "gemini-2.5-flash",
@@ -921,12 +996,19 @@ Here is the updated implementation:
     const callbackPort = Number(
         redirectURL.port || (redirectURL.protocol === "https:" ? 443 : 80)
     );
-    
+    {% if product_name == "Asgardeo" %}
     const asgardeoConfig = {
         afterSignInUrl: process.env.REDIRECT_URI || "",
         clientId: process.env.CLIENT_ID || "",
         baseUrl: process.env.ASGARDEO_BASE_URL || "",
     };
+    {% else %}
+    const identityServrConfig = {
+        afterSignInUrl: process.env.REDIRECT_URI || "",
+        clientId: process.env.CLIENT_ID || "",
+        baseUrl: process.env.IDENTITY_SERVER_BASE_URL || "",
+    };
+    {% endif %}
     
     const agentConfig = {
         agentID: process.env.AGENT_ID || "",
@@ -981,9 +1063,13 @@ Here is the updated implementation:
     }
     
     async function runAgent() {
+        {% if product_name == "Asgardeo" %}
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
-    
         const authURL = await asgardeoJavaScriptClient.getOBOSignInURL(agentConfig);
+        {% else %}
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServrConfig);
+        const authURL = await identityServerJavaScriptClient.getOBOSignInURL(agentConfig);
+        {% endif %}
         console.log("Opening authentication URL in your browser...");
         await open(authURL);
     
@@ -1091,6 +1177,7 @@ Add environment configuration by creating a `.env` file at the project root to h
 
 ```properties title=".env"
 # Asgardeo OAuth2 Configuration
+{% if product_name == "Asgardeo" %}
 ASGARDEO_BASE_URL=https://api.asgardeo.io/t/<your-tenant>
 CLIENT_ID=<your-client-id>
 REDIRECT_URI=http://localhost:3001/callback
@@ -1098,6 +1185,15 @@ REDIRECT_URI=http://localhost:3001/callback
 # Asgardeo Agent Credentials
 AGENT_ID=<agent_id>
 AGENT_SECRET=<agent_secret>
+{% else %}
+IDENTITY_SERVER_BASE_URL=https://localhost:9443/t/<your-tenant>
+CLIENT_ID=<your-client-id>
+REDIRECT_URI=http://localhost:3001/callback
+
+# Identity Server Agent Credentials
+AGENT_ID=<agent_id>
+AGENT_SECRET=<agent_secret>
+{% endif %}
 
 # Google Gemini API Key
 GOOGLE_API_KEY=<google_api_key>

--- a/en/includes/quick-starts/agent-auth-ts.md
+++ b/en/includes/quick-starts/agent-auth-ts.md
@@ -880,7 +880,7 @@ Here is the updated implementation:
         {% if product_name == "Asgardeo" %}
         const oboToken = await asgardeoJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
         {% else %}
-        const oboToken = await idenityServerJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
+        const oboToken = await identityServerJavaScriptClient.getOBOToken(agentConfig, authCodeResponse);
         {% endif %}
         const rootAgent = new LlmAgent({
             name: "example_agent",
@@ -1003,7 +1003,7 @@ Here is the updated implementation:
         baseUrl: process.env.ASGARDEO_BASE_URL || "",
     };
     {% else %}
-    const identityServrConfig = {
+    const identityServerConfig = {
         afterSignInUrl: process.env.REDIRECT_URI || "",
         clientId: process.env.CLIENT_ID || "",
         baseUrl: process.env.IDENTITY_SERVER_BASE_URL || "",
@@ -1067,7 +1067,7 @@ Here is the updated implementation:
         const asgardeoJavaScriptClient = new AsgardeoJavaScriptClient(asgardeoConfig);
         const authURL = await asgardeoJavaScriptClient.getOBOSignInURL(agentConfig);
         {% else %}
-        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServrConfig);
+        const identityServerJavaScriptClient = new AsgardeoJavaScriptClient(identityServerConfig);
         const authURL = await identityServerJavaScriptClient.getOBOSignInURL(agentConfig);
         {% endif %}
         console.log("Opening authentication URL in your browser...");

--- a/en/includes/quick-starts/mcp-auth-server-py.md
+++ b/en/includes/quick-starts/mcp-auth-server-py.md
@@ -118,16 +118,26 @@ Stop the running server before continuing.
 
 Add environment configuration by creating a `.env` file at the project root to hold the {{ product_name }} configuration:
 
+{% if product_name == "Asgardeo" %}
+
 ```properties title=".env"
 AUTH_ISSUER=https://api.asgardeo.io/t/<your-tenant>/oauth2/token
 CLIENT_ID=<your-client-id>
 JWKS_URL=https://api.asgardeo.io/t/<your-tenant>/oauth2/jwks
 ```
+{% else %}
+
+```properties title=".env"
+AUTH_ISSUER=https://localhost:9443/t/<your-tenant>/oauth2/token
+CLIENT_ID=<your-client-id>
+JWKS_URL=https://localhost:9443/t/<your-tenant>/oauth2/jwks
+```
+{% endif %}
 
 !!! Important
 
     Replace `<your-tenant>` and `<your-client-id>` with the values obtained from the {{ product_name }} console.
-    The tenant name is visible in the console URL path (e.g., `https://console.asgardeo.io/t/<your-tenant>`), and the client ID is found in the application's **Protocol** tab.
+    The tenant name is visible in the console URL path {% if product_name == "Asgardeo" %}(e.g., `https://console.asgardeo.io/t/<your-tenant>`) {% else %} (e.g., `https://localhost:9443/t/<your-tenant>`) {% endif %}, and the client ID is found in the application's **Protocol** tab.
 
 Create a `jwt_validator.py` file in the project directory using the implementation below.
 

--- a/en/includes/quick-starts/mcp-auth-server-py.md
+++ b/en/includes/quick-starts/mcp-auth-server-py.md
@@ -125,6 +125,7 @@ AUTH_ISSUER=https://api.asgardeo.io/t/<your-tenant>/oauth2/token
 CLIENT_ID=<your-client-id>
 JWKS_URL=https://api.asgardeo.io/t/<your-tenant>/oauth2/jwks
 ```
+
 {% else %}
 
 ```properties title=".env"
@@ -132,6 +133,7 @@ AUTH_ISSUER=https://localhost:9443/t/<your-tenant>/oauth2/token
 CLIENT_ID=<your-client-id>
 JWKS_URL=https://localhost:9443/t/<your-tenant>/oauth2/jwks
 ```
+
 {% endif %}
 
 !!! Important

--- a/en/includes/quick-starts/mcp-auth-server.md
+++ b/en/includes/quick-starts/mcp-auth-server.md
@@ -233,14 +233,12 @@ Create '.env' file and add the base URL of your {{product_name}} organization as
 
 ```env
 BASE_URL=https://api.asgardeo.io/t/<you-org-name>
-
 ```
 
 {% else %}
 
 ```env
 BASE_URL=https://localhost:9443/t/<you-org-name>
-
 ```
 
 {% endif %}

--- a/en/includes/quick-starts/mcp-auth-server.md
+++ b/en/includes/quick-starts/mcp-auth-server.md
@@ -228,16 +228,21 @@ Stop the dev server and install the Asgardeo MCP Auth SDK.
     ```
 
 Create '.env' file and add the base URL of your {{product_name}} organization as given below.
+
 {% if product_name == "Asgardeo" %}
+
 ```env
 BASE_URL=https://api.asgardeo.io/t/<you-org-name>
 
 ```
+
 {% else %}
+
 ```env
 BASE_URL=https://localhost:9443/t/<you-org-name>
 
 ```
+
 {% endif %}
 
 Update `server.ts` to integrate the Asgardeo middleware. This adds:

--- a/en/includes/quick-starts/mcp-auth-server.md
+++ b/en/includes/quick-starts/mcp-auth-server.md
@@ -228,11 +228,17 @@ Stop the dev server and install the Asgardeo MCP Auth SDK.
     ```
 
 Create '.env' file and add the base URL of your {{product_name}} organization as given below.
-
+{% if product_name == "Asgardeo" %}
 ```env
 BASE_URL=https://api.asgardeo.io/t/<you-org-name>
 
 ```
+{% else %}
+```env
+BASE_URL=https://localhost:9443/t/<you-org-name>
+
+```
+{% endif %}
 
 Update `server.ts` to integrate the Asgardeo middleware. This adds:
 


### PR DESCRIPTION
Fixed broken links in the MCP documentation's "What's Next?" section for Identity Server versions by adding missing quick-start wrapper files.

Problem

  The MCP documentation (/guides/agentic-ai/mcp/) contains links to MCP quick-start guides:
  - {{base_path}}/quick-starts/mcp-auth-server/ (TypeScript)
  - {{base_path}}/quick-starts/mcp-auth-server-py/ (Python)

  These links worked in Asgardeo but were broken in Identity Server (versions 7.2.0 and next) because the wrapper
  files didn't exist.

  Solution

  Created 4 new quick-start wrapper files following the existing architecture pattern used for other quick-starts
  (e.g., react.md):

  Files added:
  - en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server.md
  - en/identity-server/7.2.0/docs/quick-starts/mcp-auth-server-py.md
  - en/identity-server/next/docs/quick-starts/mcp-auth-server.md
  - en/identity-server/next/docs/quick-starts/mcp-auth-server-py.md
  
  Fix Issue:- https://github.com/wso2/product-is/issues/27478