### PR TITLE
[IS] Add fido2 user response timeout docs.

### DIFF
--- a/en/identity-server/7.2.0/docs/_data/configuration_catalog.yaml
+++ b/en/identity-server/7.2.0/docs/_data/configuration_catalog.yaml
@@ -1712,6 +1712,21 @@ sections:
 
   # ─────────────────────────── FIDO / PASSKEYS ───────────────────────────
 
+  - id: fido
+    hyperlink: fido
+    title: FIDO
+    tasks: [configure-fido]
+    description: >
+      Configures general FIDO/WebAuthn settings such as the user response timeout for FIDO2 device registration.
+
+    configs:
+      - key: user_response_timeout
+        type: string
+        required: false
+        default: "300000"
+        description: >
+          The time in milliseconds sent as a hint to the browser for how long to wait for the user to interact with their FIDO2 authenticator during device registration. This timeout is enforced by the browser, not the server, and applies only to FIDO2 device registration (not authentication).
+
   - id: fido.metadata_service
     hyperlink: fido-metadata-service
     title: FIDO metadata service

--- a/en/identity-server/next/docs/_data/configuration_catalog.yaml
+++ b/en/identity-server/next/docs/_data/configuration_catalog.yaml
@@ -1712,6 +1712,21 @@ sections:
 
   # ─────────────────────────── FIDO / PASSKEYS ───────────────────────────
 
+  - id: fido
+    hyperlink: fido
+    title: FIDO
+    tasks: [configure-fido]
+    description: >
+      Configures general FIDO/WebAuthn settings such as the user response timeout for FIDO2 device registration.
+
+    configs:
+      - key: user_response_timeout
+        type: string
+        required: false
+        default: "300000"
+        description: >
+          The time in milliseconds sent as a hint to the browser for how long to wait for the user to interact with their FIDO2 authenticator during device registration. This timeout is enforced by the browser, not the server, and applies only to FIDO2 device registration (not authentication).
+
   - id: fido.metadata_service
     hyperlink: fido-metadata-service
     title: FIDO metadata service

--- a/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-passkey.md
+++ b/en/includes/guides/authentication/passwordless-login/add-passwordless-login-with-passkey.md
@@ -186,4 +186,29 @@ To enable this restriction, add the following configuration to the `<IS_HOME>/re
 
 {% endif %}
 
+{% if is_version is defined and is_version >= "7.1.0" %}
+
+## Configure FIDO user response timeout
+
+During FIDO2 device registration, {{ product_name }} sends a timeout hint to the browser indicating how long it should wait for the user to interact with their FIDO2 authenticator. By default, this is set to **300000 milliseconds (5 minutes)**.
+
+!!! note
+    This timeout is enforced by the browser, not by {{ product_name }}, and only applies to **device registration**. It does not affect the authentication flow. Some browsers may override this value based on their own policies.
+
+To change this timeout, add the following configuration to the `<IS_HOME>/repository/conf/deployment.toml` file.
+
+  ```toml
+    [fido]
+    user_response_timeout = "<timeout_in_milliseconds>"
+  ```
+
+For example, to set the timeout to 2 minutes:
+
+  ```toml
+    [fido]
+    user_response_timeout = "120000"
+  ```
+
+{% endif %}
+
 {% include "./fido-trusted-applications.md" %}


### PR DESCRIPTION
This pull request adds documentation for configuring the FIDO2 user response timeout during device registration in Identity Server. It introduces a new configuration option for FIDO/WebAuthn settings, explains its usage, and updates the configuration catalog for both versioned and "next" documentation.

**FIDO2 user response timeout documentation:**

* Added a new section to the configuration catalog (`configuration_catalog.yaml` for both `7.2.0` and `next`) describing the `user_response_timeout` setting under the new `fido` config group, including its default value, type, and description.
* Updated the passwordless login with passkey guide (`add-passwordless-login-with-passkey.md`) to document how to configure the FIDO user response timeout, including TOML configuration examples and a note about browser enforcement and scope of the timeout.