### PR TITLE
Update new docker registry references

### DIFF
--- a/en/identity-server/6.1.0/docs/deploy/enable-adaptive-authentication.md
+++ b/en/identity-server/6.1.0/docs/deploy/enable-adaptive-authentication.md
@@ -21,7 +21,7 @@ Follow the steps below to enable adaptive authentication for a standard deployme
 
 ## For Docker deployments
 
-You can find the docker images for WSO2 Identity Server in the [WSO2 Docker Hub](https://docker.wso2.com/tags.php?repo=wso2is).
+You can find the docker images for WSO2 Identity Server in the [WSO2 Docker Registry](https://registry.wso2.com/harbor/projects/7/repositories/is/artifacts-tab).
 
 To create a Docker image with adaptive authentication enabled, add the following commands to your Dockerfile and run it against the base image.
 

--- a/en/identity-server/7.0.0/docs/deploy/enable-adaptive-authentication.md
+++ b/en/identity-server/7.0.0/docs/deploy/enable-adaptive-authentication.md
@@ -21,7 +21,7 @@ Follow the steps below to enable adaptive authentication for a standard deployme
 
 ## For Docker deployments
 
-You can find the docker images for {{product_name}} in the [WSO2 Docker Hub](https://docker.wso2.com/tags.php?repo=wso2is){:target="_blank"}.
+You can find the docker images for {{product_name}} in the [WSO2 Docker Registry](https://registry.wso2.com/harbor/projects/7/repositories/is/artifacts-tab){:target="_blank"}.
 
 To create a Docker image with adaptive authentication enabled, add the following commands to your Dockerfile and run it against the base image.
 


### PR DESCRIPTION
## Purpose
This PR updates outdated references to the deprecated Docker registry docker.wso2.com across the documentation. All occurrences have been replaced with the correct registry endpoint registry.wso2.com to ensure users are directed to the supported and active Docker registry.

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


