### PR TITLE
fix: replace incorrect "role-based" label with "login-attempt-based" …

### DIFF
--- a/en/identity-server/next/docs/guides/authentication/conditional-auth/login-attempt-based-template.md
+++ b/en/identity-server/next/docs/guides/authentication/conditional-auth/login-attempt-based-template.md
@@ -28,11 +28,11 @@ To enable conditional authentication:
 
 2. Select the relevant application and go to its **Login Flow** tab.
 
-3. Add role-based adaptive MFA as follows:
+3. Add login-attempt-based adaptive MFA as follows:
 
     1. Go to **Predefined Flows** > **Conditional Login Flows**.
 
-    2. Click **Adaptive MFA** > **Login-Attempts-Based** > **ADD** to add the role-based adaptive MFA script.
+    2. Click **Adaptive MFA** > **Login-Attempts-Based** > **ADD** to add the login-attempt-based adaptive MFA script.
 
         ![Login attempts based adaptive MFA with visual editor]({{base_path}}/assets/img/guides/conditional-auth/login-attempt-based-adaptive-mfa-with-visual-editor.png){: style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 

--- a/en/identity-server/next/docs/guides/authentication/conditional-auth/login-attempt-based-template.md
+++ b/en/identity-server/next/docs/guides/authentication/conditional-auth/login-attempt-based-template.md
@@ -32,7 +32,7 @@ To enable conditional authentication:
 
     1. Go to **Predefined Flows** > **Conditional Login Flows**.
 
-    2. Click **Adaptive MFA** > **Login-Attempts-Based** > **ADD** to add the login-attempt-based adaptive MFA script.
+    2. Click **Adaptive MFA** > **Login-Attempts-Based** > **ADD** to add the login attempt based adaptive MFA script.
 
         ![Login attempts based adaptive MFA with visual editor]({{base_path}}/assets/img/guides/conditional-auth/login-attempt-based-adaptive-mfa-with-visual-editor.png){: style="display: block; margin: 0; border: 0.3px solid lightgrey;"}
 

--- a/en/identity-server/next/docs/guides/authentication/conditional-auth/login-attempt-based-template.md
+++ b/en/identity-server/next/docs/guides/authentication/conditional-auth/login-attempt-based-template.md
@@ -28,7 +28,7 @@ To enable conditional authentication:
 
 2. Select the relevant application and go to its **Login Flow** tab.
 
-3. Add login-attempt-based adaptive MFA as follows:
+3. Add login attempt based adaptive MFA as follows:
 
     1. Go to **Predefined Flows** > **Conditional Login Flows**.
 


### PR DESCRIPTION
### **Purpose**
Step 3 in the "Configure the login flow" section of the 'Add MFA based on login attempts' guide incorrectly said "role-based adaptive MFA" instead of "login-attempt-based adaptive MFA" due to a mistake from the role-based template.

### **Approach**
Updated the two incorrect labels in `login-attempt-based-template.md`:
- Step 3 heading: `role-based` → `login-attempt-based`
- Step 3(b) description: `role-based adaptive MFA script` → `login-attempt-based adaptive MFA script`