### PR TITLE
[IS-7.0] Add attribute name format property into SAML configurations

### DIFF
--- a/en/identity-server/7.0.0/docs/apis/restapis/application.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/application.yaml
@@ -4552,6 +4552,15 @@ components:
         alwaysIncludeAttributesInResponse:
           type: boolean
           default: false
+        nameFormat:
+          type: string
+          default: urn:oasis:names:tc:SAML:2.0:attrname-format:basic
+          enum:
+            - urn:oasis:names:tc:SAML:2.0:attrname-format:basic
+            - urn:oasis:names:tc:SAML:2.0:attrname-format:uri
+          description: >
+            Specifies the type of attribute names used in the attribute statement of SAML assertions.
+            **Available from update level 7.0.0.156 onwards.**
     SingleLogoutProfile:
       type: object
       properties:

--- a/en/includes/references/app-settings/saml-settings-for-app.md
+++ b/en/includes/references/app-settings/saml-settings-for-app.md
@@ -203,6 +203,11 @@ Specifies whether to include the user's attributes in the SAML assertions as par
 
 #### Attribute name format
 
+{% if product_name == "WSO2 Identity Server" and is_version == "7.0.0" %}
+!!! note
+    This improvement is available from **update level 7.0.0.156** onwards. See the instructions on [updating WSO2 products](https://updates.docs.wso2.com/en/latest/).
+{% endif %}
+
 The attribute name format specifies the type of attribute names used in the attribute statements of SAML assertions. The following are the attribute name format types supported by {{ product_name }}.
 
 - `urn:oasis:names:tc:SAML:2.0:attrname-format:basic`


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->
This PR introduces changes for the new SAML configuration, `Attribute Name Format`, which allows modifying the name format of attributes in a SAML assertion.

## Related Issue
- N/A