### PR TITLE
Enable CIBA on-behalf-of delegation docs for version 7.3.0

### DIFF
--- a/en/includes/guides/agentic-ai/ai-agents/agent-authentication.md
+++ b/en/includes/guides/agentic-ai/ai-agents/agent-authentication.md
@@ -179,7 +179,7 @@ As shown in the above sequence diagram, the flow proceeds as follows.
 9. **Successful Access**
    The request succeeds. The AI agent is now authorized to act on the user’s behalf and access the required resources.
 
-{% if is_version == "next" or product == "asgardeo" %}
+{% if is_version == "7.3.0" or is_version == "next" or product == "asgardeo" %}
 
 ### Using CIBA for on-behalf-of delegation
 


### PR DESCRIPTION
## Summary
  - Updated version conditional to include 7.3.0 for CIBA on-behalf-of delegation documentation
  - The "Using CIBA for on-behalf-of delegation" section is now visible in IS 7.3.0 documentation

  ## Changes
  Modified `agent-authentication.md` to extend the version condition from:
  {% if is_version == "next" or product == "asgardeo" %}

  to:
  {% if is_version == "7.3.0" or is_version == "next" or product == "asgardeo" %}

