### PR TITLE
Update CTL tool documentation for Asgardeo

### DIFF
--- a/en/includes/deploy/ctl-tool/propagate-between-child-organizations.md
+++ b/en/includes/deploy/ctl-tool/propagate-between-child-organizations.md
@@ -46,6 +46,11 @@ Take note of the **Client ID** and **Client Secret** of the application you crea
 
 Open the **serverConfig.json** file and provide the details of the application shared with the child organization and the child organization details, before running the tool.
 
+{% if product_name == "Asgardeo" %}
+!!! note
+    `SERVER_VERSION` is only relevant for on-premise deployments. Leave this field empty ("") for Asgardeo.
+{% endif %}
+
 === "serverConfig.json"
 
     ```json

--- a/en/includes/deploy/ctl-tool/tool-setup-and-usage.md
+++ b/en/includes/deploy/ctl-tool/tool-setup-and-usage.md
@@ -46,7 +46,7 @@ Follow the steps below to learn how you can configure IAM-CTL.
 
     {% if product_name == "Asgardeo" %}
     !!! note
-        `SERVER_VERSION` is only relevant for on-premise deployments. Leave this field empty for Asgardeo.
+        `SERVER_VERSION` is only relevant for on-premise deployments. Leave this field empty ("") for Asgardeo.
     {% endif %}
 
     === "serverConfig.json"

--- a/en/includes/deploy/ctl-tool/tool-setup-and-usage.md
+++ b/en/includes/deploy/ctl-tool/tool-setup-and-usage.md
@@ -44,6 +44,11 @@ Follow the steps below to learn how you can configure IAM-CTL.
 
     To propagate resources between root organizations, provide the details of the M2M application created in the root organization and the organization details.
 
+    {% if product_name == "Asgardeo" %}
+    !!! note
+        `SERVER_VERSION` is only relevant for on-premise deployments. Leave this field empty for Asgardeo.
+    {% endif %}
+
     === "serverConfig.json"
 
         ```json


### PR DESCRIPTION
## Purpose
Add note in Asgardeo docs clarifying `SERVER_VERSION` in CTL tool configs should be left empty for Asgardeo.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


