### PR TITLE
Fix accountDisabled attribute name

### DIFF
--- a/en/identity-server/6.0.0/docs/guides/identity-lifecycles/enable-account.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-lifecycles/enable-account.md
@@ -96,10 +96,10 @@ management console.
 
 	7.	Click **User Profile** adjecent to the user that needs to be enabled or disabled. The **User ID** value will be mentioned by default now. 
 
-2.	After obtaining the SCIM ID of the user, invoke the following curl command with the `accountDisable` attribute set to `true` or `false` to disable or enable the user account respectively.
+2.	After obtaining the SCIM ID of the user, invoke the following curl command with the `accountDisabled` attribute set to `true` or `false` to disable or enable the user account respectively.
 
 	```curl 
-	curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","value":{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"accountDisable":"true"}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/<User-ID>
+	curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","value":{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"accountDisabled":"true"}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/<User-ID>
 	```
 
 After setting the disable status to `true` for a particular user, the server should reject any authentication attempts done by that account.

--- a/en/identity-server/6.1.0/docs/guides/identity-lifecycles/enable-account.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-lifecycles/enable-account.md
@@ -96,10 +96,10 @@ management console.
 
 	7.	Click **User Profile** adjecent to the user that needs to be enabled or disabled. The **User ID** value will be mentioned by default now. 
 
-2.	After obtaining the SCIM ID of the user, invoke the following curl command with the `accountDisable` attribute set to `true` or `false` to disable or enable the user account respectively.
+2.	After obtaining the SCIM ID of the user, invoke the following curl command with the `accountDisabled` attribute set to `true` or `false` to disable or enable the user account respectively.
 
 	```curl 
-	curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","value":{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"accountDisable":"true"}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/<User-ID>
+	curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","value":{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"accountDisabled":"true"}}}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/<User-ID>
 	```
 
 After setting the disable status to `true` for a particular user, the server should reject any authentication attempts done by that account.


### PR DESCRIPTION
This pull request updates the documentation for enabling or disabling user accounts to correct the attribute name used in SCIM API calls. The attribute `accountDisable` has been replaced with the correct `accountDisabled` in both the description and the example curl command.

**Documentation corrections:**

* Updated the SCIM API attribute from `accountDisable` to `accountDisabled` in both the instructions and the example curl command in `enable-account.md` for versions 6.0.0 and 6.1.0.

### Related Issues
- https://github.com/wso2/product-is/issues/27839