### PR TITLE
Address review comments on #5956.

### DIFF
--- a/en/includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md
+++ b/en/includes/guides/authentication/conditional-auth/otp-retry-resend-limits.md
@@ -65,7 +65,7 @@ Once a user reaches either limit, the login flow blocks further retries or resen
 5. Click **Update** to save the script.
 
 !!! note "Account lock takes precedence"
-    If {{ product_name }} locks the user account (for example, due to too many failed login attempts at the tenant level) before the user reaches <code>maximumAllowedFailureAttempts</code>, the account lock ends the authentication flow immediately.
+    If {{ product_name }} locks the user account (for example, due to too many failed login attempts at the organization level) before the user reaches <code>maximumAllowedFailureAttempts</code>, the account lock ends the authentication flow immediately.
 
 !!! note "Connection-level resend block"
     You can also configure a resend block at the connection level using settings such as **Allowed OTP resend attempt count** and **Resend block duration**. If the connection-level block triggers before the application-level limit (<code>maximumAllowedResendAttempts</code>), the connection temporarily blocks resend requests for the configured duration.


### PR DESCRIPTION
Fixes review comments on

- [ ] https://github.com/wso2/docs-is/pull/5956

This pull request updates the documentation to clarify the behavior of account locking during authentication flows. The main change is to specify that account locks occur at the organization level, not the tenant level, which helps prevent confusion about where lockouts are enforced.

Documentation clarification:

* Updated the note in `otp-retry-resend-limits.md` to state that user accounts are locked at the organization level (rather than the tenant level) if there are too many failed login attempts, ending the authentication flow immediately.