### PR TITLE
Fix incorrect regex property for email-as-username configuration

### DIFF
--- a/en/identity-server/5.10.0/docs/learn/using-email-address-as-the-username.md
+++ b/en/identity-server/5.10.0/docs/learn/using-email-address-as-the-username.md
@@ -4,23 +4,20 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Open the 
-    `          <IS_HOME>/repository/conf/deployment.toml         ` file.
-2.  Add the following configuration.
+1. Open the
+    `<IS_HOME>/repository/conf/deployment.toml` file.
+2. Add the following configuration.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
 
-3.  Login to the management console and configure the ` Mapped Attribute
-    ` property of the ` http://wso2.org/claims/username ` claim ID that
-    is under **Dialect dialectURI** `http://wso2.org/claims` to ` mail
-    `.
+3. Login to the management console and configure the `Mapped Attribute` property of the `http://wso2.org/claims/username` claim ID that
+    is under **Dialect dialectURI** `http://wso2.org/claims` to `mail`.
 
-4.  Configure the following set of parameters in the user store
+4. Configure the following set of parameters in the user store
     configuration, depending on the type of user store you are connected
     to (LDAP/Active Directory/ JDBC).
     <table>
@@ -66,18 +63,18 @@
     <div class="admonition tip">
     <p class="admonition-title">Tip</p>
     <p>you are trying with the default embedded LDAP user store, this configuration change is not needed.</p>
-    </div> 
+    </div>
     </div>
     </div>
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant user store manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant user store manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -106,28 +103,27 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="../../assets/img/using-wso2-identity-server/super-admin.png" width="600" /></p></div>
+    <img src="../../assets/img/using-wso2-identity-server/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         With these configuration users can log in to super tenant with both
         email user name (**`bob@gmail.com`**) or
         non-email user names (**`alice`**). But for tenant only email user names
-        allowed (**`tod@gmail.com@wso2.com`**). 
+        allowed (**`tod@gmail.com@wso2.com`**).
 
     !!! note
-    
+
         You can configure email user name without enabling
         **`enable_email_domain`** property, then
         users can login to both super tenant and tenant using email and
         non-email user names. But super tenant users should always use
         ***@carbon.super*** at the end of user names.
-    
 
-5.  Restart the server.
+5. Restart the server.
 
 !!! info "Related Topics"
 

--- a/en/identity-server/5.11.0/docs/learn/using-email-address-as-the-username.md
+++ b/en/identity-server/5.11.0/docs/learn/using-email-address-as-the-username.md
@@ -4,23 +4,20 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Open the 
-    `          <IS_HOME>/repository/conf/deployment.toml         ` file.
-2.  Add the following configuration.
+1. Open the
+    `<IS_HOME>/repository/conf/deployment.toml` file.
+2. Add the following configuration.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
 
-3.  Login to the management console and configure the ` Mapped Attribute
-    ` property of the ` http://wso2.org/claims/username ` claim ID that
-    is under **Dialect dialectURI** `http://wso2.org/claims` to ` mail
-    `.
+3. Login to the management console and configure the `Mapped Attribute` property of the `http://wso2.org/claims/username` claim ID that
+    is under **Dialect dialectURI** `http://wso2.org/claims` to `mail`.
 
-4.  Configure the following set of parameters in the user store
+4. Configure the following set of parameters in the user store
     configuration, depending on the type of user store you are connected
     to (LDAP/Active Directory/ JDBC).
     <table>
@@ -66,18 +63,18 @@
     <div class="admonition tip">
     <p class="admonition-title">Tip</p>
     <p>you are trying with the default embedded LDAP user store, this configuration change is not needed.</p>
-    </div> 
+    </div>
     </div>
     </div>
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant user store manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant user store manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -106,28 +103,27 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="../../assets/img/using-wso2-identity-server/super-admin.png" width="600" /></p></div>
+    <img src="../../assets/img/using-wso2-identity-server/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         With these configuration users can log in to super tenant with both
         email user name (**`alex@gmail.com`**) or
         non-email user names (`larry`). But for tenant only email user names
-        allowed (**`tod@gmail.com@wso2.com`**). 
+        allowed (**`tod@gmail.com@wso2.com`**).
 
     !!! note
-    
+
         You can configure email user name without enabling
         **`enable_email_domain`** property, then
         users can login to both super tenant and tenant using email and
         non-email user names. But super tenant users should always use
         ***@carbon.super*** at the end of user names.
-    
 
-5.  Restart the server.
+5. Restart the server.
 
 !!! info "Related Topics"
 

--- a/en/identity-server/5.9.0/docs/learn/using-email-address-as-the-username.md
+++ b/en/identity-server/5.9.0/docs/learn/using-email-address-as-the-username.md
@@ -4,23 +4,20 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Open the 
-    `          <IS_HOME>/repository/conf/deployment.toml         ` file.
-2.  Add the following configuration.
+1. Open the
+    `<IS_HOME>/repository/conf/deployment.toml` file.
+2. Add the following configuration.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
 
-3.  Login to the management console and configure the ` Mapped Attribute
-    ` property of the ` http://wso2.org/claims/username ` claim ID that
-    is under **Dialect dialectURI** `http://wso2.org/claims` to ` mail
-    `.
+3. Login to the management console and configure the `Mapped Attribute` property of the `http://wso2.org/claims/username` claim ID that
+    is under **Dialect dialectURI** `http://wso2.org/claims` to `mail`.
 
-4.  Configure the following set of parameters in the user store
+4. Configure the following set of parameters in the user store
     configuration, depending on the type of user store you are connected
     to (LDAP/Active Directory/ JDBC).
     <table>
@@ -66,18 +63,18 @@
     <div class="admonition tip">
     <p class="admonition-title">Tip</p>
     <p>you are trying with the default embedded LDAP user store, this configuration change is not needed.</p>
-    </div> 
+    </div>
     </div>
     </div>
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant user store manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant user store manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -106,28 +103,27 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="../../assets/img/using-wso2-identity-server/super-admin.png" width="600" /></p></div>
+    <img src="../../assets/img/using-wso2-identity-server/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         With these configuration users can log in to super tenant with both
         email user name (**`bob@gmail.com`**) or
         non-email user names (**`alice`**). But for tenant only email user names
-        allowed (**`tod@gmail.com@wso2.com`**). 
+        allowed (**`tod@gmail.com@wso2.com`**).
 
     !!! note
-    
+
         You can configure email user name without enabling
         **`enable_email_domain`** property, then
         users can login to both super tenant and tenant using email and
         non-email user names. But super tenant users should always use
         ***@carbon.super*** at the end of user names.
-    
 
-5.  Restart the server.
+5. Restart the server.
 
 !!! info "Related Topics"
 

--- a/en/identity-server/6.0.0/docs/guides/identity-lifecycles/enable-email-as-username.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-lifecycles/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.

--- a/en/identity-server/6.0.0/docs/guides/identity-lifecycles/outbound-provisioning-with-salesforce.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-lifecycles/outbound-provisioning-with-salesforce.md
@@ -7,8 +7,8 @@ its [identity provisioning framework]({{base_path}}/references/concepts/provisio
 This topic provides instructions on how to configure Salesforce as the
 Identity Provider to provision users from WSO2 Identity Server. The
 service provider in this scenario is WSO2 Identity Server. When WSO2 IS
-is the service provider, it is configured as the resident Service
-Provider. Therefore, after completing this tutorial you can see the
+is the service provider, it's configured as the resident Service
+Provider. After completing this tutorial you can see the
 users you add using WSO2 Identity Server being created in Salesforce
 too.
 
@@ -16,34 +16,34 @@ too.
 
 ## Configure Salesforce
 
-1.  Sign up as a Salesforce developer.
-    1.  Fill out the relevant information found in the following URL:
+1. Sign up as a Salesforce developer.
+    1. Fill out the relevant information found in the following URL:
         <https://developer.salesforce.com/signup>
-    2.  Click **Sign me up**.
-    3.  Click **Allow** to enable Salesforce to access your basic
+    2. Click **Sign me up**.
+    3. Click **Allow** to enable Salesforce to access your basic
     information. This message pops up only when you log in to Salesforce
     for the first time.
 
-    !!! note    
+    !!! note
         This document is explained using the Salesforce lightning theme. If
-        you are using the classic theme, click **Switch to Lightning Experience** on the top panel. 
+        you are using the classic theme, click **Switch to Lightning Experience** on the top panel.
 
         ![lighteninig-experience]({{base_path}}/assets/img/guides/switch-to-lightening.png)
 
         You will be navigated to the lightening theme of Salesforce.
 
-        ![welcome-to-lightening.png]({{base_path}}/assets/img/guides/welcome-to-lightening.png) 
+        ![welcome-to-lightening.png]({{base_path}}/assets/img/guides/welcome-to-lightening.png)
 
-4.  Once you are logged in, add a connected app. Follow instructions
-    below on how to do this. 
+2. Once you are logged in, add a connected app. Follow instructions
+    below on how to do this.
 
-    1. Expand the **Apps** options in the left panel and click on **App Manager**. 
+    1. Expand the **Apps** options in the left panel and click on **App Manager**.
 
-    2. Click on **New Connected App**. 
+    2. Click on **New Connected App**.
 
-       ![connected-app]({{base_path}}/assets/img/guides/connected-app.png) 
+       ![connected-app]({{base_path}}/assets/img/guides/connected-app.png)
 
-    3.  Fill in the form that appears with relevant details. 
+    3. Fill in the form that appears with relevant details.
         The following table describes the form labels in detail.
 
         <table>
@@ -72,7 +72,7 @@ too.
         </tr>
         <tr class="odd">
         <td>Callback URL</td>
-        <td>The <strong>Callback URL</strong> is used for redirection. This is typically the URL that a user’s browser is redirected to after successful authentication. Use the following value here: <code>                 https://login.salesforce.com/services/oauth2/token                </code></td>
+        <td>The <strong>Callback URL</strong> is used for redirection. This is typically the URL that a user's browser is redirected to after successful authentication. Use the following value here: <code>                 https://login.salesforce.com/services/oauth2/token                </code></td>
         </tr>
         <tr class="even">
         <td>Selected OAuth Scopes</td>
@@ -81,7 +81,7 @@ too.
         <div>
         <div class="user-content-block">
         <p>These scopes refer to permissions the user gives to the connected app while it is running. The OAuth token name is in parentheses.<br />
-        Full access (full) allows access to the logged-in user’s data, and encompasses all other scopes. Full does not return a refresh token. You must explicitly request the refresh_token scope to get one.</p>
+        Full access (full) allows access to the logged-in user's data, and encompasses all other scopes. Full does not return a refresh token. You must explicitly request the refresh_token scope to get one.</p>
         </div>
         </div>
         </div></td>
@@ -89,19 +89,19 @@ too.
         </tbody>
         </table>
 
-        ![new-connected-app]({{base_path}}/assets/img/guides/fill-connected-app.png) 
+        ![new-connected-app]({{base_path}}/assets/img/guides/fill-connected-app.png)
 
-    4.  Click **Save** > **Continue** to add the connected app.
+    4. Click **Save** > **Continue** to add the connected app.
 
-5.  <a name ="step5"></a>The resulting screen displays key information that you will need to
-    configure WSO2 IS to Salesforce.  
+3. <a name ="step5"></a>The resulting screen displays key information that you will need to
+    configure WSO2 IS to Salesforce.
     Make a note of the following details as you need them in upcoming
     configurations.
 
-    1.  Consumer Key
-    2.  Consumer Secret (Click the **Click to reveal** link to view the
+    1. Consumer Key
+    2. Consumer Secret (Click the **Click to reveal** link to view the
         consumer secret)
-    3.  Callback URL
+    3. Callback URL
 
     !!! info
         **Consumer Key** : A value used by the consumer to identify itself
@@ -110,58 +110,56 @@ too.
         ownership of the consumer key. Referred to as `client_secret` in
         OAuth 2.0.
 
-    ![consumer-secret]({{base_path}}/assets/img/guides/connected-app-screen.png) 
+    ![consumer-secret]({{base_path}}/assets/img/guides/connected-app-screen.png)
 
-6.  <a name="step6"></a>Add your connected app to the profile you are going to use. This is
+4. <a name="step6"></a>Add your connected app to the profile you are going to use. This is
     necessary as this profile is used when you add users in to
     Salesforce from the Identity Server.
 
     !!! note
         Allow from 2-10 minutes for your changes to take effect on the
         server before using the connected app.
-    
-    1.  Expand **Users** in the **Administration** section of the left hand panel and click **Profiles**. A list of existing
-        profiles can be viewed.  
-        ![user-profiles]({{base_path}}/assets/img/guides/profiles.png) 
 
-    2.  As an example, if you use the profile “Chatter Free User”, click
+    1. Expand **Users** in the **Administration** section of the left hand panel and click **Profiles**. A list of existing
+        profiles can be viewed.
+        ![user-profiles]({{base_path}}/assets/img/guides/profiles.png)
+
+    2. As an example, if you use the profile "Chatter Free User", click
         **Edit** and select the connected app you created to configure
-        with the Identity Server using the provided checkbox.  
-         
-        ![select-connected-app]({{base_path}}/assets/img/guides/example-app.png) 
+        with the Identity Server using the provided checkbox.
 
-    3.  Click **Save**. Make a note of the profile ID (or address URL obtained from the address bar in your browser)
+        ![select-connected-app]({{base_path}}/assets/img/guides/example-app.png)
+
+    3. Click **Save**. Make a note of the profile ID (or address URL obtained from the address bar in your browser)
         of the Chatter Free User profile.
 
         !!! tip
-            Copy the URL and decode it using a URL decoder like [urldecoder.org]. 
+            Copy the URL and decode it using a URL decoder like [urldecoder.org].
 
             ![decoder-online]({{base_path}}/assets/img/guides/decoder-online.png)
 
-        
-            In this case `             00e2x000001AT3y            ` is your
+            In this case `00e2x000001AT3y` is your
             profile ID.
-        
 
-7.  <a name="public"></a>Get the public certificate for Salesforce. Do the following in order
-    to achieve this.
+5. <a name="public"></a>Get the public certificate for Salesforce. Do the following to
+    achieve this.
 
-    !!! info 
+    !!! info
         For more information on generating the certificate, see the [Salesforce
         documentation](https://help.salesforce.com/articleView?id=security_keys_creating.htm&type=0).
 
-    1.  In the left navigation panel, Expand **Security** and click
+    1. In the left navigation panel, Expand **Security** and click
         **Certificate and Key Management** or you can search for
-        Certificate and Key Management in the Quick Find search box.  
+        Certificate and Key Management in the Quick Find search box.
 
-    2.  Click **Create Self-Signed Certificate**.
-    3.  Enter the **Label** and a **Unique Name** and click **Save**.
-        The certificate is generated.  
-        ![self-signed-certificate]({{base_path}}/assets/img/guides/add-certificate.png) 
-    4.  Click the **Download Certificate** button to download the
+    2. Click **Create Self-Signed Certificate**.
+    3. Enter the **Label** and a **Unique Name** and click **Save**.
+        The certificate is generated.
+        ![self-signed-certificate]({{base_path}}/assets/img/guides/add-certificate.png)
+    4. Click the **Download Certificate** button to download the
         certificate.
 
----
+-----
 
 ## Configure email address as the username
 
@@ -170,31 +168,30 @@ accounts, e-mail authorizations in the form of rules and roles, and
 other tasks such as provisioning of resources associated with enabling
 new users.
 
-When you log into Salesforce, you normally use an email address. So, to integrate this with the Identity Server, you need to configure WSO2 IS to enable users to log in using their email addresses. In order to do that, follow the steps given below.
+When you log into Salesforce, you normally use an email address. So, to integrate this with the Identity Server, you need to configure WSO2 IS to enable users to log in using their email addresses. To do that, follow the steps given below.
 
 !!! warning
-    Configuring the email address as the username in an **already running
-    Identity Server** is not the production recommended way. Therefore,
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. So,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -243,12 +240,12 @@ When you log into Salesforce, you normally use an email address. So, to integrat
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -277,35 +274,35 @@ When you log into Salesforce, you normally use an email address. So, to integrat
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.
 
----
+-----
 
 ## Configure Salesforce as the Identity Provider
 
-1.  Start the WSO2 Identity Server if it is not started up already and
+1. Start the WSO2 Identity Server if it's not started up already and
     log in using the email you configured in the realm as instructed in the above section.
-2.  On the Management Console, navigate to **Main** > **Identity** > **Identity Providers** > **Add**.
-3.  In the form that appears, provide a name for your identity provider
+2. On the Management Console, navigate to **Main** > **Identity** > **Identity Providers** > **Add**.
+3. In the form that appears, provide a name for your identity provider
     by filling in the **Identity Provider Name**. You can use
     "Salesforce.com" as an example, but this can be any name you choose.
-    
-4.  Upload the Salesforce public certificate that you generated and
+
+4. Upload the Salesforce public certificate that you generated and
     saved in [step 5 under Configure Salesforce](#public)
-    .  
+    .
     Do this by selecting **Upload IDP certificate** and clicking the
     **Choose File** button next to **Identity Provider Public
     Certificate**.
@@ -317,55 +314,55 @@ When you log into Salesforce, you normally use an email address. So, to integrat
         Identity Provider and to send encrypted data to the Identity
         Provider.
 
-    ![idp-public-certificate]({{base_path}}/assets/img/guides/idp-public-certificate.png) 
+    ![idp-public-certificate]({{base_path}}/assets/img/guides/idp-public-certificate.png)
 
-5.  Expand the **Claim Configuration** section of the form, followed by
+5. Expand the **Claim Configuration** section of the form, followed by
     the **Basic Claim Configuration** section, and select **Define
     Custom Claim Dialect**.
 
-    !!! info 
-        We are adding a claim map in order to provision the users claim
+    !!! info
+        We are adding a claim map to provision the users claim
         values to salesforce when outbound provisioning users to salesforce
         via WSO2 Identity Server. Here, the **Identity Provider Claim URI**
         is the claim URI in Salesforce, which maps local claim URI in WSO2
         Identity Server. Read more about [Claim
         Management]({{base_path}}/guides/dialects/configure-claims/).
 
-6.  Click **Add Claim Mapping** and add the following claims.  
+6. Click **Add Claim Mapping** and add the following claims.
     Local claims in WSO2 IS are unique URIs. These are mapped to the
     [attributes required by salesforce to create a new
     profile](https://help.salesforce.com/articleView?id=000007571&language=en_US&type=1)
-. Therefore, in this step you are mapping the attributes required by
+. So, in this step you are mapping the attributes required by
     Salesforce to a unique URI. Now, when creating a new profile/user
     WSO2 IS sends these values to the correct attribute of Salesforce.
 
     | Identity Provider Claim URI        | Local Claim URI                                                                |
     |------------------------------------|--------------------------------------------------------------------------------|
-    | Alias                              | `               http://wso2.org/claims/givenname              `                |
-    | Email                              | `               http://wso2.org/claims/emailaddress              `             |
-    | EmailEncodingKey                   | `               http://wso2.org/claims/otherphone              `               |
-    | LanguageLocaleKey                  | `               http://wso2.org/claims/dob              `                      |
-    | LastName                           | `               http://wso2.org/claims/lastname              `                 |
-    | LocaleSidKey                       | `               http://wso2.org/claims/primaryChallengeQuestion              ` |
-    | ProfileId                          | `               http://wso2.org/claims/role              `                     |
-    | TimeZoneSidKey                     | `               http://wso2.org/claims/challengeQuestion1              `       |
-    | UserPermissionsCallCenterAutoLogin | `               http://wso2.org/claims/telephone              `                |
-    | UserPermissionsMarketingUser       | `               http://wso2.org/claims/mobile              `                   |
-    | UserPermissionsOfflineUser         | `               http://wso2.org/claims/country              `                  |
-    | Username                           | `               http://wso2.org/claims/emailaddress              `             |
+    | Alias                              | `http://wso2.org/claims/givenname`                |
+    | Email                              | `http://wso2.org/claims/emailaddress`             |
+    | EmailEncodingKey                   | `http://wso2.org/claims/otherphone`               |
+    | LanguageLocaleKey                  | `http://wso2.org/claims/dob`                      |
+    | LastName                           | `http://wso2.org/claims/lastname`                 |
+    | LocaleSidKey                       | `http://wso2.org/claims/primaryChallengeQuestion` |
+    | ProfileId                          | `http://wso2.org/claims/role`                     |
+    | TimeZoneSidKey                     | `http://wso2.org/claims/challengeQuestion1`       |
+    | UserPermissionsCallCenterAutoLogin | `http://wso2.org/claims/telephone`                |
+    | UserPermissionsMarketingUser       | `http://wso2.org/claims/mobile`                   |
+    | UserPermissionsOfflineUser         | `http://wso2.org/claims/country`                  |
+    | Username                           | `http://wso2.org/claims/emailaddress`             |
 
-    ![add-claim-mapping]({{base_path}}/assets/img/guides/add-claim-mapping.png) 
+    ![add-claim-mapping]({{base_path}}/assets/img/guides/add-claim-mapping.png)
 
-7.  Expand the **Advanced Claim Configuration** section.
-8.  Select the Claim URI you added from the **Provisioning Claim
-    Filter** dropdown and click **Add Claim**.  
-    ![provisioning-claim-filter]({{base_path}}/assets/img/guides/provisioning-claim-filter.png) 
-9.  For each Claim URI, enter a default value as shown in the following
+7. Expand the **Advanced Claim Configuration** section.
+8. Select the Claim URI you added from the **Provisioning Claim
+    Filter** dropdown and click **Add Claim**.
+    ![provisioning-claim-filter]({{base_path}}/assets/img/guides/provisioning-claim-filter.png)
+9. For each Claim URI, enter a default value as shown in the following
     table. The default values are used when creating the role in
-    Salesforce.  
+    Salesforce.
     For example, the alias, email, profile ID and all the values listed
     below are shown when a user is
-    created.  
+    created.
     These are sample values to help you understand better about claim
     URI and its value types.
     <table>
@@ -435,120 +432,119 @@ When you log into Salesforce, you normally use an email address. So, to integrat
     </tbody>
     </table>
 
-    ![advanced-claim-config]({{base_path}}/assets/img/guides/advanced-claim-config.png) 
+    ![advanced-claim-config]({{base_path}}/assets/img/guides/advanced-claim-config.png)
 
 10. Expand the **Outbound Provisioning Connectors** section followed by
     the **Salesforce Provisioning Configuration** section.
 11. Do the following configurations for Salesforce provisioning. <!--For more information on any of these fields, see [Configuring Salesforce provisioning]({{base_path}}/learn/configuring-outbound-provisioning-connectors-for-an-identity-provider#configuring-salesforce-provisioning).-->
-    
-    1.  Select **Enable Connector** to enable the Salesforce connector.
-    2.  Enter the **API version**. This is the version of the API you
-        are using in Salesforce.  
-        Follow the steps given below to get the API version:  
-        1.  To obtain this, log into <https://login.salesforce.com>.
-        2.  Search for **API** in the Quick Find search box and click
+
+    1. Select **Enable Connector** to enable the Salesforce connector.
+    2. Enter the **API version**. This is the version of the API you
+        are using in Salesforce.
+        Follow the steps given below to get the API version:
+        1. To get this, log into <https://login.salesforce.com>.
+        2. Search for **API** in the Quick Find search box and click
             API.
-        3.  Generate any one of the WSDL's to check the version. You are
+        3. Generate any one of the WSDL's to check the version. You are
             navigated to page with XML syntaxes.
-        4.  On the top it will mention as "
-            `              Salesforce.com Enterprise Web Services API Version <VERSION>             `
-            ".  For example:
-            `              Salesforce.com Enterprise Web Services API Version 41.0             `
-        5.  Enter this value for the API version in the following
-            format: `              v<VERSION_NUMBER>             `. For
-            example: `              v41.0             `.
-    3.  Enter the **Domain**. If you do not have a Salesforce domain,
-        you need to create a domain by logging into
+        4. On the top it will mention as "
+            `Salesforce.com Enterprise Web Services API Version <VERSION>`
+            ". For example:
+            `Salesforce.com Enterprise Web Services API Version 41.0`
+        5. Enter this value for the API version in the following
+            format: `v<VERSION_NUMBER>`. For
+            example: `v41.0`.
+    3. Enter the **Domain**. If you do not have a Salesforce domain,
+        you need to create a domain by logging into
         [https://login.salesforce.com](https://login.salesforce.com/).
 
         ??? note "Click here for more information on creating the domain on Salesforce."
 
-            1.  Search for My Domain in the search bar that is on the left
-                navigation panel.  
-                ![my-domain]({{base_path}}/assets/img/guides/my-domain.png) 
-            2.  Click **My Domain**.
-            3.  In the page that appears, come up with a name for your
+            1. Search for My Domain in the search bar that is on the left
+                navigation panel.
+                ![my-domain]({{base_path}}/assets/img/guides/my-domain.png)
+            2. Click **My Domain**.
+            3. In the page that appears, come up with a name for your
                 domain. You can check if the domain is available by clicking
                 the **Check Availability** button.
-                !!! info 
+                !!! info
                     For the page given below to load on your browser, make sure
                     that the Salesforce cookies are not blocked.
                 ![check-domain-availability]({{base_path}}/assets/img/guides/check-domain-availability.png)
 
-            4.  If the domain is available, select **I agree to Terms and
+            4. If the domain is available, select **I agree to Terms and
                 Conditions** and click **Register Domain** to register your
                 new domain.
 
-            5.  Once the domain is registered to your account, click the
+            5. Once the domain is registered to your account, click the
                 **Click here to login** button to test this out.
 
-        !!! info 
-            1.  Search for **My Domain** using the Quick Find search box and
-                click **My Domain**.  
-                You see the domain as follows: Your domain name is
-                `                               <DOMAIN>-dev-ed.my.salesforce.com                             `
-            2.  Make sure you enter the domain with an HTTPS prefix so that
+        !!! info
+            1. Search for **My Domain** using the Quick Find search box and
+                click **My Domain**.
+                You see the domain as follows: Your domain name is
+                `<DOMAIN>-dev-ed.my.salesforce.com`
+            2. Make sure you enter the domain with an HTTPS prefix so that
                 it resembles a URL:
-                `               https://<DOMAIN>-dev-ed.my.salesforce.com              `
+                `https://<DOMAIN>-dev-ed.my.salesforce.com`
 .
 
-    4.  Enter the **Client ID**. This is the Consumer Key obtained in
+    4. Enter the **Client ID**. This is the Consumer Key obtained in
         [step 3 when configuring
         Salesforce](#step5)
 .
 
         ??? note "Did not save the details? Click here for more information on getting the details."
 
-            1.  Search for **App Manager** using the Quick Find search box
+            1. Search for **App Manager** using the Quick Find search box
                 and click **App Manager**.
-            2.  Click the expand button for your Connected App and click
-                **View**.  
-                ![view-connected-app]({{base_path}}/assets/img/guides/view-connected-app.png) 
-            3.  You are navigated to the page that has the Client ID and
+            2. Click the expand button for your Connected App and click
+                **View**.
+                ![view-connected-app]({{base_path}}/assets/img/guides/view-connected-app.png)
+            3. You are navigated to the page that has the Client ID and
                 Client Secret of the app under **API (Enable OAuth
                 Settings)**.
 
-    5.  Enter the **Client Secret**. This is the Consumer Secret
+    5. Enter the **Client Secret**. This is the Consumer Secret
         obtained in [step 3 when configuring
         Salesforce](#step5)
 .
-    6.  Enter the **Username**. This is the Salesforce username.
-    7.  Enter the **Password**. This is the Salesforce password and
+    6. Enter the **Username**. This is the Salesforce username.
+    7. Enter the **Password**. This is the Salesforce password and
         must be entered along with the security token. So you would
         enter this in the following format:
-        `             <password><security_token            ` \>  
+        `<password><security_token` \>
         For example, if your password is
-        `             testpassword            ` and your security token
-        is `             37f37f4433123            `, the value you
+        `testpassword` and your security token
+        is `37f37f4433123`, the value you
         would enter here is
-        `             testpassword37f37f4433123            `.
+        `testpassword37f37f4433123`.
 
         ??? tip "Where can I get the security token?"
-            1.  Log in to Salesforce: <https://login.salesforce.com/>
-            2.  Click on your avatar and click My Settings. You are
-                navigated to the Personal Information page.  
-                ![salesforce-personal-info]({{base_path}}/assets/img/guides/salesforce-personal-info.png) 
-            3.  On the left navigation, click **Reset My Security Token**
-.  
-                ![reset-security-token]({{base_path}}/assets/img/guides/reset-security-token.png) 
-            4.  Click **Reset Security Token**.  
+            1. Log in to Salesforce: <https://login.salesforce.com/>
+            2. Click on your avatar and click My Settings. You are
+                navigated to the Personal Information page.
+                ![salesforce-personal-info]({{base_path}}/assets/img/guides/salesforce-personal-info.png)
+            3. On the left navigation, click **Reset My Security Token**
+.
+                ![reset-security-token]({{base_path}}/assets/img/guides/reset-security-token.png)
+            4. Click **Reset Security Token**.
                 An email is sent to you with the new security token. Check
                 the email of the email address you configured for
-                Salesforce.  
-                ![new-security-token]({{base_path}}/assets/img/guides/new-security-token.png) 
-        
+                Salesforce.
+                ![new-security-token]({{base_path}}/assets/img/guides/new-security-token.png)
 
 12. Click **Register**.
 
----
+-----
 
 ## Configure WSO2 IS as the resident Service Provider
 
 {!./includes/resident-sp.md !}
 
----
+-----
 
-## Add a user using SCIM.
+## Add a user using SCIM
 
 You can also add users to Salesforce using SCIM.
 
@@ -558,21 +554,17 @@ You can also add users to Salesforce using SCIM.
     For more information see the [Salesforce documentation](https://help.salesforce.com/s/articleView?id=000325728&type=1).
     Later on, if you want to update the user details, you won't be able to update the email address.
 
-Select the correct SCIM user endpoint given in **Resident** > **Inbound Provisioning Configuration** and use it in the curl command.  
+Select the correct SCIM user endpoint given in **Resident** > **Inbound Provisioning Configuration** and use it in the curl command.
     The following is a sample cURL command to add users.
 
 ```curl
-curl -v -k --header "Content-Type:application/json" --user kim@wso2.com:password --data '{"schemas":     ["urn:scim:schemas:core:1.0"],"userName”:”kim@wso2.com","password”:”test123”,”name":{"familyName”:”paul”},”emails":     [“kim@wso2.com"],"entitlements":     [{"value":"00e2x000001AT3y","display":"ChatterFreeUser"}]}' https://localhost:9443/wso2/scim2/Users  
+curl -v -k --header "Content-Type:application/json" --user kim@wso2.com:password --data '{"schemas":     ["urn:scim:schemas:core:1.0"],"userName":"kim@wso2.com","password":"test123","name":{"familyName":"paul"},"emails":     ["kim@wso2.com"],"entitlements":     [{"value":"00e2x000001AT3y","display":"ChatterFreeUser"}]}' https://localhost:9443/wso2/scim2/Users
 ```
 
 You can see that the user has been created in the "Users" section in salesforce.
 
 ![salesforce-user]({{base_path}}/assets/img/guides/salesforce-user.png)
 
-
 !!! info "Related topics"
     - [Concept: Identity Provisioning Framework]({{base_path}}/references/concepts/provisioning-framework/)
     - [Guide: Configure Just-In-Time Provisioning for an Identity Provider]({{base_path}}/guides/identity-federation/jit-workflow)
-
-
-

--- a/en/identity-server/6.0.0/docs/guides/login/log-into-google-using-is.md
+++ b/en/identity-server/6.0.0/docs/guides/login/log-into-google-using-is.md
@@ -3,10 +3,12 @@
 This page guides you through using WSO2 Identity Server to log in to Google.
 
 -----
+
 !!! tip "Before you begin!"
     You need to have a Google domain. Click
-    [here](https://www.bettercloud.com/monitor/the-academy/create-google-apps-domain-three-easy-steps/)
+    [Create Google Apps Domain](https://www.bettercloud.com/monitor/the-academy/create-google-apps-domain-three-easy-steps/)
     for more information on creating the domain.
+
 -----
 
 ## Configure Google
@@ -16,7 +18,7 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 2. Click **Security**.
 
     !!! info
-        Can't see the Security section? Click the **MORE CONTROLS** bar at the bottom and you can see the Security section.
+        Can't see the Security section? Click the **MORE CONTROLS** bar at the bottom and you can see the Security section.
 
     ![more-controls]({{base_path}}/assets/img/guides/security-google.png)
 
@@ -35,14 +37,14 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 
     ![sso-fill-google.png]({{base_path}}/assets/img/guides/sso-fill-google.png)
 
-5. Upload the Identity Server certificate:  
+5. Upload the Identity Server certificate:
     The certificate file must contain the public key for Google to
     verify the sign-in requests.
 
     1. Navigate to the
         `<IS_HOME>/repository/resources/security`
         directory via the terminal.
-    2. Run the command given below to import the public certificate
+    2. Run the command given below to import the public certificate
         from the keystore to a `.pem` file.
 
         ``` java
@@ -62,28 +64,27 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 ## Configure Email Address as the Username
 
 !!! warning
-    Configuring the email address as the username in an **already running
-    Identity Server** is not the production recommended way. Therefore,
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. So,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -132,12 +133,12 @@ This page guides you through using WSO2 Identity Server to log in to Google.
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -166,20 +167,20 @@ This page guides you through using WSO2 Identity Server to log in to Google.
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.
 
 -----
 
@@ -235,25 +236,23 @@ Now, you have successfully configured Google and WSO2 Identity Server.
 
 !!! note
     The admin users of your Google domain do not get redirected to WSO2 IS.
-    Therefore, to try out the tutorial you need to use a user who is not an
+    To try out the tutorial, you need to use a user who is not an
     admin in your Google account.
 
 1. Create a user in WSO2 Identity Server. Make sure that the same user
-    exists in your Google domain.  
+    exists in your Google domain.
     In this example, `alex@wso2support.com`
-    is in the Google domain. Therefore, we need to create the same user in WSO2 Identity Server.
+    is in the Google domain. So, we need to create the same user in WSO2 Identity Server.
 
     {!./includes/create-user-email-username.md!}
 
 2. Navigate to
     `https://google.com/a/<ENTER_YOUR_DOMAIN>/acs`
-    and enter the email address (username) of the user you created.  
+    and enter the email address (username) of the user you created.
     You are navigated to WSO2 Identity Server's sign in screen.
-3. Enter the username and password of the user you created.  
+3. Enter the username and password of the user you created.
     You are navigated to the G-Suite of that domain and you can select
     the application you need to use.
-
-  
 
 !!! tip
     If you want to only access Gmail, navigate to

--- a/en/identity-server/6.0.0/docs/guides/login/log-into-salesforce-using-is.md
+++ b/en/identity-server/6.0.0/docs/guides/login/log-into-salesforce-using-is.md
@@ -1,64 +1,64 @@
 # Log in to Salesforce using the Identity Server
 
-This page guides you through using WSO2 Identity  Server to log in to Salesforce. 
+This page guides you through using WSO2 Identity Server to log in to Salesforce.
 
-----
+-----
 
 ## Configure Salesforce
 
-1.  Sign up as a Salesforce developer.
-    1.  Fill out the relevant information found in the following URL:
+1. Sign up as a Salesforce developer.
+    1. Fill out the relevant information found in the following URL:
         <https://developer.salesforce.com/signup>
-    2.  Click **Sign me up**.
-    3.  Click **Allow** to enable Salesforce to access your basic
+    2. Click **Sign me up**.
+    3. Click **Allow** to enable Salesforce to access your basic
     information. This message pops up only when you log in to Salesforce
     for the first time.
     4. You will be navigated to the lightening theme of Salesforce.
-    
+
        ![welcome-to-lightening.png]({{base_path}}/assets/img/guides/welcome-to-lightening.png)
-       
-    !!! note    
+
+    !!! note
         This document is explained using the Salesforce lightning theme. If
-        you are using the classic theme, click **Switch to Lightning Experience** on the top panel. 
+        you are using the classic theme, click **Switch to Lightning Experience** on the top panel.
 
         ![lighteninig-experience]({{base_path}}/assets/img/guides/switch-to-lightening.png)
 
-2.  Once you are logged in, create a new domain and access it. To do
-    this, do the following steps.  
-    1.  Search for **My Domain** in the search bar that is on the left
-        navigation panel.  
+2. Once you are logged in, create a new domain and access it. To do
+    this, do the following steps.
+    1. Search for **My Domain** in the search bar that is on the left
+        navigation panel.
         ![my-domain]({{base_path}}/assets/img/guides/my-domain-salesforce.png)
 
-    2.  Click **My Domain**.
-    3.  On the page that appears, come up with a name for your domain.
+    2. Click **My Domain**.
+    3. On the page that appears, come up with a name for your domain.
         You can check if the domain is available by clicking the **Check
         Availability** button.
-		
-		!!! info 
-			For the page given below to load on your browser, make sure that
-			the Salesforce cookies are not blocked.
+
+        !!! info
+            For the page given below to load on your browser, make sure that
+            the Salesforce cookies are not blocked.
 
         ![sales-force-cookies]({{base_path}}/assets/img/guides/domain-available-salesforce.png)
 
-    4.  If the domain is available, click **Register Domain** to register your new
+    4. If the domain is available, click **Register Domain** to register your new
         domain.
 
-    5.  The verification might take a few minutes. On successful verification, you will proceed to step 3 where you can test your login. 
+    5. The verification might take a few minutes. On successful verification, you will proceed to step 3 where you can test your login.
 
     6. Click **Log in**.
 
-5.  On the left navigation menu, search for **Single Sign-On Settings** and click on it.
-    
-6.  On the page that appears, click **Edit** and then select the **SAML
-    Enabled** check box to enable federated single sign-on using SAML.  
-    ![saml-enabled]({{base_path}}/assets/img/guides/enable-saml-salesforce.png)
-    
-7.  Click **Save**.
+3. On the left navigation menu, search for **Single Sign-On Settings** and click on it.
 
-8.  Click **New** under **SAML Single Sign-On Settings**. The following
-    screen appears.  
+4. On the page that appears, click **Edit** and then select the **SAML
+    Enabled** check box to enable federated single sign-on using SAML.
+    ![saml-enabled]({{base_path}}/assets/img/guides/enable-saml-salesforce.png)
+
+5. Click **Save**.
+
+6. Click **New** under **SAML Single Sign-On Settings**. The following
+    screen appears.
     ![saml-sso-setting]({{base_path}}/assets/img/guides/saml-sso-salesforce.png)
-    
+
     Ensure that you configure the following properties.
 
     <table>
@@ -92,7 +92,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     <p><code>                 wso2.crt                </code></p>
     <div class="admonition note">
 	<p class="admonition-title">Note</p>
-	<p>To create the Identity Provider Certificate, open the terminal, traverse to the `<IS_HOME>/repository/resources/security` directory. 
+	<p>To create the Identity Provider Certificate, open the terminal, traverse to the `<IS_HOME>/repository/resources/security` directory.
 	Next, execute the following command.
 	<div class="code panel pdl" style="border-width: 1px;">
 	<div class="codeContent panelContent pdl">
@@ -136,11 +136,11 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     <td><code>                               https://localhost:9443/samlsso                             </code></td>
     </tr>
     <tr class="even">
-    <td>Custom Error URL</td>
+    <td>Custom Error URL</td>
     <td>Leave blank</td>
     </tr>
     <tr class="odd">
-    <td>User Provisioning Enabled</td>
+    <td>User Provisioning Enabled</td>
     <td>Leave blank</td>
     </tr>
     </tbody>
@@ -148,47 +148,46 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
 
     Click **Save** to save your configurations.
 
-9.  Navigate to **Company Settings** in the left navigation pane and click **My Domain**.
-    
-10. Click **Deploy to Users**. Click **Ok** to the confirmation message
-    that appears.
-    
-11. On the page that appears, you must configure the **Authentication Configuration** section. Scroll down to this section and click
-    **Edit**.
-    
-12. Under **Authentication Service**, select **SSO** instead of **Login
-    Page**.  
-    ![authentication-service-sso]({{base_path}}/assets/img/guides/auth-config-salesforce.png)
-    
-13. Click **Save**.
+7. Navigate to **Company Settings** in the left navigation pane and click **My Domain**.
 
-----
+8. Click **Deploy to Users**. Click **Ok** to the confirmation message
+    that appears.
+
+9. On the page that appears, you must configure the **Authentication Configuration** section. Scroll down to this section and click
+    **Edit**.
+
+10. Under **Authentication Service**, select **SSO** instead of **Login
+    Page**.
+    ![authentication-service-sso]({{base_path}}/assets/img/guides/auth-config-salesforce.png)
+
+11. Click **Save**.
+
+-----
 
 ## Configure Email Address as the Username
 
 !!! warning
-    Configuring the email address as the username in an **already running
-    Identity Server** is not the production recommended way. Therefore,
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. So,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -237,12 +236,12 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -271,20 +270,20 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.
 
 -----
 
@@ -292,7 +291,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
 
 {!./includes/register-a-service-provider.md!}
 
----
+-----
 
 ### SAML Configurations
 
@@ -302,27 +301,27 @@ Make the following changes to the created service provider.
 
 2. Enter the **Issuer** as `https://saml.salesforce.com`.
 
-    !!! note 
+    !!! note
         The **Issuer** is the unique identifier of the service provider. This is also the issuer value specified in the SAML Authentication Request issued by the service provider.
-        
-3. Enter **Assertion Consumer URL** and click **Add**. 
-    
+
+3. Enter **Assertion Consumer URL** and click **Add**.
+
     !!! note
         The **Assertion Consumer URL** is the URL of the page to which the browser is redirected to after successful authentication.
-        To obtain the **Assertion Consumer URL** from Salesforce, follow the below provided steps. <br>
+        To get the **Assertion Consumer URL** from Salesforce, follow the below provided steps. <br>
         1. Navigate to **Identity > Single Sign-On Settings** from the left hand side panel.  <br>
         2. Click on the name of the SAML SSO component created.  <br>
-        3. Note down the login URL. 
+        3. Note down the login URL.
 
-9. Select **Enable Response Signing** to sign the SAML2 Responses returned after the authentication process.
+4. Select **Enable Response Signing** to sign the SAML2 Responses returned after the authentication process.
 
-10. Select **Enable Attribute Profile** and **Include Attributes in the Response Always** so that the the identity provider 
+5. Select **Enable Attribute Profile** and **Include Attributes in the Response Always** so that the the identity provider
     will always include the attribute values related to the selected claims in the SAML2 attribute statement.
 
-12. Click **Register**. 
+6. Click **Register**.
 
 !!! tip
-     To configure more advanced configurations, see [Advanced SAML Configurations]({{base_path}}/guides/login/saml-app-config-advanced). 
+     To configure more advanced configurations, see [Advanced SAML Configurations]({{base_path}}/guides/login/saml-app-config-advanced).
 
 -----
 
@@ -331,68 +330,66 @@ Make the following changes to the created service provider.
 Do the following steps to test out the configurations for a new user in
 Salesforce and the Identity Server.
 
-1.  Create a user in WSO2 IS. 
- 
+1. Create a user in WSO2 IS.
+
     {!./includes/create-user-email-username.md!}
-        
-2.  Create a user in Salesforce. This user should have the same
-    email address as the user in WSO2 IS  
-    1.  Log in to the Salesforce developer account:
+
+2. Create a user in Salesforce. This user should have the same
+    email address as the user in WSO2 IS
+    1. Log in to the Salesforce developer account:
         [https://login.salesforce.com/](https://login.salesforce.com/?lt=de).
-    2.  On the left navigation pane, under **ADMINISTRATION**, click
+    2. On the left navigation pane, under **ADMINISTRATION**, click
         **Users** under **Users**.
-    3.  On the page that appears, click the **New User** button to
+    3. On the page that appears, click the **New User** button to
         create a new user.
-    4.  Create a user with the same username as the one you created in
+    4. Create a user with the same username as the one you created in
         WSO2 Identity Server. Click **Save** to save your changes. An
         email will be sent to the email address you provided for the
         user.
 
         !!! note
-			This is mainly for testing purposes. In a real
-			business scenario, you would be more likely to use Just-In-Time
-			(JIT) provisioning to provision a user to Salesforce.
-        
+            This is mainly for testing purposes. In a real
+            business scenario, you would be more likely to use Just-In-Time
+            (JIT) provisioning to provision a user to Salesforce.
 
-3.  Access your Salesforce login URL on an incognito or private browser.
-	
-	!!! info 
-		The salesforce login URL is unique to your Salesforce application.
-		Follow the steps given below to get this URL:
+3. Access your Salesforce login URL on an incognito or private browser.
 
-		1.  Search for **My Domain** in the search bar that is on the left
-			navigation panel.
-			
-		2.  Click **My Domain** and you are navigated to the domain you created
-			under the section, [Configure
-			Salesforce](#configure-salesforce).
+    !!! info
+        The salesforce login URL is unique to your Salesforce application.
+        Follow the steps given below to get this URL:
 
-		3.  Click **Edit** under Authentication Configurations and you are
-			navigated to a new page having the following URl:
-			`              https://<DOMAIN_NAME>/domainname/EditLogin.apexp             `. 
-			
-		4.  On the left navigation menu, expand **Security Controls**, and
-			click, **Single Sign-On Settings**.
-			
-		5.  Click on the name of the created **Single Sign-On Setting**. For this example, click **SSO**.  
-			![single-sign-on-setting]({{base_path}}/assets/img/guides/single-sign-on-setting.png)
-			
-		6.  Copy the URL that is defined for **Login URL** to access
-			Salesforce.  
-			![login-url-for-salesforce]({{base_path}}/assets/img/guides/login-url-for-salesforce.png)
+        1. Search for **My Domain** in the search bar that is on the left
+            navigation panel.
 
-4.  Log in using the new credentials of the user you just created. You
+        2. Click **My Domain** and you are navigated to the domain you created
+            under the section, [Configure
+            Salesforce](#configure-salesforce).
+
+        3. Click **Edit** under Authentication Configurations and you are
+            navigated to a new page having the following URl:
+            `https://<DOMAIN_NAME>/domainname/EditLogin.apexp`.
+
+        4. On the left navigation menu, expand **Security Controls**, and
+            click, **Single Sign-On Settings**.
+
+        5. Click on the name of the created **Single Sign-On Setting**. For this example, click **SSO**.
+            ![single-sign-on-setting]({{base_path}}/assets/img/guides/single-sign-on-setting.png)
+
+        6. Copy the URL that is defined for **Login URL** to access
+            Salesforce.
+            ![login-url-for-salesforce]({{base_path}}/assets/img/guides/login-url-for-salesforce.png)
+
+4. Log in using the new credentials of the user you just created. You
     are then redirected back to Salesforce.
-    
-----
 
+-----
 
 ## Troubleshooting guidelines
 
-Additional troubleshooting information regarding any Salesforce side SSO
+Additional troubleshooting information about any Salesforce side SSO
 failures can be retrieved by using Salesforce SAML Assertion Validator.
-Further information regarding the steps are available
-[here](https://developer.salesforce.com/docs/atlas.en-us.sso.meta/sso/sso_saml_validation_errors.htm#!).
+Further information about the steps are available
+[in the Salesforce SAML validation errors documentation](https://developer.salesforce.com/docs/atlas.en-us.sso.meta/sso/sso_saml_validation_errors.htm#!).
 
 !!! info "Related topics"
     - [Concept: Identity Federation]({{base_path}}/references/concepts/identity-federation/)

--- a/en/identity-server/6.0.0/docs/includes/enable-email-as-username.md
+++ b/en/identity-server/6.0.0/docs/includes/enable-email-as-username.md
@@ -70,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>

--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/enable-email-as-username.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.

--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/outbound-provisioning-with-salesforce.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/outbound-provisioning-with-salesforce.md
@@ -7,8 +7,8 @@ its [identity provisioning framework]({{base_path}}/references/concepts/provisio
 This topic provides instructions on how to configure Salesforce as the
 Identity Provider to provision users from WSO2 Identity Server. The
 service provider in this scenario is WSO2 Identity Server. When WSO2 IS
-is the service provider, it is configured as the resident Service
-Provider. Therefore, after completing this tutorial you can see the
+is the service provider, it's configured as the resident Service
+Provider. After completing this tutorial you can see the
 users you add using WSO2 Identity Server being created in Salesforce
 too.
 
@@ -16,34 +16,34 @@ too.
 
 ## Configure Salesforce
 
-1.  Sign up as a Salesforce developer.
-    1.  Fill out the relevant information found in the following URL:
+1. Sign up as a Salesforce developer.
+    1. Fill out the relevant information found in the following URL:
         <https://developer.salesforce.com/signup>
-    2.  Click **Sign me up**.
-    3.  Click **Allow** to enable Salesforce to access your basic
+    2. Click **Sign me up**.
+    3. Click **Allow** to enable Salesforce to access your basic
     information. This message pops up only when you log in to Salesforce
     for the first time.
 
-    !!! note    
+    !!! note
         This document is explained using the Salesforce lightning theme. If
-        you are using the classic theme, click **Switch to Lightning Experience** on the top panel. 
+        you are using the classic theme, click **Switch to Lightning Experience** on the top panel.
 
         ![lighteninig-experience]({{base_path}}/assets/img/guides/switch-to-lightening.png)
 
         You will be navigated to the lightening theme of Salesforce.
 
-        ![welcome-to-lightening.png]({{base_path}}/assets/img/guides/welcome-to-lightening.png) 
+        ![welcome-to-lightening.png]({{base_path}}/assets/img/guides/welcome-to-lightening.png)
 
-4.  Once you are logged in, add a connected app. Follow instructions
-    below on how to do this. 
+2. Once you are logged in, add a connected app. Follow instructions
+    below on how to do this.
 
-    1. Expand the **Apps** options in the left panel and click on **App Manager**. 
+    1. Expand the **Apps** options in the left panel and click on **App Manager**.
 
-    2. Click on **New Connected App**. 
+    2. Click on **New Connected App**.
 
-       ![connected-app]({{base_path}}/assets/img/guides/connected-app.png) 
+       ![connected-app]({{base_path}}/assets/img/guides/connected-app.png)
 
-    3.  Fill in the form that appears with relevant details. 
+    3. Fill in the form that appears with relevant details.
         The following table describes the form labels in detail.
 
         <table>
@@ -72,7 +72,7 @@ too.
         </tr>
         <tr class="odd">
         <td>Callback URL</td>
-        <td>The <strong>Callback URL</strong> is used for redirection. This is typically the URL that a user’s browser is redirected to after successful authentication. Use the following value here: <code>                 https://login.salesforce.com/services/oauth2/token                </code></td>
+        <td>The <strong>Callback URL</strong> is used for redirection. This is typically the URL that a user's browser is redirected to after successful authentication. Use the following value here: <code>                 https://login.salesforce.com/services/oauth2/token                </code></td>
         </tr>
         <tr class="even">
         <td>Selected OAuth Scopes</td>
@@ -81,7 +81,7 @@ too.
         <div>
         <div class="user-content-block">
         <p>These scopes refer to permissions the user gives to the connected app while it is running. The OAuth token name is in parentheses.<br />
-        Full access (full) allows access to the logged-in user’s data, and encompasses all other scopes. Full does not return a refresh token. You must explicitly request the refresh_token scope to get one.</p>
+        Full access (full) allows access to the logged-in user's data, and encompasses all other scopes. Full does not return a refresh token. You must explicitly request the refresh_token scope to get one.</p>
         </div>
         </div>
         </div></td>
@@ -89,19 +89,19 @@ too.
         </tbody>
         </table>
 
-        ![new-connected-app]({{base_path}}/assets/img/guides/fill-connected-app.png) 
+        ![new-connected-app]({{base_path}}/assets/img/guides/fill-connected-app.png)
 
-    4.  Click **Save** > **Continue** to add the connected app.
+    4. Click **Save** > **Continue** to add the connected app.
 
-5.  <a name ="step5"></a>The resulting screen displays key information that you will need to
-    configure WSO2 IS to Salesforce.  
+3. <a name ="step5"></a>The resulting screen displays key information that you will need to
+    configure WSO2 IS to Salesforce.
     Make a note of the following details as you need them in upcoming
     configurations.
 
-    1.  Consumer Key
-    2.  Consumer Secret (Click the **Click to reveal** link to view the
+    1. Consumer Key
+    2. Consumer Secret (Click the **Click to reveal** link to view the
         consumer secret)
-    3.  Callback URL
+    3. Callback URL
 
     !!! info
         **Consumer Key** : A value used by the consumer to identify itself
@@ -110,58 +110,56 @@ too.
         ownership of the consumer key. Referred to as `client_secret` in
         OAuth 2.0.
 
-    ![consumer-secret]({{base_path}}/assets/img/guides/connected-app-screen.png) 
+    ![consumer-secret]({{base_path}}/assets/img/guides/connected-app-screen.png)
 
-6.  <a name="step6"></a>Add your connected app to the profile you are going to use. This is
+4. <a name="step6"></a>Add your connected app to the profile you are going to use. This is
     necessary as this profile is used when you add users in to
     Salesforce from the Identity Server.
 
     !!! note
         Allow from 2-10 minutes for your changes to take effect on the
         server before using the connected app.
-    
-    1.  Expand **Users** in the **Administration** section of the left hand panel and click **Profiles**. A list of existing
-        profiles can be viewed.  
-        ![user-profiles]({{base_path}}/assets/img/guides/profiles.png) 
 
-    2.  As an example, if you use the profile “Chatter Free User”, click
+    1. Expand **Users** in the **Administration** section of the left hand panel and click **Profiles**. A list of existing
+        profiles can be viewed.
+        ![user-profiles]({{base_path}}/assets/img/guides/profiles.png)
+
+    2. As an example, if you use the profile "Chatter Free User", click
         **Edit** and select the connected app you created to configure
-        with the Identity Server using the provided checkbox.  
-         
-        ![select-connected-app]({{base_path}}/assets/img/guides/example-app.png) 
+        with the Identity Server using the provided checkbox.
 
-    3.  Click **Save**. Make a note of the profile ID (or address URL obtained from the address bar in your browser)
+        ![select-connected-app]({{base_path}}/assets/img/guides/example-app.png)
+
+    3. Click **Save**. Make a note of the profile ID (or address URL from the address bar in your browser)
         of the Chatter Free User profile.
 
         !!! tip
-            Copy the URL and decode it using a URL decoder like [urldecoder.org]. 
+            Copy the URL and decode it using a URL decoder like [urldecoder.org].
 
             ![decoder-online]({{base_path}}/assets/img/guides/decoder-online.png)
 
-        
-            In this case `             00e2x000001AT3y            ` is your
+            In this case `00e2x000001AT3y` is your
             profile ID.
-        
 
-7.  <a name="public"></a>Get the public certificate for Salesforce. Do the following in order
-    to achieve this.
+5. <a name="public"></a>Get the public certificate for Salesforce. Do the following to
+    achieve this.
 
-    !!! info 
+    !!! info
         For more information on generating the certificate, see the [Salesforce
         documentation](https://help.salesforce.com/articleView?id=security_keys_creating.htm&type=0).
 
-    1.  In the left navigation panel, Expand **Security** and click
+    1. In the left navigation panel, Expand **Security** and click
         **Certificate and Key Management** or you can search for
-        Certificate and Key Management in the Quick Find search box.  
+        Certificate and Key Management in the Quick Find search box.
 
-    2.  Click **Create Self-Signed Certificate**.
-    3.  Enter the **Label** and a **Unique Name** and click **Save**.
-        The certificate is generated.  
-        ![self-signed-certificate]({{base_path}}/assets/img/guides/add-certificate.png) 
-    4.  Click the **Download Certificate** button to download the
+    2. Click **Create Self-Signed Certificate**.
+    3. Enter the **Label** and a **Unique Name** and click **Save**.
+        The certificate is generated.
+        ![self-signed-certificate]({{base_path}}/assets/img/guides/add-certificate.png)
+    4. Click the **Download Certificate** button to download the
         certificate.
 
----
+-----
 
 ## Configure email address as the username
 
@@ -170,31 +168,30 @@ accounts, e-mail authorizations in the form of rules and roles, and
 other tasks such as provisioning of resources associated with enabling
 new users.
 
-When you log into Salesforce, you normally use an email address. So, to integrate this with the Identity Server, you need to configure WSO2 IS to enable users to log in using their email addresses. In order to do that, follow the steps given below.
+When you log into Salesforce, you normally use an email address. So, to integrate this with the Identity Server, you need to configure WSO2 IS to enable users to log in using their email addresses. To do that, follow the steps given below.
 
 !!! warning
-    Configuring the email address as the username in an **already running
-    Identity Server** is not the production recommended way. Therefore,
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. So,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -243,12 +240,12 @@ When you log into Salesforce, you normally use an email address. So, to integrat
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -277,35 +274,34 @@ When you log into Salesforce, you normally use an email address. So, to integrat
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.
 
----
+-----
 
 ## Configure Salesforce as the Identity Provider
 
-1.  Start the WSO2 Identity Server if it is not started up already and
+1. Start the WSO2 Identity Server if it's not started up already and
     log in using the email you configured in the realm as instructed in the above section.
-2.  On the Management Console, navigate to **Main** > **Identity** > **Identity Providers** > **Add**.
-3.  In the form that appears, provide a name for your identity provider
+2. On the Management Console, navigate to **Main** > **Identity** > **Identity Providers** > **Add**.
+3. In the form that appears, provide a name for your identity provider
     by filling in the **Identity Provider Name**. You can use
     "Salesforce.com" as an example, but this can be any name you choose.
-    
-4.  Upload the Salesforce public certificate that you generated and
-    saved in [step 5 under Configure Salesforce](#public)
-    .  
+
+4. Upload the Salesforce public certificate that you generated and
+    saved in [step 5 under Configure Salesforce](#public).
     Do this by selecting **Upload IDP certificate** and clicking the
     **Choose File** button next to **Identity Provider Public
     Certificate**.
@@ -317,55 +313,55 @@ When you log into Salesforce, you normally use an email address. So, to integrat
         Identity Provider and to send encrypted data to the Identity
         Provider.
 
-    ![idp-public-certificate]({{base_path}}/assets/img/guides/idp-public-certificate.png) 
+    ![idp-public-certificate]({{base_path}}/assets/img/guides/idp-public-certificate.png)
 
-5.  Expand the **Claim Configuration** section of the form, followed by
+5. Expand the **Claim Configuration** section of the form, followed by
     the **Basic Claim Configuration** section, and select **Define
     Custom Claim Dialect**.
 
-    !!! info 
-        We are adding a claim map in order to provision the users claim
+    !!! info
+        We are adding a claim map to provision the users claim
         values to salesforce when outbound provisioning users to salesforce
         via WSO2 Identity Server. Here, the **Identity Provider Claim URI**
         is the claim URI in Salesforce, which maps local claim URI in WSO2
         Identity Server. Read more about [Claim
         Management]({{base_path}}/guides/dialects/configure-claims/).
 
-6.  Click **Add Claim Mapping** and add the following claims.  
+6. Click **Add Claim Mapping** and add the following claims.
     Local claims in WSO2 IS are unique URIs. These are mapped to the
     [attributes required by salesforce to create a new
     profile](https://help.salesforce.com/articleView?id=000007571&language=en_US&type=1)
-. Therefore, in this step you are mapping the attributes required by
+. So, in this step you are mapping the attributes required by
     Salesforce to a unique URI. Now, when creating a new profile/user
     WSO2 IS sends these values to the correct attribute of Salesforce.
 
     | Identity Provider Claim URI        | Local Claim URI                                                                |
     |------------------------------------|--------------------------------------------------------------------------------|
-    | Alias                              | `               http://wso2.org/claims/givenname              `                |
-    | Email                              | `               http://wso2.org/claims/emailaddress              `             |
-    | EmailEncodingKey                   | `               http://wso2.org/claims/otherphone              `               |
-    | LanguageLocaleKey                  | `               http://wso2.org/claims/dob              `                      |
-    | LastName                           | `               http://wso2.org/claims/lastname              `                 |
-    | LocaleSidKey                       | `               http://wso2.org/claims/primaryChallengeQuestion              ` |
-    | ProfileId                          | `               http://wso2.org/claims/role              `                     |
-    | TimeZoneSidKey                     | `               http://wso2.org/claims/challengeQuestion1              `       |
-    | UserPermissionsCallCenterAutoLogin | `               http://wso2.org/claims/telephone              `                |
-    | UserPermissionsMarketingUser       | `               http://wso2.org/claims/mobile              `                   |
-    | UserPermissionsOfflineUser         | `               http://wso2.org/claims/country              `                  |
-    | Username                           | `               http://wso2.org/claims/emailaddress              `             |
+    | Alias                              | `http://wso2.org/claims/givenname`                |
+    | Email                              | `http://wso2.org/claims/emailaddress`             |
+    | EmailEncodingKey                   | `http://wso2.org/claims/otherphone`               |
+    | LanguageLocaleKey                  | `http://wso2.org/claims/dob`                      |
+    | LastName                           | `http://wso2.org/claims/lastname`                 |
+    | LocaleSidKey                       | `http://wso2.org/claims/primaryChallengeQuestion` |
+    | ProfileId                          | `http://wso2.org/claims/role`                     |
+    | TimeZoneSidKey                     | `http://wso2.org/claims/challengeQuestion1`       |
+    | UserPermissionsCallCenterAutoLogin | `http://wso2.org/claims/telephone`                |
+    | UserPermissionsMarketingUser       | `http://wso2.org/claims/mobile`                   |
+    | UserPermissionsOfflineUser         | `http://wso2.org/claims/country`                  |
+    | Username                           | `http://wso2.org/claims/emailaddress`             |
 
-    ![add-claim-mapping]({{base_path}}/assets/img/guides/add-claim-mapping.png) 
+    ![add-claim-mapping]({{base_path}}/assets/img/guides/add-claim-mapping.png)
 
-7.  Expand the **Advanced Claim Configuration** section.
-8.  Select the Claim URI you added from the **Provisioning Claim
-    Filter** dropdown and click **Add Claim**.  
-    ![provisioning-claim-filter]({{base_path}}/assets/img/guides/provisioning-claim-filter.png) 
-9.  For each Claim URI, enter a default value as shown in the following
+7. Expand the **Advanced Claim Configuration** section.
+8. Select the Claim URI you added from the **Provisioning Claim
+    Filter** dropdown and click **Add Claim**.
+    ![provisioning-claim-filter]({{base_path}}/assets/img/guides/provisioning-claim-filter.png)
+9. For each Claim URI, enter a default value as shown in the following
     table. The default values are used when creating the role in
-    Salesforce.  
+    Salesforce.
     For example, the alias, email, profile ID and all the values listed
     below are shown when a user is
-    created.  
+    created.
     These are sample values to help you understand better about claim
     URI and its value types.
     <table>
@@ -435,120 +431,115 @@ When you log into Salesforce, you normally use an email address. So, to integrat
     </tbody>
     </table>
 
-    ![advanced-claim-config]({{base_path}}/assets/img/guides/advanced-claim-config.png) 
+    ![advanced-claim-config]({{base_path}}/assets/img/guides/advanced-claim-config.png)
 
 10. Expand the **Outbound Provisioning Connectors** section followed by
     the **Salesforce Provisioning Configuration** section.
 11. Do the following configurations for Salesforce provisioning. <!--For more information on any of these fields, see [Configuring Salesforce provisioning]({{base_path}}/learn/configuring-outbound-provisioning-connectors-for-an-identity-provider#configuring-salesforce-provisioning).-->
-    
-    1.  Select **Enable Connector** to enable the Salesforce connector.
-    2.  Enter the **API version**. This is the version of the API you
-        are using in Salesforce.  
-        Follow the steps given below to get the API version:  
-        1.  To obtain this, log into <https://login.salesforce.com>.
-        2.  Search for **API** in the Quick Find search box and click
+
+    1. Select **Enable Connector** to enable the Salesforce connector.
+    2. Enter the **API version**. This is the version of the API you
+        are using in Salesforce.
+        Follow the steps given below to get the API version:
+        1. To get this, log into <https://login.salesforce.com>.
+        2. Search for **API** in the Quick Find search box and click
             API.
-        3.  Generate any one of the WSDL's to check the version. You are
+        3. Generate any one of the WSDL's to check the version. You are
             navigated to page with XML syntaxes.
-        4.  On the top it will mention as "
-            `              Salesforce.com Enterprise Web Services API Version <VERSION>             `
-            ".  For example:
-            `              Salesforce.com Enterprise Web Services API Version 41.0             `
-        5.  Enter this value for the API version in the following
-            format: `              v<VERSION_NUMBER>             `. For
-            example: `              v41.0             `.
-    3.  Enter the **Domain**. If you do not have a Salesforce domain,
-        you need to create a domain by logging into
+        4. On the top it will mention as "
+            `Salesforce.com Enterprise Web Services API Version <VERSION>`
+            ". For example:
+            `Salesforce.com Enterprise Web Services API Version 41.0`
+        5. Enter this value for the API version in the following
+            format: `v<VERSION_NUMBER>`. For
+            example: `v41.0`.
+    3. Enter the **Domain**. If you do not have a Salesforce domain,
+        you need to create a domain by logging into
         [https://login.salesforce.com](https://login.salesforce.com/).
 
         ??? note "Click here for more information on creating the domain on Salesforce."
 
-            1.  Search for My Domain in the search bar that is on the left
-                navigation panel.  
-                ![my-domain]({{base_path}}/assets/img/guides/my-domain.png) 
-            2.  Click **My Domain**.
-            3.  In the page that appears, come up with a name for your
+            1. Search for My Domain in the search bar that is on the left
+                navigation panel.
+                ![my-domain]({{base_path}}/assets/img/guides/my-domain.png)
+            2. Click **My Domain**.
+            3. In the page that appears, come up with a name for your
                 domain. You can check if the domain is available by clicking
                 the **Check Availability** button.
-                !!! info 
+                !!! info
                     For the page given below to load on your browser, make sure
                     that the Salesforce cookies are not blocked.
                 ![check-domain-availability]({{base_path}}/assets/img/guides/check-domain-availability.png)
 
-            4.  If the domain is available, select **I agree to Terms and
+            4. If the domain is available, select **I agree to Terms and
                 Conditions** and click **Register Domain** to register your
                 new domain.
 
-            5.  Once the domain is registered to your account, click the
+            5. Once the domain is registered to your account, click the
                 **Click here to login** button to test this out.
 
-        !!! info 
-            1.  Search for **My Domain** using the Quick Find search box and
-                click **My Domain**.  
-                You see the domain as follows: Your domain name is
-                `                               <DOMAIN>-dev-ed.my.salesforce.com                             `
-            2.  Make sure you enter the domain with an HTTPS prefix so that
+        !!! info
+            1. Search for **My Domain** using the Quick Find search box and
+                click **My Domain**.
+                You see the domain as follows: Your domain name is
+                `<DOMAIN>-dev-ed.my.salesforce.com`
+            2. Make sure you enter the domain with an HTTPS prefix so that
                 it resembles a URL:
-                `               https://<DOMAIN>-dev-ed.my.salesforce.com              `
-.
+                `https://<DOMAIN>-dev-ed.my.salesforce.com`.
 
-    4.  Enter the **Client ID**. This is the Consumer Key obtained in
+    4. Enter the **Client ID**. This is the Consumer Key from
         [step 3 when configuring
-        Salesforce](#step5)
-.
+        Salesforce](#step5).
 
         ??? note "Did not save the details? Click here for more information on getting the details."
 
-            1.  Search for **App Manager** using the Quick Find search box
+            1. Search for **App Manager** using the Quick Find search box
                 and click **App Manager**.
-            2.  Click the expand button for your Connected App and click
-                **View**.  
-                ![view-connected-app]({{base_path}}/assets/img/guides/view-connected-app.png) 
-            3.  You are navigated to the page that has the Client ID and
+            2. Click the expand button for your Connected App and click
+                **View**.
+                ![view-connected-app]({{base_path}}/assets/img/guides/view-connected-app.png)
+            3. You are navigated to the page that has the Client ID and
                 Client Secret of the app under **API (Enable OAuth
                 Settings)**.
 
-    5.  Enter the **Client Secret**. This is the Consumer Secret
-        obtained in [step 3 when configuring
-        Salesforce](#step5)
-.
-    6.  Enter the **Username**. This is the Salesforce username.
-    7.  Enter the **Password**. This is the Salesforce password and
+    5. Enter the **Client Secret**. This is the Consumer Secret
+        from [step 3 when configuring
+        Salesforce](#step5).
+    6. Enter the **Username**. This is the Salesforce username.
+    7. Enter the **Password**. This is the Salesforce password and
         must be entered along with the security token. So you would
         enter this in the following format:
-        `             <password><security_token            ` \>  
+        `<password><security_token` \>
         For example, if your password is
-        `             testpassword            ` and your security token
-        is `             37f37f4433123            `, the value you
+        `testpassword` and your security token
+        is `37f37f4433123`, the value you
         would enter here is
-        `             testpassword37f37f4433123            `.
+        `testpassword37f37f4433123`.
 
         ??? tip "Where can I get the security token?"
-            1.  Log in to Salesforce: <https://login.salesforce.com/>
-            2.  Click on your avatar and click My Settings. You are
-                navigated to the Personal Information page.  
-                ![salesforce-personal-info]({{base_path}}/assets/img/guides/salesforce-personal-info.png) 
-            3.  On the left navigation, click **Reset My Security Token**
-.  
-                ![reset-security-token]({{base_path}}/assets/img/guides/reset-security-token.png) 
-            4.  Click **Reset Security Token**.  
+            1. Log in to Salesforce: <https://login.salesforce.com/>
+            2. Click on your avatar and click My Settings. You are
+                navigated to the Personal Information page.
+                ![salesforce-personal-info]({{base_path}}/assets/img/guides/salesforce-personal-info.png)
+            3. On the left navigation, click **Reset My Security Token**.
+                ![reset-security-token]({{base_path}}/assets/img/guides/reset-security-token.png)
+            4. Click **Reset Security Token**.
                 An email is sent to you with the new security token. Check
                 the email of the email address you configured for
-                Salesforce.  
-                ![new-security-token]({{base_path}}/assets/img/guides/new-security-token.png) 
-        
+                Salesforce.
+                ![new-security-token]({{base_path}}/assets/img/guides/new-security-token.png)
 
 12. Click **Register**.
 
----
+-----
 
 ## Configure WSO2 IS as the resident Service Provider
 
 {!./includes/resident-sp.md !}
 
----
+-----
 
-## Add a user using SCIM.
+## Add a user using SCIM
 
 You can also add users to Salesforce using SCIM.
 
@@ -558,20 +549,17 @@ You can also add users to Salesforce using SCIM.
     For more information see the [Salesforce documentation](https://help.salesforce.com/s/articleView?id=000325728&type=1).
     Later on, if you want to update the user details, you won't be able to update the email address.
 
-Select the correct SCIM user endpoint given in **Resident** > **Inbound Provisioning Configuration** and use it in the curl command.  
+Select the correct SCIM user endpoint given in **Resident** > **Inbound Provisioning Configuration** and use it in the curl command.
     The following is a sample cURL command to add users.
 
 ```curl
-curl -v -k --header "Content-Type:application/json" --user kim@wso2.com:password --data '{"schemas":     ["urn:scim:schemas:core:1.0"],"userName”:”kim@wso2.com","password”:”test123”,”name":{"familyName”:”paul”},”emails":     [“kim@wso2.com"],"entitlements":     [{"value":"00e2x000001AT3y","display":"ChatterFreeUser"}]}' https://localhost:9443/wso2/scim2/Users  
+curl -v -k --header "Content-Type:application/json" --user kim@wso2.com:password --data '{"schemas":     ["urn:scim:schemas:core:1.0"],"userName":"kim@wso2.com","password":"test123","name":{"familyName":"paul"},"emails":     ["kim@wso2.com"],"entitlements":     [{"value":"00e2x000001AT3y","display":"ChatterFreeUser"}]}' https://localhost:9443/wso2/scim2/Users
 ```
 
 You can see that the user has been created in the "Users" section in salesforce.
 
 ![salesforce-user]({{base_path}}/assets/img/guides/salesforce-user.png)
 
-
 !!! info "Related topics"
     - [Concept: Identity Provisioning Framework]({{base_path}}/references/concepts/provisioning-framework/)
     - [Guide: Configure Just-In-Time Provisioning for an Identity Provider]({{base_path}}/guides/identity-federation/jit-workflow)
-
-

--- a/en/identity-server/6.1.0/docs/guides/login/log-into-google-using-is.md
+++ b/en/identity-server/6.1.0/docs/guides/login/log-into-google-using-is.md
@@ -3,10 +3,12 @@
 This page guides you through using WSO2 Identity Server to log in to Google.
 
 -----
+
 !!! tip "Before you begin!"
     You need to have a Google domain. Click
-    [here](https://www.bettercloud.com/monitor/the-academy/create-google-apps-domain-three-easy-steps/)
+    [Create Google Apps Domain](https://www.bettercloud.com/monitor/the-academy/create-google-apps-domain-three-easy-steps/)
     for more information on creating the domain.
+
 -----
 
 ## Configure Google
@@ -16,7 +18,7 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 2. Click **Security**.
 
     !!! info
-        Can't see the Security section? Click the **MORE CONTROLS** bar at the bottom and you can see the Security section.
+        Can't see the Security section? Click the **MORE CONTROLS** bar at the bottom and you can see the Security section.
 
     ![more-controls]({{base_path}}/assets/img/guides/security-google.png)
 
@@ -35,14 +37,14 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 
     ![sso-fill-google.png]({{base_path}}/assets/img/guides/sso-fill-google.png)
 
-5. Upload the Identity Server certificate:  
+5. Upload the Identity Server certificate:
     The certificate file must contain the public key for Google to
     verify the sign-in requests.
 
     1. Navigate to the
         `<IS_HOME>/repository/resources/security`
         directory via the terminal.
-    2. Run the command given below to import the public certificate
+    2. Run the command given below to import the public certificate
         from the keystore to a `.pem` file.
 
         ``` java
@@ -62,28 +64,27 @@ This page guides you through using WSO2 Identity Server to log in to Google.
 ## Configure Email Address as the Username
 
 !!! warning
-    Configuring the email address as the username in an **already running
-    Identity Server** is not the production recommended way. Therefore,
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. So,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -132,12 +133,12 @@ This page guides you through using WSO2 Identity Server to log in to Google.
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -166,20 +167,20 @@ This page guides you through using WSO2 Identity Server to log in to Google.
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.
 
 -----
 
@@ -235,25 +236,23 @@ Now, you have successfully configured Google and WSO2 Identity Server.
 
 !!! note
     The admin users of your Google domain do not get redirected to WSO2 IS.
-    Therefore, to try out the tutorial you need to use a user who is not an
+    To try out the tutorial, you need to use a user who is not an
     admin in your Google account.
 
 1. Create a user in WSO2 Identity Server. Make sure that the same user
-    exists in your Google domain.  
+    exists in your Google domain.
     In this example, `alex@wso2support.com`
-    is in the Google domain. Therefore, we need to create the same user in WSO2 Identity Server.
+    is in the Google domain. So, we need to create the same user in WSO2 Identity Server.
 
     {!./includes/create-user-email-username.md!}
 
 2. Navigate to
     `https://google.com/a/<ENTER_YOUR_DOMAIN>/acs`
-    and enter the email address (username) of the user you created.  
+    and enter the email address (username) of the user you created.
     You are navigated to WSO2 Identity Server's sign in screen.
-3. Enter the username and password of the user you created.  
+3. Enter the username and password of the user you created.
     You are navigated to the G-Suite of that domain and you can select
     the application you need to use.
-
-  
 
 !!! tip
     If you want to only access Gmail, navigate to

--- a/en/identity-server/6.1.0/docs/guides/login/log-into-salesforce-using-is.md
+++ b/en/identity-server/6.1.0/docs/guides/login/log-into-salesforce-using-is.md
@@ -1,64 +1,64 @@
 # Log in to Salesforce using the Identity Server
 
-This page guides you through using WSO2 Identity  Server to log in to Salesforce. 
+This page guides you through using WSO2 Identity Server to log in to Salesforce.
 
-----
+-----
 
 ## Configure Salesforce
 
-1.  Sign up as a Salesforce developer.
-    1.  Fill out the relevant information found in the following URL:
+1. Sign up as a Salesforce developer.
+    1. Fill out the relevant information found in the following URL:
         <https://developer.salesforce.com/signup>
-    2.  Click **Sign me up**.
-    3.  Click **Allow** to enable Salesforce to access your basic
+    2. Click **Sign me up**.
+    3. Click **Allow** to enable Salesforce to access your basic
     information. This message pops up only when you log in to Salesforce
     for the first time.
     4. You will be navigated to the lightening theme of Salesforce.
-    
+
        ![welcome-to-lightening.png]({{base_path}}/assets/img/guides/welcome-to-lightening.png)
-       
-    !!! note    
+
+    !!! note
         This document is explained using the Salesforce lightning theme. If
-        you are using the classic theme, click **Switch to Lightning Experience** on the top panel. 
+        you are using the classic theme, click **Switch to Lightning Experience** on the top panel.
 
         ![lighteninig-experience]({{base_path}}/assets/img/guides/switch-to-lightening.png)
 
-2.  Once you are logged in, create a new domain and access it. To do
-    this, do the following steps.  
-    1.  Search for **My Domain** in the search bar that is on the left
-        navigation panel.  
+2. Once you are logged in, create a new domain and access it. To do
+    this, do the following steps.
+    1. Search for **My Domain** in the search bar that is on the left
+        navigation panel.
         ![my-domain]({{base_path}}/assets/img/guides/my-domain-salesforce.png)
 
-    2.  Click **My Domain**.
-    3.  On the page that appears, come up with a name for your domain.
+    2. Click **My Domain**.
+    3. On the page that appears, come up with a name for your domain.
         You can check if the domain is available by clicking the **Check
         Availability** button.
-		
-		!!! info 
-			For the page given below to load on your browser, make sure that
-			the Salesforce cookies are not blocked.
+
+        !!! info
+            For the page given below to load on your browser, make sure that
+            the Salesforce cookies are not blocked.
 
         ![sales-force-cookies]({{base_path}}/assets/img/guides/domain-available-salesforce.png)
 
-    4.  If the domain is available, click **Register Domain** to register your new
+    4. If the domain is available, click **Register Domain** to register your new
         domain.
 
-    5.  The verification might take a few minutes. On successful verification, you will proceed to step 3 where you can test your login. 
+    5. The verification might take a few minutes. On successful verification, you will proceed to step 3 where you can test your login.
 
     6. Click **Log in**.
 
-5.  On the left navigation menu, search for **Single Sign-On Settings** and click on it.
-    
-6.  On the page that appears, click **Edit** and then select the **SAML
-    Enabled** check box to enable federated single sign-on using SAML.  
-    ![saml-enabled]({{base_path}}/assets/img/guides/enable-saml-salesforce.png)
-    
-7.  Click **Save**.
+3. On the left navigation menu, search for **Single Sign-On Settings** and click on it.
 
-8.  Click **New** under **SAML Single Sign-On Settings**. The following
-    screen appears.  
+4. On the page that appears, click **Edit** and then select the **SAML
+    Enabled** check box to enable federated single sign-on using SAML.
+    ![saml-enabled]({{base_path}}/assets/img/guides/enable-saml-salesforce.png)
+
+5. Click **Save**.
+
+6. Click **New** under **SAML Single Sign-On Settings**. The following
+    screen appears.
     ![saml-sso-setting]({{base_path}}/assets/img/guides/saml-sso-salesforce.png)
-    
+
     Ensure that you configure the following properties.
 
     <table>
@@ -92,7 +92,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     <p><code>                 wso2.crt                </code></p>
     <div class="admonition note">
 	<p class="admonition-title">Note</p>
-	<p>To create the Identity Provider Certificate, open the terminal, traverse to the `<IS_HOME>/repository/resources/security` directory. 
+	<p>To create the Identity Provider Certificate, open the terminal, traverse to the `<IS_HOME>/repository/resources/security` directory.
 	Next, execute the following command.
 	<div class="code panel pdl" style="border-width: 1px;">
 	<div class="codeContent panelContent pdl">
@@ -136,11 +136,11 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     <td><code>                               https://localhost:9443/samlsso                             </code></td>
     </tr>
     <tr class="even">
-    <td>Custom Error URL</td>
+    <td>Custom Error URL</td>
     <td>Leave blank</td>
     </tr>
     <tr class="odd">
-    <td>User Provisioning Enabled</td>
+    <td>User Provisioning Enabled</td>
     <td>Leave blank</td>
     </tr>
     </tbody>
@@ -148,47 +148,46 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
 
     Click **Save** to save your configurations.
 
-9.  Navigate to **Company Settings** in the left navigation pane and click **My Domain**.
-    
-10. Click **Deploy to Users**. Click **Ok** to the confirmation message
-    that appears.
-    
-11. On the page that appears, you must configure the **Authentication Configuration** section. Scroll down to this section and click
-    **Edit**.
-    
-12. Under **Authentication Service**, select **SSO** instead of **Login
-    Page**.  
-    ![authentication-service-sso]({{base_path}}/assets/img/guides/auth-config-salesforce.png)
-    
-13. Click **Save**.
+7. Navigate to **Company Settings** in the left navigation pane and click **My Domain**.
 
-----
+8. Click **Deploy to Users**. Click **Ok** to the confirmation message
+    that appears.
+
+9. On the page that appears, you must configure the **Authentication Configuration** section. Scroll down to this section and click
+    **Edit**.
+
+10. Under **Authentication Service**, select **SSO** instead of **Login
+    Page**.
+    ![authentication-service-sso]({{base_path}}/assets/img/guides/auth-config-salesforce.png)
+
+11. Click **Save**.
+
+-----
 
 ## Configure Email Address as the Username
 
 !!! warning
-    Configuring the email address as the username in an **already running
-    Identity Server** is not the production recommended way. Therefore,
+    Configuring the email address as the username in an **already running
+    Identity Server** is not the production recommended way. So,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
-   
+1. Log in to the Management Console and click **Claims > List > http://wso2.org/claims**.
+
 2. Click the **Edit** link corresponding to the **Username** claim and configure the `Mapped Attribute` property to `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/email-as-username-attribute-mapping.png)
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -237,12 +236,12 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -271,20 +270,20 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-    !!! info 
+    !!! info
         - With these configuration users can log in to super tenant with both
         email username (**`alex@gmail.com`**) or
-        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**). 
+        non-email usernames (`larry`). However, for tenants, only email usernames are allowed. (**`tod@gmail.com@wso2.com`**).
         - You can configure email username without enabling the **`enable_email_domain`** property (step 5). Then users can log in to both the super tenant and the tenant using email and non-email usernames. However, super tenant users should always use
         ***@carbon.super*** at the end of usernames.
 
-7.  Restart the server.
+7. Restart the server.
 
 -----
 
@@ -292,7 +291,7 @@ This page guides you through using WSO2 Identity  Server to log in to Salesforce
 
 {!./includes/register-a-service-provider.md!}
 
----
+-----
 
 ### SAML Configurations
 
@@ -302,27 +301,27 @@ Make the following changes to the created service provider.
 
 2. Enter the **Issuer** as `https://saml.salesforce.com`.
 
-    !!! note 
+    !!! note
         The **Issuer** is the unique identifier of the service provider. This is also the issuer value specified in the SAML Authentication Request issued by the service provider.
-        
-3. Enter **Assertion Consumer URL** and click **Add**. 
-    
+
+3. Enter **Assertion Consumer URL** and click **Add**.
+
     !!! note
         The **Assertion Consumer URL** is the URL of the page to which the browser is redirected to after successful authentication.
-        To obtain the **Assertion Consumer URL** from Salesforce, follow the below provided steps. <br>
+        To get the **Assertion Consumer URL** from Salesforce, follow the below provided steps. <br>
         1. Navigate to **Identity > Single Sign-On Settings** from the left hand side panel.  <br>
         2. Click on the name of the SAML SSO component created.  <br>
-        3. Note down the login URL. 
+        3. Note down the login URL.
 
-9. Select **Enable Response Signing** to sign the SAML2 Responses returned after the authentication process.
+4. Select **Enable Response Signing** to sign the SAML2 Responses returned after the authentication process.
 
-10. Select **Enable Attribute Profile** and **Include Attributes in the Response Always** so that the the identity provider 
+5. Select **Enable Attribute Profile** and **Include Attributes in the Response Always** so that the the identity provider
     will always include the attribute values related to the selected claims in the SAML2 attribute statement.
 
-12. Click **Register**. 
+6. Click **Register**.
 
 !!! tip
-     To configure more advanced configurations, see [Advanced SAML Configurations]({{base_path}}/guides/login/saml-app-config-advanced). 
+     To configure more advanced configurations, see [Advanced SAML Configurations]({{base_path}}/guides/login/saml-app-config-advanced).
 
 -----
 
@@ -331,68 +330,66 @@ Make the following changes to the created service provider.
 Do the following steps to test out the configurations for a new user in
 Salesforce and the Identity Server.
 
-1.  Create a user in WSO2 IS. 
- 
+1. Create a user in WSO2 IS.
+
     {!./includes/create-user-email-username.md!}
-        
-2.  Create a user in Salesforce. This user should have the same
-    email address as the user in WSO2 IS  
-    1.  Log in to the Salesforce developer account:
+
+2. Create a user in Salesforce. This user should have the same
+    email address as the user in WSO2 IS
+    1. Log in to the Salesforce developer account:
         [https://login.salesforce.com/](https://login.salesforce.com/?lt=de).
-    2.  On the left navigation pane, under **ADMINISTRATION**, click
+    2. On the left navigation pane, under **ADMINISTRATION**, click
         **Users** under **Users**.
-    3.  On the page that appears, click the **New User** button to
+    3. On the page that appears, click the **New User** button to
         create a new user.
-    4.  Create a user with the same username as the one you created in
+    4. Create a user with the same username as the one you created in
         WSO2 Identity Server. Click **Save** to save your changes. An
         email will be sent to the email address you provided for the
         user.
 
         !!! note
-			This is mainly for testing purposes. In a real
-			business scenario, you would be more likely to use Just-In-Time
-			(JIT) provisioning to provision a user to Salesforce.
-        
+            This is mainly for testing purposes. In a real
+            business scenario, you would be more likely to use Just-In-Time
+            (JIT) provisioning to provision a user to Salesforce.
 
-3.  Access your Salesforce login URL on an incognito or private browser.
-	
-	!!! info 
-		The salesforce login URL is unique to your Salesforce application.
-		Follow the steps given below to get this URL:
+3. Access your Salesforce login URL on an incognito or private browser.
 
-		1.  Search for **My Domain** in the search bar that is on the left
-			navigation panel.
-			
-		2.  Click **My Domain** and you are navigated to the domain you created
-			under the section, [Configure
-			Salesforce](#configure-salesforce).
+    !!! info
+        The salesforce login URL is unique to your Salesforce application.
+        Follow the steps given below to get this URL:
 
-		3.  Click **Edit** under Authentication Configurations and you are
-			navigated to a new page having the following URl:
-			`              https://<DOMAIN_NAME>/domainname/EditLogin.apexp             `. 
-			
-		4.  On the left navigation menu, expand **Security Controls**, and
-			click, **Single Sign-On Settings**.
-			
-		5.  Click on the name of the created **Single Sign-On Setting**. For this example, click **SSO**.  
-			![single-sign-on-setting]({{base_path}}/assets/img/guides/single-sign-on-setting.png)
-			
-		6.  Copy the URL that is defined for **Login URL** to access
-			Salesforce.  
-			![login-url-for-salesforce]({{base_path}}/assets/img/guides/login-url-for-salesforce.png)
+        1. Search for **My Domain** in the search bar that is on the left
+            navigation panel.
 
-4.  Log in using the new credentials of the user you just created. You
+        2. Click **My Domain** and you are navigated to the domain you created
+            under the section, [Configure
+            Salesforce](#configure-salesforce).
+
+        3. Click **Edit** under Authentication Configurations and you are
+            navigated to a new page having the following URl:
+            `https://<DOMAIN_NAME>/domainname/EditLogin.apexp`.
+
+        4. On the left navigation menu, expand **Security Controls**, and
+            click, **Single Sign-On Settings**.
+
+        5. Click on the name of the created **Single Sign-On Setting**. For this example, click **SSO**.
+            ![single-sign-on-setting]({{base_path}}/assets/img/guides/single-sign-on-setting.png)
+
+        6. Copy the URL that is defined for **Login URL** to access
+            Salesforce.
+            ![login-url-for-salesforce]({{base_path}}/assets/img/guides/login-url-for-salesforce.png)
+
+4. Log in using the new credentials of the user you just created. You
     are then redirected back to Salesforce.
-    
-----
 
+-----
 
 ## Troubleshooting guidelines
 
-Additional troubleshooting information regarding any Salesforce side SSO
+Additional troubleshooting information about any Salesforce side SSO
 failures can be retrieved by using Salesforce SAML Assertion Validator.
-Further information regarding the steps are available
-[here](https://developer.salesforce.com/docs/atlas.en-us.sso.meta/sso/sso_saml_validation_errors.htm#!).
+Further information about the steps are available
+[in the Salesforce SAML validation errors documentation](https://developer.salesforce.com/docs/atlas.en-us.sso.meta/sso/sso_saml_validation_errors.htm#!).
 
 !!! info "Related topics"
     - [Concept: Identity Federation]({{base_path}}/references/concepts/identity-federation/)

--- a/en/identity-server/6.1.0/docs/includes/enable-email-as-username.md
+++ b/en/identity-server/6.1.0/docs/includes/enable-email-as-username.md
@@ -70,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>

--- a/en/identity-server/7.0.0/docs/guides/users/attributes/enable-email-as-username.md
+++ b/en/identity-server/7.0.0/docs/guides/users/attributes/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
-   
+1. Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
+
 2. Click the **Username** attribute and configure the `Mapped Attribute` as `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/organization/attributes/email-as-username-attribute-mapping.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-7.  Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
+7. Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
 
     !!! warning "Important"
-        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore. 
-        
+        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore.
+
         Without this change, the super admin's username will remain stored under the `uid` attribute instead of `mail`, which can cause issues.
 
     In the `<Dialect dialectURI="http://wso2.org/claims">` dialect, locate the `<Claim>` element with `ClaimURI` as `http://wso2.org/claims/username` and update the `AttributeID` from `uid` to `mail`:
@@ -129,4 +128,4 @@
     </Claim>
     ```
 
-8.  Restart the server.
+8. Restart the server.

--- a/en/identity-server/7.1.0/docs/guides/users/attributes/enable-email-as-username.md
+++ b/en/identity-server/7.1.0/docs/guides/users/attributes/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
-   
+1. Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
+
 2. Click the **Username** attribute and configure the `Mapped Attribute` as `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/organization/attributes/email-as-username-attribute-mapping.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-7.  Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
+7. Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
 
     !!! warning "Important"
-        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore. 
-        
+        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore.
+
         Without this change, the super admin's username will remain stored under the `uid` attribute instead of `mail`, which can cause issues.
 
     In the `<Dialect dialectURI="http://wso2.org/claims">` dialect, locate the `<Claim>` element with `ClaimURI` as `http://wso2.org/claims/username` and update the `AttributeID` from `uid` to `mail`:
@@ -130,4 +129,4 @@
     </Claim>
     ```
 
-8.  Restart the server.
+8. Restart the server.

--- a/en/identity-server/7.2.0/docs/guides/users/attributes/enable-email-as-username.md
+++ b/en/identity-server/7.2.0/docs/guides/users/attributes/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
-   
+1. Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
+
 2. Click the **Username** attribute and configure the `Mapped Attribute` as `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/organization/attributes/email-as-username-attribute-mapping.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-7.  Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
+7. Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
 
     !!! warning "Important"
-        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore. 
-        
+        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore.
+
         Without this change, the super admin's username will remain stored under the `uid` attribute instead of `mail`, which can cause issues.
 
     In the `<Dialect dialectURI="http://wso2.org/claims">` dialect, locate the `<Claim>` element with `ClaimURI` as `http://wso2.org/claims/username` and update the `AttributeID` from `uid` to `mail`:
@@ -130,4 +129,4 @@
     </Claim>
     ```
 
-8.  Restart the server.
+8. Restart the server.

--- a/en/identity-server/7.3.0/docs/guides/users/attributes/enable-email-as-username.md
+++ b/en/identity-server/7.3.0/docs/guides/users/attributes/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
-   
+1. Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
+
 2. Click the **Username** attribute and configure the `Mapped Attribute` as `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/organization/attributes/email-as-username-attribute-mapping.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-7.  Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
+7. Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
 
     !!! warning "Important"
-        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore. 
-        
+        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore.
+
         Without this change, the super admin's username will remain stored under the `uid` attribute instead of `mail`, which can cause issues.
 
     In the `<Dialect dialectURI="http://wso2.org/claims">` dialect, locate the `<Claim>` element with `ClaimURI` as `http://wso2.org/claims/username` and update the `AttributeID` from `uid` to `mail`:
@@ -130,4 +129,4 @@
     </Claim>
     ```
 
-8.  Restart the server.
+8. Restart the server.

--- a/en/identity-server/next/docs/guides/users/attributes/enable-email-as-username.md
+++ b/en/identity-server/next/docs/guides/users/attributes/enable-email-as-username.md
@@ -4,25 +4,24 @@
     Configuring the email address as the username in an **already running
     Identity Server** is not the production recommended way. Therefore,
     **make sure to configure it before you begin working with WSO2 IS**.
-    
 
-1.  Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
-   
+1. Log in to the WSO2 Identity Server Console and click **User Attributes & Stores** > **Attributes**.
+
 2. Click the **Username** attribute and configure the `Mapped Attribute` as `mail`.
 
     ![email-as-username-attribute-mapping]({{base_path}}/assets/img/guides/organization/attributes/email-as-username-attribute-mapping.png){: width="600" style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
-    
+
 3. Click **Update** to save the changes.
 
-4.  Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+4. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 
-5.  Add the following configuration to enable email authentication.
+5. Add the following configuration to enable email authentication.
 
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
     ```
-    
+
 6. Configure the following set of parameters in the userstore
     configuration, depending on the type of userstore you are connected
     to (LDAP/Active Directory/ JDBC).
@@ -71,12 +70,12 @@
     </div></td>
     </tr>
     <tr class="even">
-    <td><code>               UsernameJavaScriptRegEx              </code></td>
+    <td><code>               UsernameWithEmailJavaScriptRegEx              </code></td>
     <td><div class="content-wrapper">
-    <p>Change this property that is under the relevant userstore manager tag as follows. This property allows you to add special characters like "@" in the username.</p>
+    <p>Change this property that is under the relevant userstore manager tag as follows. This property validates usernames when email is used as the username and allows special characters like "@" in the username.</p>
     <div class="code panel pdl" style="border-width: 1px;">
     <div class="codeContent panelContent pdl">
-    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store]<br>username_java_script_regex = &apos;^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$&apos;</code></pre></div>
+    <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>[user_store.properties]<br>UsernameWithEmailJavaScriptRegEx = &apos;^[a-zA-Z0-9_@.+-]{5,200}$&apos;</code></pre></div>
     </div>
     </div>
     </div></td>
@@ -105,17 +104,17 @@
     <p class="admonition-title">Note</p>
     <p>Before this configuration, the user having the username <strong>admin</strong> and password <strong>admin</strong> was considered the super administrator. The super administrator user cannot be deleted.</p>
     <p>After this configuration, the user having the username <strong><code>                  admin@wso2.com                 </code></strong> is considered the super administrator. The user having the username admin is considered as a normal administrator.<br />
-    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" width="600" /></p></div>
+    <img src="{{base_path}}/assets/img/guides/organization/attributes/super-admin.png" alt="super-admin" width="600" /></p></div>
     </div></td>
     </tr>
     </tbody>
     </table>
 
-7.  Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
+7. Update the username claim mapping in the `<IS_HOME>/repository/conf/claim-config.xml` file.
 
     !!! warning "Important"
-        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore. 
-        
+        By default, the claim `http://wso2.org/claims/username` is mapped to the `uid` attribute in the userstore. When enabling email as username, this mapping must be changed to `mail` to ensure the username is correctly stored and retrieved from the userstore.
+
         Without this change, the super admin's username will remain stored under the `uid` attribute instead of `mail`, which can cause issues.
 
     In the `<Dialect dialectURI="http://wso2.org/claims">` dialect, locate the `<Claim>` element with `ClaimURI` as `http://wso2.org/claims/username` and update the `AttributeID` from `uid` to `mail`:
@@ -130,4 +129,4 @@
     </Claim>
     ```
 
-8.  Restart the server.
+8. Restart the server.


### PR DESCRIPTION
## Summary

- Fix incorrect user store property name for email-as-username regex validation: `UsernameJavaScriptRegEx` → `UsernameWithEmailJavaScriptRegEx`
- Fix incorrect deployment.toml configuration section: `[user_store]` → `[user_store.properties]`
- Update regex pattern to `'^[a-zA-Z0-9_@\\.\\-\\+]{5,200}$'`

## Details

When email-as-username is enabled, the self-registration code in `UserSelfRegistrationManager` reads the `UsernameWithEmailJavaScriptRegEx` property (not `UsernameJavaScriptRegEx`). The documentation was incorrectly instructing users to configure `UsernameJavaScriptRegEx` under `[user_store]`, which has no effect on the email username validation path, causing self-registration to fail.

Verified via bytecode inspection that all IS versions (5.10.0 through 7.3.0) use `UsernameWithEmailJavaScriptRegEx` in both `UserSelfRegistrationManager` and `AbstractUserStoreManager`.

## Affected versions

5.10.0, 5.11.0, 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0, 7.3.0, next

Fixes https://github.com/wso2/product-is/issues/21499