### PR TITLE
Update Helm chart image registry and repository for deployment instructions

### DIFF
--- a/en/includes/deploy/deploy-is-on-kubernetes.md
+++ b/en/includes/deploy/deploy-is-on-kubernetes.md
@@ -87,8 +87,8 @@ There are two ways to install the {{product_name}} using the Helm chart. The Hel
     ```shell
     helm install $RELEASE_NAME wso2/identity-server --version {{is_version}}-2 \
     -n $NAMESPACE \
-    --set deployment.image.registry="wso2" \
-    --set deployment.image.repository="wso2is" \
+    --set deployment.image.registry="registry.wso2.com" \
+    --set deployment.image.repository="wso2is/is" \
     --set deployment.image.tag="{{is_version}}" \
     --set deployment.apparmor.enabled="false"
     ```
@@ -96,8 +96,8 @@ There are two ways to install the {{product_name}} using the Helm chart. The Hel
     ```shell
     helm install $RELEASE_NAME wso2/identity-server --version {{is_version}} \
     -n $NAMESPACE \
-    --set deployment.image.registry="wso2" \
-    --set deployment.image.repository="wso2is" \
+    --set deployment.image.registry="registry.wso2.com" \
+    --set deployment.image.repository="wso2is/is" \
     --set deployment.image.tag="{{is_version}}" \
     --set deployment.apparmor.enabled="false"
     ```
@@ -131,8 +131,8 @@ If you prefer to build the chart from the source, follow the steps below:
 
     ```shell
     helm install $RELEASE_NAME -n $NAMESPACE . \
-    --set deployment.image.registry="wso2" \
-    --set deployment.image.repository="wso2is" \
+    --set deployment.image.registry="registry.wso2.com" \
+    --set deployment.image.repository="wso2is/is" \
     --set deployment.image.tag="{{is_version}}" \
     --set deployment.apparmor.enabled="false"
     ```


### PR DESCRIPTION
This pull request updates the Helm chart installation instructions for deploying the product on Kubernetes. The main change is updating the Docker image registry and repository references to use the new registry and image path.

**Helm Chart Installation Documentation Updates:**

* Changed the Docker image registry from `wso2` to `registry.wso2.com` in all Helm install command examples.
* Updated the Docker image repository from `wso2is` to `wso2is/is` in all Helm install command examples.