### PR TITLE
Fix typo in .NET complete guide (naviate → navigate)

### DIFF
--- a/en/identity-server/7.2.0/docs/complete-guides/dotnet/add-login-and-logout.md
+++ b/en/identity-server/7.2.0/docs/complete-guides/dotnet/add-login-and-logout.md
@@ -10,7 +10,7 @@ read_time: 10 min
 
     In WSO2 Identity Server, the default certificate is a self signed certificate. This certificate needs to be added to your OS System Trust to allow the .NET application to connect to the Identity Server
 
-    To obtain the certificate naviate to the <IS_HOME>/repository/resources/security directory and execute the following
+    To obtain the certificate navigate to the <IS_HOME>/repository/resources/security directory and execute the following
 
     ```bash
     keytool -export -alias wso2carbon -file carbon_public2.crt -keystore wso2carbon.p12 -storetype PKCS12 -storepass wso2carbon


### PR DESCRIPTION
## Purpose
Fix a typo in the .NET complete guide. naviate has been corrected to navigate in the add-login-and-logout page.

## Related PRs
None

## Test environment
Documentation change only (no code)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


