### PR TITLE
docs: fix duplicate "the" typo in React quickstart guide

### DIFF
--- a/en/identity-server/7.0.0/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/7.0.0/docs/get-started/try-your-own-app/react.md
@@ -154,7 +154,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 

--- a/en/identity-server/7.1.0/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/7.1.0/docs/get-started/try-your-own-app/react.md
@@ -155,7 +155,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 

--- a/en/identity-server/7.2.0/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/7.2.0/docs/get-started/try-your-own-app/react.md
@@ -155,7 +155,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 

--- a/en/identity-server/next/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/next/docs/get-started/try-your-own-app/react.md
@@ -155,7 +155,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 


### PR DESCRIPTION
## Purpose
This PR Fixes a typographical error where the word "the" was duplicated in the React quickstart 
guide across multiple IS versions.  
Resolves #27551

## Approach
Removed the duplicate "the" across multiple versions of the `react.md` guide (`next`, `7.2.0`, `7.1.0`, `7.0.0`) to ensure consistency and improve readability.