### PR TITLE
Add Vue and Nuxt quickstart pages

### DIFF
--- a/en/identity-server/next/docs/quick-starts/nuxt.md
+++ b/en/identity-server/next/docs/quick-starts/nuxt.md
@@ -1,0 +1,24 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Create a new Nuxt app",
+      "Install <a href='https://www.npmjs.com/package/@asgardeo/nuxt' target='_blank' rel='noopener noreferrer'>@asgardeo/nuxt</a> module",
+      "Add user sign-in and sign-out",
+      "Display user profile information",
+      "Protect a page with middleware"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "Install <a href='https://nodejs.org/en/download/package-manager' target='_blank' rel='noopener noreferrer'>Node.js</a> on your system.",
+      "Make sure you have a JavaScript package manager like <code>npm</code>, <code>yarn</code>, or <code>pnpm</code>.",
+      "A favorite text editor or IDE"
+    ]
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/nuxt.md" %}

--- a/en/identity-server/next/docs/quick-starts/vue.md
+++ b/en/identity-server/next/docs/quick-starts/vue.md
@@ -1,0 +1,23 @@
+---
+template: templates/quick-start.html
+---
+
+<script>
+  const meta = {
+    what_you_will_learn: [
+      "Create a new Vue app using Vite",
+      "Install <a href='https://www.npmjs.com/package/@asgardeo/vue' target='_blank' rel='noopener noreferrer'>@asgardeo/vue</a> package",
+      "Add user sign-in and sign-out",
+      "Display user profile information"
+    ],
+    prerequisites: [
+      "About 15 minutes",
+      "<a href='{{ base_path }}/get-started/quick-set-up/'>Set-up {{ product_name }}</a>",
+      "Install <a href='https://nodejs.org/en/download/package-manager' target='_blank' rel='noopener noreferrer'>Node.js</a> on your system.",
+      "Make sure you have a JavaScript package manager like <code>npm</code>, <code>yarn</code>, or <code>pnpm</code>.",
+      "A favorite text editor or IDE"
+    ]
+  };
+</script>
+
+{% include "../../../../includes/quick-starts/vue.md" %}

--- a/en/identity-server/next/mkdocs.yml
+++ b/en/identity-server/next/mkdocs.yml
@@ -130,6 +130,10 @@ extra:
               url: Get started|Quick Setup
             - title: Connect React App
               url: Get started|Connect App|React|Quickstart
+            - title: Connect Vue App
+              url: Get started|Connect App|Vue|Quickstart
+            - title: Connect Nuxt App
+              url: Get started|Connect App|Nuxt|Quickstart
             - title: Connect Angular App
               url: Get started|Connect App|Angular|Quickstart
             - title: Connect Javascript App
@@ -566,6 +570,10 @@ nav:
           - React:
               - Quickstart: quick-starts/react.md
               - Complete Guide: complete-guides/react/introduction.md
+          - Vue:
+              - Quickstart: quick-starts/vue.md
+          - Nuxt:
+              - Quickstart: quick-starts/nuxt.md
           - Angular:
               - Quickstart: quick-starts/angular.md
               - Complete Guide: complete-guides/angular/introduction.md


### PR DESCRIPTION
## Purpose
Add quickstart documentation pages for Vue and Nuxt to the Identity Server `next` version, using the existing shared include templates from `en/includes/quick-starts/`.

## Behaviour
<img width="1800" height="1128" alt="Screenshot 2026-05-05 at 2 01 30 PM" src="https://github.com/user-attachments/assets/1b3aa91e-2121-4a10-bb93-0a201b7816a8" />
<img width="1800" height="1128" alt="Screenshot 2026-05-05 at 2 01 48 PM" src="https://github.com/user-attachments/assets/4e9b3564-78c5-4bd7-8771-c9b62ae694d6" />


## Implementation
- Created `docs/quick-starts/vue.md` and `docs/quick-starts/nuxt.md` wrapper files following the same pattern as existing quickstart pages (frontmatter, `meta` script block with `what_you_will_learn` and `prerequisites`, include statement pointing to the shared template).
- Registered both pages in `mkdocs.yml` under the **Connect App** section, positioned after React with nested **Quickstart** entries.
- Added corresponding homepage card entries under **Connect App**, ordered React → Vue → Nuxt → Angular → …