### PR TITLE
Document token binding support for non-persistent access tokens (7.3.0)

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/data-dictionary/identity-related-tables.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/data-dictionary/identity-related-tables.md
@@ -254,6 +254,23 @@ the values it contains.
 
 ---
 
+#### IDN_OAUTH2_REFRESH_TOKEN_BINDING
+
+Stores token-binding metadata associated with a refresh token when non-persistent
+access tokens are enabled. The binding row is created at refresh-token issuance
+and looked up during the refresh-token flow so that the new access token inherits
+the original binding (DPoP, certificate, cookie, SSO session, client-request, etc.).
+
+| Column              | Description                                                                                  |
+|---------------------|----------------------------------------------------------------------------------------------|
+| REFRESH_TOKEN_ID    | Foreign key to `IDN_OAUTH2_REFRESH_TOKEN.REFRESH_TOKEN_ID`. Deleted on cascade.              |
+| TOKEN_BINDING_TYPE  | Binding type — e.g. `DPoP`, `certificate`, `cookie`, `sso-session-based`, `client-request`. |
+| TOKEN_BINDING_REF   | Reference identifier used to look up the binding during the refresh flow.                    |
+| TOKEN_BINDING_VALUE | Opaque value bound to the token (e.g. JWK thumbprint for DPoP, x5t#S256 for certificate).    |
+| TENANT_ID           | Tenant ID of the bound token.                                                                |
+
+---
+
 ####  IDN_SCIM_GROUP
 
 When creating a new role in the userstore, the SCIM attributes for the created role are stored in

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/data-dictionary/identity-related-tables.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/data-dictionary/identity-related-tables.md
@@ -254,23 +254,6 @@ the values it contains.
 
 ---
 
-#### IDN_OAUTH2_REFRESH_TOKEN_BINDING
-
-Stores token-binding metadata associated with a refresh token when non-persistent
-access tokens are enabled. The binding row is created at refresh-token issuance
-and looked up during the refresh-token flow so that the new access token inherits
-the original binding (DPoP, certificate, cookie, SSO session, client-request, etc.).
-
-| Column              | Description                                                                                  |
-|---------------------|----------------------------------------------------------------------------------------------|
-| REFRESH_TOKEN_ID    | Foreign key to `IDN_OAUTH2_REFRESH_TOKEN.REFRESH_TOKEN_ID`. Deleted on cascade.              |
-| TOKEN_BINDING_TYPE  | Binding type — e.g. `DPoP`, `certificate`, `cookie`, `sso-session-based`, `client-request`. |
-| TOKEN_BINDING_REF   | Reference identifier used to look up the binding during the refresh flow.                    |
-| TOKEN_BINDING_VALUE | Opaque value bound to the token (e.g. JWK thumbprint for DPoP, x5t#S256 for certificate).    |
-| TENANT_ID           | Tenant ID of the bound token.                                                                |
-
----
-
 ####  IDN_SCIM_GROUP
 
 When creating a new role in the userstore, the SCIM attributes for the created role are stored in

--- a/en/identity-server/7.3.0/docs/deploy/token-persistence.md
+++ b/en/identity-server/7.3.0/docs/deploy/token-persistence.md
@@ -85,7 +85,7 @@ In large-scale WSO2 Identity Server deployments, especially with millions of use
   - **Opaque token generation** will continue to work as expected for applications configured to use opaque tokens.
   - Applications configured for **JWT access token type** will be switched to **non-persistent access token mode**, meaning JWT access tokens will no longer be stored in the database.
 - In the case of persistent token storage, if an active access token already exists during the token generation flow, the existing token will be marked as inactive. However, in the non-persistent mode, multiple active tokens can exist, as the authorization server does not store the access tokens.
-- **Token binding**, **Retrieving authorized apps for user**,**Rich Authorization Details**,  and **OIDC Request Object** features are currently not supported in **non-persistent access token mode**.
+- **Retrieving authorized apps for user**, **Rich Authorization Details**, and **OIDC Request Object** features are currently not supported in **non-persistent access token mode**.
 - Actions like revoking issued access tokens when re-submitting an authorization code and revoking all issued access tokens when revoking refresh tokens are also not supported, because the Identity Server does not store access tokens in this mode.
 - In non-persistent mode, the cleanup deletes the selected entries; they are not moved to an audit table as in the persistent case.
 


### PR DESCRIPTION
- Remove "Token binding" from the list of features unsupported in non-persistent access token mode in deploy/token-persistence.md.
- Add IDN_OAUTH2_REFRESH_TOKEN_BINDING table to the identity data dictionary so admins can reference the new schema introduced for refresh-token-anchored token binding continuity.

Related: https://github.com/wso2/product-is/issues/27808

## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


