### PR TITLE
Remove deprecated label from roles v2 API docs

### DIFF
--- a/en/asgardeo/docs/apis/restapis/roles.yaml
+++ b/en/asgardeo/docs/apis/restapis/roles.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  title:  Asgardeo - SCIM 2.0 Roles V2 API (deprecated)
+  title:  Asgardeo - SCIM 2.0 Roles V2 API
   description: |
-    This is the deprecated RESTful API for SCIM 2.0 Roles API in Asgardeo. 
+    This is the RESTful API for SCIM 2.0 Roles API in Asgardeo. 
     This API allows creating, deleting, listing, roles and updating role name, permissions, users and groups of the roles.
     
     To access the SCIM 2.0 Roles APIs in Asgardeo, you need to first [get an access token](https://wso2.com/asgardeo/docs/apis/authentication/#get-an-access-token) from your organization.


### PR DESCRIPTION
## Purpose
> $subject

Removing the deprecated label which was missed in https://github.com/wso2/docs-is/pull/5619


