### PR TITLE
Fix typo react login page

### DIFF
--- a/en/identity-server/7.0.0/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/7.0.0/docs/get-started/try-your-own-app/react.md
@@ -154,7 +154,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 

--- a/en/identity-server/7.1.0/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/7.1.0/docs/get-started/try-your-own-app/react.md
@@ -155,7 +155,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 

--- a/en/identity-server/7.2.0/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/7.2.0/docs/get-started/try-your-own-app/react.md
@@ -155,7 +155,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 

--- a/en/identity-server/next/docs/get-started/try-your-own-app/react.md
+++ b/en/identity-server/next/docs/get-started/try-your-own-app/react.md
@@ -155,7 +155,7 @@ Implement a login button as follows using the `signIn()` function in the `useAut
 ```js
 <button onClick={ () => signIn() }>Login</button>
 ```
-Clicking on the **Login** button will take the user to the the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
+Clicking on the **Login** button will take the user to the {{ product_name }} login page. Once `signIn()` succeeds, the user will be redirected to the app (based on the `signInRedirectURL` specified in the [AuthProvider configuration](#configure-the-sdk)) and the `state.isAuthenticated` will be set to `true`.
 
 ### Get access token
 


### PR DESCRIPTION
## Description
This PR fixes a grammatical typo in the React SPA integration quickstart guide where the word "the" is duplicated.

Original sentence:
"Clicking on the Login button will take the user to the the WSO2 Identity Server login page."

Updated sentence:
"Clicking on the Login button will take the user to the WSO2 Identity Server login page."

## Affected Files
The fix has been applied to the following files:

- en/identity-server/next/docs/get-started/try-your-own-app/react.md (line 158)
- en/identity-server/7.2.0/docs/get-started/try-your-own-app/react.md (line 158)
- en/identity-server/7.1.0/docs/get-started/try-your-own-app/react.md (line 158)
- en/identity-server/7.0.0/docs/get-started/try-your-own-app/react.md (line 157)

## Fix
Removed the duplicate "the" in all affected versions to ensure grammatical correctness and consistency across documentation.

## Related Issue
wso2/product-is#27551