### PR TITLE
Fix inconsistency in email templates details in the documentation.

### DIFF
--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/email-templates-v2.yaml
@@ -16,7 +16,7 @@ tags:
 
       - User creation with SCIM2 APIs
       - Locking/Unlocking accounts with SCIM2 APIs
-      - Password recovery API
+      - Password recovery API V2
       - Email verification flows
       - Resend email flows
 

--- a/en/identity-server/7.1.0/docs/apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.1.0/docs/apis/restapis/email-templates-v2.yaml
@@ -14,11 +14,11 @@ tags:
 
       Application-specific email templates are triggered whenever the user interacts with applications that use the default WSO2 Identity Server UI. However, if the user interacts directly with APIs, application-specific email templates are supported by the following APIs:
 
-      - User creation with SCIM2 APIs
-      - Locking/Unlocking accounts with SCIM2 APIs
-      - Password recovery API
-      - Email verification flows
-      - Resend email flows
+      - [User creation with SCIM2 APIs](../scim2/scim2-users-rest-api)
+      - [Locking/Unlocking accounts with SCIM2 APIs](../scim2/scim2-users-rest-api)
+      - [Password recovery API V2](../user-account-recovery-v2-rest-api/#tag/Password-Recovery)
+      - [Email verification flows](../user-account-recovery-v2-rest-api)
+      - [Resend email flows](../user-account-recovery-v2-rest-api/#tag/Password-Recovery/operation/resendConfirmation)
 
       Note: To ensure application-specific branding is applied during the above API interactions, they must be invoked using an access token issued specifically for the application. If an access token generated from admin credentials is used instead, the branding will default to organization-specific settings.
 security:

--- a/en/identity-server/7.2.0/docs/apis/organization-apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.2.0/docs/apis/organization-apis/restapis/email-templates-v2.yaml
@@ -16,7 +16,7 @@ tags:
 
       - User creation with SCIM2 APIs
       - Locking/Unlocking accounts with SCIM2 APIs
-      - Password recovery API
+      - Password recovery API V2
       - Email verification flows
       - Resend email flows
 

--- a/en/identity-server/7.2.0/docs/apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/7.2.0/docs/apis/restapis/email-templates-v2.yaml
@@ -14,11 +14,11 @@ tags:
 
       Application-specific email templates are triggered whenever the user interacts with applications that use the default WSO2 Identity Server UI. However, if the user interacts directly with APIs, application-specific email templates are supported by the following APIs:
 
-      - User creation with SCIM2 APIs
-      - Locking/Unlocking accounts with SCIM2 APIs
-      - Password recovery API
-      - Email verification flows
-      - Resend email flows
+      - [User creation with SCIM2 APIs](../scim2/scim2-users-rest-api)
+      - [Locking/Unlocking accounts with SCIM2 APIs](../scim2/scim2-users-rest-api)
+      - [Password recovery API V2](../user-account-recovery-v2-rest-api/#tag/Password-Recovery)
+      - [Email verification flows](../user-account-recovery-v2-rest-api)
+      - [Resend email flows](../user-account-recovery-v2-rest-api/#tag/Password-Recovery/operation/resendConfirmation)
 
       Note: To ensure application-specific branding is applied during the above API interactions, they must be invoked using an access token issued specifically for the application. If an access token generated from admin credentials is used instead, the branding will default to organization-specific settings.
 security:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/email-templates-v2.yaml
@@ -16,7 +16,7 @@ tags:
 
       - User creation with SCIM2 APIs
       - Locking/Unlocking accounts with SCIM2 APIs
-      - Password recovery API
+      - Password recovery API V2
       - Email verification flows
       - Resend email flows
 

--- a/en/identity-server/next/docs/apis/restapis/email-templates-v2.yaml
+++ b/en/identity-server/next/docs/apis/restapis/email-templates-v2.yaml
@@ -14,11 +14,11 @@ tags:
 
       Application-specific email templates are triggered whenever the user interacts with applications that use the default WSO2 Identity Server UI. However, if the user interacts directly with APIs, application-specific email templates are supported by the following APIs:
 
-      - User creation with SCIM2 APIs
-      - Locking/Unlocking accounts with SCIM2 APIs
-      - Password recovery API
-      - Email verification flows
-      - Resend email flows
+      - [User creation with SCIM2 APIs](../scim2/scim2-users-rest-api)
+      - [Locking/Unlocking accounts with SCIM2 APIs](../scim2/scim2-users-rest-api)
+      - [Password recovery API V2](../user-account-recovery-v2-rest-api/#tag/Password-Recovery)
+      - [Email verification flows](../user-account-recovery-v2-rest-api)
+      - [Resend email flows](../user-account-recovery-v2-rest-api/#tag/Password-Recovery/operation/resendConfirmation)
 
       Note: To ensure application-specific branding is applied during the above API interactions, they must be invoked using an access token issued specifically for the application. If an access token generated from admin credentials is used instead, the branding will default to organization-specific settings.
 security:


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/27039

This pull request updates the documentation for email template APIs across multiple versions of the WSO2 Identity Server. The main focus is to clarify and improve references to supported APIs, especially around password recovery and related flows. The changes include renaming and linking to the correct versioned APIs, and providing direct documentation links for better clarity.

**API reference updates and documentation improvements:**

* Updated the API list in the `email-templates-v2.yaml` files to refer to "Password recovery API V2" instead of the generic "Password recovery API" for organization APIs in versions 7.1.0, 7.2.0, and next.
* Enhanced the list of supported APIs in the REST API documentation by converting plain text items into direct links to their respective documentation pages, covering user creation, account locking/unlocking, password recovery, email verification, and resend email flows for versions 7.1.0, 7.2.0, and next.