### PR TITLE
Fix documentation grammar and spelling errors

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/multi-channel-self-registration-and-account-confirmation.md
+++ b/en/identity-server/5.10.0/docs/learn/multi-channel-self-registration-and-account-confirmation.md
@@ -369,7 +369,7 @@ to WSO2 Identity Server is managed by an external notification management mechan
         - For more information, see [Notification channel selection criteria](../.
         ./learn/extended-self-registration-api-and-account-confirmation-api/#notification-channel-selection-criteria).
         
-3. If the notification channel is **EMAIL**, access the relevant email account and and click 
+3. If the notification channel is **EMAIL**, access the relevant email account and click 
 the button or the confirmation link. Then the user account will be unlocked.
 
     !!! Note

--- a/en/identity-server/5.10.0/docs/setup/configuring-email-sending.md
+++ b/en/identity-server/5.10.0/docs/setup/configuring-email-sending.md
@@ -24,7 +24,7 @@ notifications](../../learn/enabling-notifications-for-user-operations),
     |                                                   |                                                |
     |---------------------------------------------------|------------------------------------------------|
     | `               from_address                `     | The mail address from where you want to send the notification. It can be any working mail address. |
-    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the the mail you have provide in **from_address**    |
+    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the mail you have provided in **from_address**    |
     | `               password                        ` | Provide the password of the SMTP account. <br/> Password of the mail you have provided in **from_address**     |
     | `               host                        ` | The SMTP server to connect to. |
     | `               port                         `|The SMTP server port to connect to, if the connect() method does not explicitly specify one. Defaults to 25. |

--- a/en/identity-server/5.10.0/docs/setup/configuring-email-sending.md
+++ b/en/identity-server/5.10.0/docs/setup/configuring-email-sending.md
@@ -24,7 +24,7 @@ notifications](../../learn/enabling-notifications-for-user-operations),
     |                                                   |                                                |
     |---------------------------------------------------|------------------------------------------------|
     | `               from_address                `     | The mail address from where you want to send the notification. It can be any working mail address. |
-    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the mail you have provided in **from_address**    |
+    | `               username                    `     | Provide the username of the SMTP account. <br/> Username of the mail you have provided in **from_address**    |
     | `               password                        ` | Provide the password of the SMTP account. <br/> Password of the mail you have provided in **from_address**     |
     | `               host                        ` | The SMTP server to connect to. |
     | `               port                         `|The SMTP server port to connect to, if the connect() method does not explicitly specify one. Defaults to 25. |

--- a/en/identity-server/5.11.0/docs/learn/multi-channel-self-registration-and-account-confirmation.md
+++ b/en/identity-server/5.11.0/docs/learn/multi-channel-self-registration-and-account-confirmation.md
@@ -350,7 +350,7 @@ to WSO2 Identity Server is managed by an external notification management mechan
         - For more information, see [Notification channel selection criteria](../.
         ./learn/extended-self-registration-api-and-account-confirmation-api/#notification-channel-selection-criteria).
         
-3. If the notification channel is **EMAIL**, access the relevant email account and and click 
+3. If the notification channel is **EMAIL**, access the relevant email account and click 
 the button or the confirmation link. Then the user account will be unlocked.
 
     !!! Note

--- a/en/identity-server/5.11.0/docs/setup/configuring-email-sending.md
+++ b/en/identity-server/5.11.0/docs/setup/configuring-email-sending.md
@@ -21,7 +21,7 @@ This document explains the steps to configure WSO2 Identity Server to send email
     |                                                   |                                                |
     |---------------------------------------------------|------------------------------------------------|
     | `               from_address                `     | The mail address from where you want to send the notification. It can be any working mail address. |
-    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the the mail you have provide in **from_address**    |
+    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the mail you have provided in **from_address**    |
     | `               password                        ` | Provide the password of the SMTP account. <br/> Password of the mail you have provided in **from_address**     |
     | `               host                        ` | The SMTP server to connect to. |
     | `               port                         `|The SMTP server port to connect to, if the connect() method does not explicitly specify one. Defaults to 25. |

--- a/en/identity-server/5.11.0/docs/setup/configuring-email-sending.md
+++ b/en/identity-server/5.11.0/docs/setup/configuring-email-sending.md
@@ -21,7 +21,7 @@ This document explains the steps to configure WSO2 Identity Server to send email
     |                                                   |                                                |
     |---------------------------------------------------|------------------------------------------------|
     | `               from_address                `     | The mail address from where you want to send the notification. It can be any working mail address. |
-    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the mail you have provided in **from_address**    |
+    | `               username                    `     | Provide the username of the SMTP account. <br/> Username of the mail you have provided in **from_address**    |
     | `               password                        ` | Provide the password of the SMTP account. <br/> Password of the mail you have provided in **from_address**     |
     | `               host                        ` | The SMTP server to connect to. |
     | `               port                         `|The SMTP server port to connect to, if the connect() method does not explicitly specify one. Defaults to 25. |

--- a/en/identity-server/5.9.0/docs/learn/configuring-email-otp.md
+++ b/en/identity-server/5.9.0/docs/learn/configuring-email-otp.md
@@ -498,7 +498,7 @@ SendGrid APIs. Follow the instructions in **one** of **Option1** or
         </tr>
         <tr class="even">
         <td><code>               GmailTokenEndpoint              </code></td>
-        <td>Use the the deafult value.</td>
+        <td>Use the default value.</td>
         </tr>
         <tr class="odd">
         <td><code>               SendgridAuthTokenType              </code></td>

--- a/en/identity-server/5.9.0/docs/learn/single-sign-on.md
+++ b/en/identity-server/5.9.0/docs/learn/single-sign-on.md
@@ -54,7 +54,7 @@ Single Sign-On (SSO) requires you to sign in only once but provides access to mu
 
 You use SSO on it's own or use SSO and Federation coupled together. Identity Federation involves configuring a third party identity provider as the federated authenticator to login to an application. When federation is coupled with SSO, the user can log in to one application using the credentials of the federated authenticator, and simultaneously be authenticated to other connected applications without having to provide credentials again.
 
-For instance, you can set up google as a federated authenticator and then set up SSO between App1 and App2.  This will allow users to log in to App1 using their google credentials. Once the user is logged in, when the user attempts to access App2, he/she will not be prompted for credentails again and is logged in automatically. 
+For instance, you can set up google as a federated authenticator and then set up SSO between App1 and App2.  This will allow users to log in to App1 using their google credentials. Once the user is logged in, when the user attempts to access App2, he/she will not be prompted for credentials again and is logged in automatically. 
 
 For more information on Identity Federation on it's own (without SSO), see the [Identity Federation](../../learn/identity-federation) topic.
 

--- a/en/identity-server/5.9.0/docs/learn/single-sign-on.md
+++ b/en/identity-server/5.9.0/docs/learn/single-sign-on.md
@@ -54,7 +54,7 @@ Single Sign-On (SSO) requires you to sign in only once but provides access to mu
 
 You use SSO on it's own or use SSO and Federation coupled together. Identity Federation involves configuring a third party identity provider as the federated authenticator to login to an application. When federation is coupled with SSO, the user can log in to one application using the credentials of the federated authenticator, and simultaneously be authenticated to other connected applications without having to provide credentials again.
 
-For instance, you can set up google as a federated authenticator and then set up SSO between App1 and App2.  This will allow users to log in to App1 using their google credentials. Once the user is logged in, when the user attempts to access App2, he/she will not be prompted for credentials again and is logged in automatically. 
+For instance, you can set up Google as a federated authenticator and then set up SSO between App1 and App2.  This will allow users to log in to App1 using their Google credentials. Once the user is logged in, when the user attempts to access App2, he/she will not be prompted for credentials again and is logged in automatically. 
 
 For more information on Identity Federation on it's own (without SSO), see the [Identity Federation](../../learn/identity-federation) topic.
 

--- a/en/identity-server/5.9.0/docs/setup/configuring-email-sending.md
+++ b/en/identity-server/5.9.0/docs/setup/configuring-email-sending.md
@@ -23,7 +23,7 @@ notifications](../../learn/enabling-notifications-for-user-operations),
     |                                                   |                                                |
     |---------------------------------------------------|------------------------------------------------|
     | `               from_address                `     | The mail address from where you want to send the notification. It can be any working mail address. |
-    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the the mail you have provide in **from_address**    |
+    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the mail you have provided in **from_address**    |
     | `               password                        ` | Provide the password of the SMTP account. <br/> Password of the mail you have provided in **from_address**     |
     | `               host                        ` | The SMTP server to connect to. |
     | `               port                         `|The SMTP server port to connect to, if the connect() method does not explicitly specify one. Defaults to 25. |

--- a/en/identity-server/5.9.0/docs/setup/configuring-email-sending.md
+++ b/en/identity-server/5.9.0/docs/setup/configuring-email-sending.md
@@ -23,7 +23,7 @@ notifications](../../learn/enabling-notifications-for-user-operations),
     |                                                   |                                                |
     |---------------------------------------------------|------------------------------------------------|
     | `               from_address                `     | The mail address from where you want to send the notification. It can be any working mail address. |
-    | `               username                    `     | Provide the username of the SMTP account. <br/> User name of the mail you have provided in **from_address**    |
+    | `               username                    `     | Provide the username of the SMTP account. <br/> Username of the mail you have provided in **from_address**    |
     | `               password                        ` | Provide the password of the SMTP account. <br/> Password of the mail you have provided in **from_address**     |
     | `               host                        ` | The SMTP server to connect to. |
     | `               port                         `|The SMTP server port to connect to, if the connect() method does not explicitly specify one. Defaults to 25. |


### PR DESCRIPTION
- Fixed spelling errors: deafult to default, credentails to credentials
- Removed duplicate words: and and to and, the the to the
- Corrected grammar: have provide to have provided

Changes across Identity Server 5.9.0, 5.10.0, and 5.11.0 documentation.

Benefits:
- Improved documentation readability
- Enhanced professional quality of technical documentation
- Better user experience when reading configuration guides

## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


