### PR TITLE
Document SCIM2 Schemas API

### DIFF
--- a/en/asgardeo/docs/apis/restapis/scim2-schemas.yaml
+++ b/en/asgardeo/docs/apis/restapis/scim2-schemas.yaml
@@ -16,13 +16,13 @@ paths:
         - Schemas Endpoint
       summary: Get All Schemas
       description: "This API returns all supported SCIM 2.0 schema definitions.\n\n
-              <b>No Scope(Permission) required.</b>"
+              <b>No additional scopes or permissions required. Authentication is required.</b>"
       operationId: getSchemas
       responses:
         200:
           description: Schemas are found
           content:
-            application/json:
+            application/scim+json:
               schema:
                 type: array
                 items:
@@ -53,7 +53,7 @@ paths:
         - Schemas Endpoint
       summary: Get Schema by ID
       description: "This API returns the SCIM 2.0 schema definition identified by the given id.\n\n
-              <b>No Scope(Permission) required.</b>"
+              <b>No additional scopes or permissions required. Authentication is required.</b>"
       operationId: getSchemaById
       parameters:
         - name: id
@@ -66,7 +66,7 @@ paths:
         200:
           description: Schema is found
           content:
-            application/json:
+            application/scim+json:
               schema:
                 $ref: '#/components/schemas/SchemaObject'
         401:
@@ -325,6 +325,7 @@ components:
     ErrorUnauthorized:
       required:
         - status
+        - schemas
       type: object
       properties:
         schemas:
@@ -341,6 +342,7 @@ components:
       required:
         - detail
         - status
+        - schemas
       type: object
       properties:
         status:

--- a/en/asgardeo/docs/apis/restapis/scim2-schemas.yaml
+++ b/en/asgardeo/docs/apis/restapis/scim2-schemas.yaml
@@ -1,0 +1,354 @@
+openapi: 3.0.1
+info:
+  title: SCIM 2.0 Schemas Retrieval API
+  description: |
+    This document specifies **SCIM 2.0 Schemas RESTful API** for **Asgardeo**.
+  version: "v1"
+servers:
+  - url: 'https://api.asgardeo.io/t/{organization-name}/scim2'
+tags:
+  - name: Schemas Endpoint
+    description: This API lists and returns metadata about SCIM 2.0 schemas.
+paths:
+  /Schemas:
+    get:
+      tags:
+        - Schemas Endpoint
+      summary: Get All Schemas
+      description: "This API returns all supported SCIM 2.0 schema definitions.\n\n
+              <b>No Scope(Permission) required.</b>"
+      operationId: getSchemas
+      responses:
+        200:
+          description: Schemas are found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SchemaObject'
+        401:
+          description: Unauthorized
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/ErrorUnauthorized'
+        404:
+          description: Schema not found
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchemaNotFound'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl -X 'GET' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Schemas' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
+
+  '/Schemas/{id}':
+    get:
+      tags:
+        - Schemas Endpoint
+      summary: Get Schema by ID
+      description: "This API returns the SCIM 2.0 schema definition identified by the given id.\n\n
+              <b>No Scope(Permission) required.</b>"
+      operationId: getSchemaById
+      parameters:
+        - name: id
+          in: path
+          description: Unique ID of the schema (e.g., urn:ietf:params:scim:schemas:core:2.0:User).
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Schema is found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaObject'
+        401:
+          description: Unauthorized
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/ErrorUnauthorized'
+        404:
+          description: Schema not found
+          content:
+            application/scim+json:
+              schema:
+                $ref: '#/components/schemas/ErrorSchemaNotFound'
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl -X 'GET' \
+            'https://api.asgardeo.io/t/{organization-name}/scim2/Schemas/{id}' \
+            -H 'accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
+
+components:
+  schemas:
+    SchemaObject:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the schema.
+          example: "User"
+        description:
+          type: string
+          description: The description of the schema.
+          example: "User Account"
+        attributes:
+          type: array
+          description: The list of attributes defined in the schema.
+          items:
+            $ref: '#/components/schemas/SchemaAttribute'
+        id:
+          type: string
+          description: The unique URI of the schema.
+          example: "urn:ietf:params:scim:schemas:core:2.0:User"
+
+    SchemaAttribute:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The attribute's name.
+          example: "userName"
+        type:
+          type: string
+          description: The attribute's data type.
+          enum:
+            - STRING
+            - COMPLEX
+            - BOOLEAN
+            - DECIMAL
+            - INTEGER
+            - DATE_TIME
+            - DATE
+            - BINARY
+            - REFERENCE
+          example: "STRING"
+        multiValued:
+          type: boolean
+          description: Whether the attribute is multi-valued.
+          example: false
+        description:
+          type: string
+          description: The attribute's human-readable description.
+          example: "Username"
+        required:
+          type: boolean
+          description: Whether the attribute is required.
+          example: false
+        caseExact:
+          type: boolean
+          description: Whether the string attribute is case sensitive.
+          example: false
+        mutability:
+          type: string
+          description: Indicates whether the attribute is mutable.
+          enum:
+            - READ_ONLY
+            - READ_WRITE
+            - IMMUTABLE
+            - WRITE_ONLY
+          example: "READ_WRITE"
+        returned:
+          type: string
+          description: Indicates when an attribute is returned in a response.
+          enum:
+            - ALWAYS
+            - NEVER
+            - DEFAULT
+            - REQUEST
+          example: "DEFAULT"
+        uniqueness:
+          type: string
+          description: Indicates how unique a value must be.
+          enum:
+            - NONE
+          example: "NONE"
+        displayName:
+          type: string
+          description: The display name of the attribute.
+          example: "Username"
+        displayOrder:
+          type: integer
+          description: The display order of the attribute.
+          example: 1
+        supportedByDefault:
+          type: boolean
+          description: Whether the attribute is supported by default.
+          example: true
+        sharedProfileValueResolvingMethod:
+          type: string
+          description: The method used to resolve shared profile values.
+          example: "FromOrigin"
+        regEx:
+          type: string
+          description: The regular expression for validating the attribute value.
+          example: "^([a-zA-Z0-9_\\.\\-])+\\@(([a-zA-Z0-9\\-])+\\.)+([a-zA-Z0-9]{2,10})+$"
+        subAttributes:
+          type: array
+          description: The sub-attributes of a COMPLEX attribute.
+          items:
+            $ref: '#/components/schemas/SchemaSubAttribute'
+        profiles:
+          type: object
+          description: Profile-specific configurations for the attribute.
+          properties:
+            console:
+              type: object
+              properties:
+                supportedByDefault:
+                  type: boolean
+                  example: true
+        inputFormat:
+          type: object
+          description: The input format configuration for the attribute.
+          properties:
+            inputType:
+              type: string
+              example: "text_input"
+        excludedUserStores:
+          type: string
+          description: Comma-separated list of excluded user stores.
+          example: ""
+
+    SchemaSubAttribute:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The sub-attribute's name.
+          example: "familyName"
+        type:
+          type: string
+          description: The sub-attribute's data type.
+          enum:
+            - STRING
+            - COMPLEX
+            - BOOLEAN
+            - DECIMAL
+            - INTEGER
+            - DATE_TIME
+            - DATE
+            - BINARY
+            - REFERENCE
+          example: "STRING"
+        multiValued:
+          type: boolean
+          description: Whether the sub-attribute is multi-valued.
+          example: false
+        description:
+          type: string
+          description: The sub-attribute's human-readable description.
+          example: "Last Name"
+        required:
+          type: boolean
+          description: Whether the sub-attribute is required.
+          example: false
+        caseExact:
+          type: boolean
+          description: Whether the string sub-attribute is case sensitive.
+          example: false
+        mutability:
+          type: string
+          description: Indicates whether the sub-attribute is mutable.
+          enum:
+            - READ_ONLY
+            - READ_WRITE
+            - IMMUTABLE
+            - WRITE_ONLY
+          example: "READ_WRITE"
+        returned:
+          type: string
+          description: Indicates when a sub-attribute is returned in a response.
+          enum:
+            - ALWAYS
+            - NEVER
+            - DEFAULT
+            - REQUEST
+          example: "DEFAULT"
+        uniqueness:
+          type: string
+          description: Indicates how unique a value must be.
+          enum:
+            - NONE
+          example: "NONE"
+        displayName:
+          type: string
+          description: The display name of the sub-attribute.
+          example: "Last Name"
+        displayOrder:
+          type: integer
+          description: The display order of the sub-attribute.
+          example: 3
+        supportedByDefault:
+          type: boolean
+          description: Whether the sub-attribute is supported by default.
+          example: true
+        sharedProfileValueResolvingMethod:
+          type: string
+          description: The method used to resolve shared profile values.
+          example: "FromOrigin"
+        regEx:
+          type: string
+          description: The regular expression for validating the sub-attribute value.
+        profiles:
+          type: object
+          description: Profile-specific configurations for the sub-attribute.
+          properties:
+            console:
+              type: object
+              properties:
+                supportedByDefault:
+                  type: boolean
+                  example: true
+        inputFormat:
+          type: object
+          description: The input format configuration for the sub-attribute.
+          properties:
+            inputType:
+              type: string
+              example: "text_input"
+        excludedUserStores:
+          type: string
+          description: Comma-separated list of excluded user stores.
+          example: ""
+
+    ErrorUnauthorized:
+      required:
+        - status
+      type: object
+      properties:
+        schemas:
+          type: string
+          example: urn:ietf:params:scim:api:messages:2.0:Error
+        detail:
+          type: string
+          example: "Authorization failure. Authorization information was invalid or missing from your request."
+        status:
+          type: string
+          example: "401"
+
+    ErrorSchemaNotFound:
+      required:
+        - detail
+        - status
+      type: object
+      properties:
+        status:
+          type: string
+          example: "404"
+        schemas:
+          type: string
+          example: urn:ietf:params:scim:api:messages:2.0:Error
+        detail:
+          type: string
+          example: Schema not found.

--- a/en/asgardeo/docs/apis/scim2/scim2-schema-rest-api.md
+++ b/en/asgardeo/docs/apis/scim2/scim2-schema-rest-api.md
@@ -1,0 +1,5 @@
+---
+template: templates/redoc.html
+---
+
+<redoc spec-url="{{base_path}}/apis/restapis/scim2-schemas.yaml" theme='{{redoc_theme}}'></redoc>

--- a/en/asgardeo/mkdocs.yml
+++ b/en/asgardeo/mkdocs.yml
@@ -728,6 +728,7 @@ nav:
           - SCIM 2.0 Groups API: apis/scim2/scim2-groups-rest-api.md
           - SCIM 2.0 Patch operations: apis/scim2/scim2-patch-operations.md
           - SCIM 2.0 Bulk API: apis/scim2/scim2-bulk-rest-api.md
+          - SCIM 2.0 Schema API: apis/scim2/scim2-schema-rest-api.md
           - SCIM 2.0 Batch Operations: apis/scim2/scim2-batch-operations.md
           - SCIM 2.0 Resource types API: apis/scim2/scim2-resource-types-rest-api.md
           - SCIM 2.0 Service provider configs API: apis/scim2/scim2-service-provider-configs-rest-api.md

--- a/en/identity-server/7.2.0/docs/apis/restapis/scim2-schemas.yaml
+++ b/en/identity-server/7.2.0/docs/apis/restapis/scim2-schemas.yaml
@@ -1,0 +1,395 @@
+swagger: '2.0'
+info:
+  version: "1.0.0"
+  title: SCIM 2.0 Endpoint Swagger Definition
+  description: |
+    SCIM 2.0 endpoints
+    It is written with [swagger 2](http://swagger.io/).
+  contact:
+    name: WSO2 Identity Server Team
+    url: 'http://wso2.com/products/identity-server'
+    email: "iam-dev@wso2.org"
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0'
+
+# The base path of the SCIM2 API.
+# If the tenant domain is carbon.super then basepath can be /scim2.
+# host: localhost:9443
+# basePath: /t/{tenant-domain}/scim2
+
+schemes:
+  - https
+
+produces:
+  - application/scim+json
+
+# Applicable authentication mechanisms.
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+  /Schemas:
+    get:
+      tags:
+        - Schemas Endpoint
+      summary: Get All Schemas
+      description: |
+        This API returns all supported SCIM 2.0 schema definitions.
+
+        <b>Permission required:</b>
+
+            * No permissions required
+      operationId: getSchemas
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        200:
+          description: Schemas are found
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/SchemaObject'
+        401:
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorUnauthorized'
+        404:
+          description: Schema not found
+          schema:
+            $ref: '#/definitions/ErrorSchemaNotFound'
+
+  '/Schemas/{id}':
+    get:
+      tags:
+        - Schemas Endpoint
+      summary: Get Schema by ID
+      description: |
+        This API returns the SCIM 2.0 schema definition identified by the given id.
+
+        <b>Permission required:</b>
+
+            * No permissions required
+      operationId: getSchemaById
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: Unique ID of the schema (e.g., urn:ietf:params:scim:schemas:core:2.0:User).
+          required: true
+          type: string
+      responses:
+        200:
+          description: Schema is found
+          schema:
+            $ref: '#/definitions/SchemaObject'
+        401:
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorUnauthorized'
+        404:
+          description: Schema not found
+          schema:
+            $ref: '#/definitions/ErrorSchemaNotFound'
+
+#-----------------------------------------------------
+# Security Definitions
+#-----------------------------------------------------
+securityDefinitions:
+  BasicAuth:
+    type: basic
+  OAuth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://localhost:9443/oauth/authorize
+    tokenUrl: https://localhost:9443/oauth/token
+    scopes:
+      read: Grants read access
+      write: Grants write access
+      admin: Grants read and write access to administrative information
+
+#-----------------------------------------------------
+# Definitions
+#-----------------------------------------------------
+definitions:
+  #-----------------------------------------------------
+  # Schema Object
+  #-----------------------------------------------------
+  SchemaObject:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The name of the schema.
+        example: "User"
+      description:
+        type: string
+        description: The description of the schema.
+        example: "User Account"
+      attributes:
+        type: array
+        description: The list of attributes defined in the schema.
+        items:
+          $ref: '#/definitions/SchemaAttribute'
+      id:
+        type: string
+        description: The unique URI of the schema.
+        example: "urn:ietf:params:scim:schemas:core:2.0:User"
+
+  #-----------------------------------------------------
+  # Schema Attribute
+  #-----------------------------------------------------
+  SchemaAttribute:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The attribute's name.
+        example: "userName"
+      type:
+        type: string
+        description: The attribute's data type.
+        enum:
+          - STRING
+          - COMPLEX
+          - BOOLEAN
+          - DECIMAL
+          - INTEGER
+          - DATE_TIME
+          - DATE
+          - BINARY
+          - REFERENCE
+        example: "STRING"
+      multiValued:
+        type: boolean
+        description: Whether the attribute is multi-valued.
+        example: false
+      description:
+        type: string
+        description: The attribute's human-readable description.
+        example: "Username"
+      required:
+        type: boolean
+        description: Whether the attribute is required.
+        example: false
+      caseExact:
+        type: boolean
+        description: Whether the string attribute is case sensitive.
+        example: false
+      mutability:
+        type: string
+        description: Indicates whether the attribute is mutable.
+        enum:
+          - READ_ONLY
+          - READ_WRITE
+          - IMMUTABLE
+          - WRITE_ONLY
+        example: "READ_WRITE"
+      returned:
+        type: string
+        description: Indicates when an attribute is returned in a response.
+        enum:
+          - ALWAYS
+          - NEVER
+          - DEFAULT
+          - REQUEST
+        example: "DEFAULT"
+      uniqueness:
+        type: string
+        description: Indicates how unique a value must be.
+        enum:
+          - NONE
+        example: "NONE"
+      displayName:
+        type: string
+        description: The display name of the attribute.
+        example: "Username"
+      displayOrder:
+        type: integer
+        description: The display order of the attribute.
+        example: 1
+      supportedByDefault:
+        type: boolean
+        description: Whether the attribute is supported by default.
+        example: true
+      sharedProfileValueResolvingMethod:
+        type: string
+        description: The method used to resolve shared profile values.
+        example: "FromOrigin"
+      regEx:
+        type: string
+        description: The regular expression for validating the attribute value.
+        example: "^([a-zA-Z0-9_\\.\\-])+\\@(([a-zA-Z0-9\\-])+\\.)+([a-zA-Z0-9]{2,10})+$"
+      subAttributes:
+        type: array
+        description: The sub-attributes of a COMPLEX attribute.
+        items:
+          $ref: '#/definitions/SchemaSubAttribute'
+      profiles:
+        type: object
+        description: Profile-specific configurations for the attribute.
+        properties:
+          console:
+            type: object
+            properties:
+              supportedByDefault:
+                type: boolean
+                example: true
+      inputFormat:
+        type: object
+        description: The input format configuration for the attribute.
+        properties:
+          inputType:
+            type: string
+            example: "text_input"
+      excludedUserStores:
+        type: string
+        description: Comma-separated list of excluded user stores.
+        example: ""
+
+  #-----------------------------------------------------
+  # Schema Sub Attribute
+  #-----------------------------------------------------
+  SchemaSubAttribute:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The sub-attribute's name.
+        example: "familyName"
+      type:
+        type: string
+        description: The sub-attribute's data type.
+        enum:
+          - STRING
+          - COMPLEX
+          - BOOLEAN
+          - DECIMAL
+          - INTEGER
+          - DATE_TIME
+          - DATE
+          - BINARY
+          - REFERENCE
+        example: "STRING"
+      multiValued:
+        type: boolean
+        description: Whether the sub-attribute is multi-valued.
+        example: false
+      description:
+        type: string
+        description: The sub-attribute's human-readable description.
+        example: "Last Name"
+      required:
+        type: boolean
+        description: Whether the sub-attribute is required.
+        example: false
+      caseExact:
+        type: boolean
+        description: Whether the string sub-attribute is case sensitive.
+        example: false
+      mutability:
+        type: string
+        description: Indicates whether the sub-attribute is mutable.
+        enum:
+          - READ_ONLY
+          - READ_WRITE
+          - IMMUTABLE
+          - WRITE_ONLY
+        example: "READ_WRITE"
+      returned:
+        type: string
+        description: Indicates when a sub-attribute is returned in a response.
+        enum:
+          - ALWAYS
+          - NEVER
+          - DEFAULT
+          - REQUEST
+        example: "DEFAULT"
+      uniqueness:
+        type: string
+        description: Indicates how unique a value must be.
+        enum:
+          - NONE
+        example: "NONE"
+      displayName:
+        type: string
+        description: The display name of the sub-attribute.
+        example: "Last Name"
+      displayOrder:
+        type: integer
+        description: The display order of the sub-attribute.
+        example: 3
+      supportedByDefault:
+        type: boolean
+        description: Whether the sub-attribute is supported by default.
+        example: true
+      sharedProfileValueResolvingMethod:
+        type: string
+        description: The method used to resolve shared profile values.
+        example: "FromOrigin"
+      regEx:
+        type: string
+        description: The regular expression for validating the sub-attribute value.
+      profiles:
+        type: object
+        description: Profile-specific configurations for the sub-attribute.
+        properties:
+          console:
+            type: object
+            properties:
+              supportedByDefault:
+                type: boolean
+                example: true
+      inputFormat:
+        type: object
+        description: The input format configuration for the sub-attribute.
+        properties:
+          inputType:
+            type: string
+            example: "text_input"
+      excludedUserStores:
+        type: string
+        description: Comma-separated list of excluded user stores.
+        example: ""
+
+  #-----------------------------------------------------
+  # The Error Unauthorized
+  #-----------------------------------------------------
+  ErrorUnauthorized:
+    type : object
+    required:
+      - status
+      - schema
+    properties:
+      status:
+        type: string
+        example: "401"
+      schemas:
+        type: string
+        example: "urn:ietf:params:scim:api:messages:2.0:Error"
+      scimType:
+        type: string
+        example: "Unauthorized"
+
+  #-----------------------------------------------------
+  # The Error Schema Not Found
+  #-----------------------------------------------------
+  ErrorSchemaNotFound:
+    type : object
+    required:
+      - status
+      - schema
+      - detail
+    properties:
+      status:
+        type: string
+        example: "404"
+      schemas:
+        type: string
+        example: "urn:ietf:params:scim:api:messages:2.0:Error"
+      detail:
+        type: string
+        example: "Schema not found."

--- a/en/identity-server/7.2.0/docs/apis/restapis/scim2-schemas.yaml
+++ b/en/identity-server/7.2.0/docs/apis/restapis/scim2-schemas.yaml
@@ -40,10 +40,10 @@ paths:
 
         <b>Permission required:</b>
 
-            * No permissions required
+            * No additional roles or scopes required. Authentication is required.
       operationId: getSchemas
       produces:
-        - application/json
+        - application/scim+json
       parameters: []
       responses:
         200:
@@ -74,7 +74,7 @@ paths:
             * No permissions required
       operationId: getSchemaById
       produces:
-        - application/json
+        - application/scim+json
       parameters:
         - name: id
           in: path
@@ -362,7 +362,7 @@ definitions:
     type : object
     required:
       - status
-      - schema
+      - schemas
     properties:
       status:
         type: string
@@ -381,7 +381,7 @@ definitions:
     type : object
     required:
       - status
-      - schema
+      - schemas
       - detail
     properties:
       status:

--- a/en/identity-server/7.2.0/docs/apis/scim2/scim2-schema-rest-api.md
+++ b/en/identity-server/7.2.0/docs/apis/scim2/scim2-schema-rest-api.md
@@ -1,0 +1,5 @@
+---
+template: templates/redoc.html
+---
+
+<redoc spec-url="{{base_path}}/apis/restapis/scim2-schemas.yaml" theme='{{redoc_theme}}'></redoc>

--- a/en/identity-server/7.2.0/mkdocs.yml
+++ b/en/identity-server/7.2.0/mkdocs.yml
@@ -1244,6 +1244,7 @@ nav:
           - SCIM 2.0 Groups API: apis/scim2/scim2-groups-rest-api.md
           - SCIM 2.0 Patch operations: apis/scim2/scim2-patch-operations.md
           - SCIM 2.0 Bulk API: apis/scim2/scim2-bulk-rest-api.md
+          - SCIM 2.0 Schema API: apis/scim2/scim2-schema-rest-api.md
           - SCIM 2.0 Batch operations: apis/scim2/scim2-batch-operations.md
           - SCIM 2.0 Resource types API: apis/scim2/scim2-resource-types.md
           - SCIM 2.0 Service provider configuration API: apis/scim2/scim2-sp-config-rest-api.md

--- a/en/identity-server/next/docs/apis/restapis/scim2-schemas.yaml
+++ b/en/identity-server/next/docs/apis/restapis/scim2-schemas.yaml
@@ -1,0 +1,395 @@
+swagger: '2.0'
+info:
+  version: "1.0.0"
+  title: SCIM 2.0 Endpoint Swagger Definition
+  description: |
+    SCIM 2.0 endpoints
+    It is written with [swagger 2](http://swagger.io/).
+  contact:
+    name: WSO2 Identity Server Team
+    url: 'http://wso2.com/products/identity-server'
+    email: "iam-dev@wso2.org"
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0'
+
+# The base path of the SCIM2 API.
+# If the tenant domain is carbon.super then basepath can be /scim2.
+# host: localhost:9443
+# basePath: /t/{tenant-domain}/scim2
+
+schemes:
+  - https
+
+produces:
+  - application/scim+json
+
+# Applicable authentication mechanisms.
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+  /Schemas:
+    get:
+      tags:
+        - Schemas Endpoint
+      summary: Get All Schemas
+      description: |
+        This API returns all supported SCIM 2.0 schema definitions.
+
+        <b>Permission required:</b>
+
+            * No permissions required
+      operationId: getSchemas
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        200:
+          description: Schemas are found
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/SchemaObject'
+        401:
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorUnauthorized'
+        404:
+          description: Schema not found
+          schema:
+            $ref: '#/definitions/ErrorSchemaNotFound'
+
+  '/Schemas/{id}':
+    get:
+      tags:
+        - Schemas Endpoint
+      summary: Get Schema by ID
+      description: |
+        This API returns the SCIM 2.0 schema definition identified by the given id.
+
+        <b>Permission required:</b>
+
+            * No permissions required
+      operationId: getSchemaById
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: Unique ID of the schema (e.g., urn:ietf:params:scim:schemas:core:2.0:User).
+          required: true
+          type: string
+      responses:
+        200:
+          description: Schema is found
+          schema:
+            $ref: '#/definitions/SchemaObject'
+        401:
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorUnauthorized'
+        404:
+          description: Schema not found
+          schema:
+            $ref: '#/definitions/ErrorSchemaNotFound'
+
+#-----------------------------------------------------
+# Security Definitions
+#-----------------------------------------------------
+securityDefinitions:
+  BasicAuth:
+    type: basic
+  OAuth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://localhost:9443/oauth/authorize
+    tokenUrl: https://localhost:9443/oauth/token
+    scopes:
+      read: Grants read access
+      write: Grants write access
+      admin: Grants read and write access to administrative information
+
+#-----------------------------------------------------
+# Definitions
+#-----------------------------------------------------
+definitions:
+  #-----------------------------------------------------
+  # Schema Object
+  #-----------------------------------------------------
+  SchemaObject:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The name of the schema.
+        example: "User"
+      description:
+        type: string
+        description: The description of the schema.
+        example: "User Account"
+      attributes:
+        type: array
+        description: The list of attributes defined in the schema.
+        items:
+          $ref: '#/definitions/SchemaAttribute'
+      id:
+        type: string
+        description: The unique URI of the schema.
+        example: "urn:ietf:params:scim:schemas:core:2.0:User"
+
+  #-----------------------------------------------------
+  # Schema Attribute
+  #-----------------------------------------------------
+  SchemaAttribute:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The attribute's name.
+        example: "userName"
+      type:
+        type: string
+        description: The attribute's data type.
+        enum:
+          - STRING
+          - COMPLEX
+          - BOOLEAN
+          - DECIMAL
+          - INTEGER
+          - DATE_TIME
+          - DATE
+          - BINARY
+          - REFERENCE
+        example: "STRING"
+      multiValued:
+        type: boolean
+        description: Whether the attribute is multi-valued.
+        example: false
+      description:
+        type: string
+        description: The attribute's human-readable description.
+        example: "Username"
+      required:
+        type: boolean
+        description: Whether the attribute is required.
+        example: false
+      caseExact:
+        type: boolean
+        description: Whether the string attribute is case sensitive.
+        example: false
+      mutability:
+        type: string
+        description: Indicates whether the attribute is mutable.
+        enum:
+          - READ_ONLY
+          - READ_WRITE
+          - IMMUTABLE
+          - WRITE_ONLY
+        example: "READ_WRITE"
+      returned:
+        type: string
+        description: Indicates when an attribute is returned in a response.
+        enum:
+          - ALWAYS
+          - NEVER
+          - DEFAULT
+          - REQUEST
+        example: "DEFAULT"
+      uniqueness:
+        type: string
+        description: Indicates how unique a value must be.
+        enum:
+          - NONE
+        example: "NONE"
+      displayName:
+        type: string
+        description: The display name of the attribute.
+        example: "Username"
+      displayOrder:
+        type: integer
+        description: The display order of the attribute.
+        example: 1
+      supportedByDefault:
+        type: boolean
+        description: Whether the attribute is supported by default.
+        example: true
+      sharedProfileValueResolvingMethod:
+        type: string
+        description: The method used to resolve shared profile values.
+        example: "FromOrigin"
+      regEx:
+        type: string
+        description: The regular expression for validating the attribute value.
+        example: "^([a-zA-Z0-9_\\.\\-])+\\@(([a-zA-Z0-9\\-])+\\.)+([a-zA-Z0-9]{2,10})+$"
+      subAttributes:
+        type: array
+        description: The sub-attributes of a COMPLEX attribute.
+        items:
+          $ref: '#/definitions/SchemaSubAttribute'
+      profiles:
+        type: object
+        description: Profile-specific configurations for the attribute.
+        properties:
+          console:
+            type: object
+            properties:
+              supportedByDefault:
+                type: boolean
+                example: true
+      inputFormat:
+        type: object
+        description: The input format configuration for the attribute.
+        properties:
+          inputType:
+            type: string
+            example: "text_input"
+      excludedUserStores:
+        type: string
+        description: Comma-separated list of excluded user stores.
+        example: ""
+
+  #-----------------------------------------------------
+  # Schema Sub Attribute
+  #-----------------------------------------------------
+  SchemaSubAttribute:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The sub-attribute's name.
+        example: "familyName"
+      type:
+        type: string
+        description: The sub-attribute's data type.
+        enum:
+          - STRING
+          - COMPLEX
+          - BOOLEAN
+          - DECIMAL
+          - INTEGER
+          - DATE_TIME
+          - DATE
+          - BINARY
+          - REFERENCE
+        example: "STRING"
+      multiValued:
+        type: boolean
+        description: Whether the sub-attribute is multi-valued.
+        example: false
+      description:
+        type: string
+        description: The sub-attribute's human-readable description.
+        example: "Last Name"
+      required:
+        type: boolean
+        description: Whether the sub-attribute is required.
+        example: false
+      caseExact:
+        type: boolean
+        description: Whether the string sub-attribute is case sensitive.
+        example: false
+      mutability:
+        type: string
+        description: Indicates whether the sub-attribute is mutable.
+        enum:
+          - READ_ONLY
+          - READ_WRITE
+          - IMMUTABLE
+          - WRITE_ONLY
+        example: "READ_WRITE"
+      returned:
+        type: string
+        description: Indicates when a sub-attribute is returned in a response.
+        enum:
+          - ALWAYS
+          - NEVER
+          - DEFAULT
+          - REQUEST
+        example: "DEFAULT"
+      uniqueness:
+        type: string
+        description: Indicates how unique a value must be.
+        enum:
+          - NONE
+        example: "NONE"
+      displayName:
+        type: string
+        description: The display name of the sub-attribute.
+        example: "Last Name"
+      displayOrder:
+        type: integer
+        description: The display order of the sub-attribute.
+        example: 3
+      supportedByDefault:
+        type: boolean
+        description: Whether the sub-attribute is supported by default.
+        example: true
+      sharedProfileValueResolvingMethod:
+        type: string
+        description: The method used to resolve shared profile values.
+        example: "FromOrigin"
+      regEx:
+        type: string
+        description: The regular expression for validating the sub-attribute value.
+      profiles:
+        type: object
+        description: Profile-specific configurations for the sub-attribute.
+        properties:
+          console:
+            type: object
+            properties:
+              supportedByDefault:
+                type: boolean
+                example: true
+      inputFormat:
+        type: object
+        description: The input format configuration for the sub-attribute.
+        properties:
+          inputType:
+            type: string
+            example: "text_input"
+      excludedUserStores:
+        type: string
+        description: Comma-separated list of excluded user stores.
+        example: ""
+
+  #-----------------------------------------------------
+  # The Error Unauthorized
+  #-----------------------------------------------------
+  ErrorUnauthorized:
+    type : object
+    required:
+      - status
+      - schema
+    properties:
+      status:
+        type: string
+        example: "401"
+      schemas:
+        type: string
+        example: "urn:ietf:params:scim:api:messages:2.0:Error"
+      scimType:
+        type: string
+        example: "Unauthorized"
+
+  #-----------------------------------------------------
+  # The Error Schema Not Found
+  #-----------------------------------------------------
+  ErrorSchemaNotFound:
+    type : object
+    required:
+      - status
+      - schema
+      - detail
+    properties:
+      status:
+        type: string
+        example: "404"
+      schemas:
+        type: string
+        example: "urn:ietf:params:scim:api:messages:2.0:Error"
+      detail:
+        type: string
+        example: "Schema not found."

--- a/en/identity-server/next/docs/apis/restapis/scim2-schemas.yaml
+++ b/en/identity-server/next/docs/apis/restapis/scim2-schemas.yaml
@@ -40,10 +40,10 @@ paths:
 
         <b>Permission required:</b>
 
-            * No permissions required
+            * No additional roles or scopes required. Authentication is required.
       operationId: getSchemas
       produces:
-        - application/json
+        - application/scim+json
       parameters: []
       responses:
         200:
@@ -74,7 +74,7 @@ paths:
             * No permissions required
       operationId: getSchemaById
       produces:
-        - application/json
+        - application/scim+json
       parameters:
         - name: id
           in: path
@@ -362,7 +362,7 @@ definitions:
     type : object
     required:
       - status
-      - schema
+      - schemas
     properties:
       status:
         type: string
@@ -381,7 +381,7 @@ definitions:
     type : object
     required:
       - status
-      - schema
+      - schemas
       - detail
     properties:
       status:

--- a/en/identity-server/next/docs/apis/scim2/scim2-schema-rest-api.md
+++ b/en/identity-server/next/docs/apis/scim2/scim2-schema-rest-api.md
@@ -1,0 +1,5 @@
+---
+template: templates/redoc.html
+---
+
+<redoc spec-url="{{base_path}}/apis/restapis/scim2-schemas.yaml" theme='{{redoc_theme}}'></redoc>

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -1262,6 +1262,7 @@ nav:
           - SCIM 2.0 Groups API: apis/scim2/scim2-groups-rest-api.md
           - SCIM 2.0 Patch operations: apis/scim2/scim2-patch-operations.md
           - SCIM 2.0 Bulk API: apis/scim2/scim2-bulk-rest-api.md
+          - SCIM 2.0 Schema API: apis/scim2/scim2-schema-rest-api.md
           - SCIM 2.0 Batch operations: apis/scim2/scim2-batch-operations.md
           - SCIM 2.0 Resource types API: apis/scim2/scim2-resource-types.md
           - SCIM 2.0 Service provider configuration API: apis/scim2/scim2-sp-config-rest-api.md


### PR DESCRIPTION
## Purpose
This pull request adds documentation and OpenAPI/Swagger definitions for the SCIM 2.0 Schema API to both the Asgardeo and Identity Server documentation. It introduces new YAML files describing the API endpoints and integrates them into the documentation navigation and Redoc rendering system, making it easier for users to explore and understand the SCIM 2.0 Schema API.

**SCIM 2.0 Schema API Documentation Integration**

*Asgardeo Documentation:*
- Added OpenAPI 3.0 YAML definition for the SCIM 2.0 Schema API at `en/asgardeo/docs/apis/restapis/scim2-schemas.yaml`, including endpoints to retrieve all schemas and a schema by ID, with detailed schema object definitions and error responses.
- Introduced a Redoc-based documentation page for the SCIM 2.0 Schema API at `en/asgardeo/docs/apis/scim2/scim2-schema-rest-api.md`.
- Updated the navigation in `en/asgardeo/mkdocs.yml` to include the new SCIM 2.0 Schema API documentation page.

*Identity Server Documentation:*
- Added Swagger 2.0 YAML definition for the SCIM 2.0 Schema API at `en/identity-server/7.2.0/docs/apis/restapis/scim2-schemas.yaml`, detailing endpoints, schema objects, security, and error responses.
- Added a Redoc-based documentation page for the SCIM 2.0 Schema API at `en/identity-server/7.2.0/docs/apis/scim2/scim2-schema-rest-api.md`.
- Updated the navigation in `en/identity-server/7.2.0/mkdocs.yml` to include the new SCIM 2.0 Schema API documentation page.

## Related Issues
- https://github.com/wso2/product-is/issues/25566


