### PR TITLE
fix: useAsgardeo import examples in SDK 

### DIFF
--- a/en/includes/sdks/nextjs/hooks/use-asgardeo.md
+++ b/en/includes/sdks/nextjs/hooks/use-asgardeo.md
@@ -9,7 +9,7 @@ The `useAsgardeo` hook provides access to the Asgardeo authentication context in
 Import and use the hook in any functional component to access authentication data:
 
 ```typescript
-import useAsgardeo from '@asgardeo/nextjs';
+import { useAsgardeo } from '@asgardeo/nextjs';
 
 const MyComponent = () => {
   const { isSignedIn, user, signIn, signOut } = useAsgardeo();
@@ -30,21 +30,23 @@ const MyComponent = () => {
 ```
 
 !!! info "Note"
-    This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
+This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
 
 ## API
 
 The hook returns all properties and methods provided by `AsgardeoContextProps`:
 
 <!-- markdownlint-disable MD056 -->
-| Property            | Type                                         | Description                                                      |
-|---------------------|----------------------------------------------|------------------------------------------------------------------|
-| `isSignedIn`        | `boolean`                                    | Whether the user is currently signed in                          |
-| `user`              | `IUser | null`                              | The authenticated user object, or `null` if not signed in        |
-| `signIn`            | `() => Promise<void>`                        | Initiates the sign-in flow                                       |
-| `signOut`           | `() => Promise<void>`                        | Initiates the sign-out flow                                      |
-| `loading`           | `boolean`                                    | Indicates if an authentication operation is in progress          |
-| `error`             | `Error | null`                              | The last error encountered during authentication, if any         |
+
+| Property     | Type                  | Description                                             |
+| ------------ | --------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| `isSignedIn` | `boolean`             | Whether the user is currently signed in                 |
+| `user`       | `IUser                | null`                                                   | The authenticated user object, or `null` if not signed in |
+| `signIn`     | `() => Promise<void>` | Initiates the sign-in flow                              |
+| `signOut`    | `() => Promise<void>` | Initiates the sign-out flow                             |
+| `loading`    | `boolean`             | Indicates if an authentication operation is in progress |
+| `error`      | `Error                | null`                                                   | The last error encountered during authentication, if any  |
+
 <!-- markdownlint-enable MD056 -->
 
 ## Error Handling

--- a/en/includes/sdks/nextjs/hooks/use-asgardeo.md
+++ b/en/includes/sdks/nextjs/hooks/use-asgardeo.md
@@ -51,7 +51,7 @@ The hook returns all properties and methods provided by `AsgardeoContextProps`:
 
 If `useAsgardeo` is called outside of an `AsgardeoProvider`, it throws:
 
-```
+```text
 Error: useAsgardeo must be used within an AsgardeoProvider
 ```
 

--- a/en/includes/sdks/nextjs/hooks/use-asgardeo.md
+++ b/en/includes/sdks/nextjs/hooks/use-asgardeo.md
@@ -30,23 +30,21 @@ const MyComponent = () => {
 ```
 
 !!! info "Note"
-This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
+    This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
 
 ## API
 
 The hook returns all properties and methods provided by `AsgardeoContextProps`:
 
 <!-- markdownlint-disable MD056 -->
-
-| Property     | Type                  | Description                                             |
-| ------------ | --------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
-| `isSignedIn` | `boolean`             | Whether the user is currently signed in                 |
-| `user`       | `IUser                | null`                                                   | The authenticated user object, or `null` if not signed in |
-| `signIn`     | `() => Promise<void>` | Initiates the sign-in flow                              |
-| `signOut`    | `() => Promise<void>` | Initiates the sign-out flow                             |
-| `loading`    | `boolean`             | Indicates if an authentication operation is in progress |
-| `error`      | `Error                | null`                                                   | The last error encountered during authentication, if any  |
-
+| Property            | Type                                         | Description                                                      |
+|---------------------|----------------------------------------------|------------------------------------------------------------------|
+| `isSignedIn`        | `boolean`                                    | Whether the user is currently signed in                          |
+| `user`              | `IUser | null`                              | The authenticated user object, or `null` if not signed in        |
+| `signIn`            | `() => Promise<void>`                        | Initiates the sign-in flow                                       |
+| `signOut`           | `() => Promise<void>`                        | Initiates the sign-out flow                                      |
+| `loading`           | `boolean`                                    | Indicates if an authentication operation is in progress          |
+| `error`             | `Error | null`                              | The last error encountered during authentication, if any         |
 <!-- markdownlint-enable MD056 -->
 
 ## Error Handling

--- a/en/includes/sdks/react/hooks/use-asgardeo.md
+++ b/en/includes/sdks/react/hooks/use-asgardeo.md
@@ -9,7 +9,7 @@ The `useAsgardeo` hook provides access to the Asgardeo authentication context in
 Import and use the hook in any functional component to access authentication data:
 
 ```typescript
-import useAsgardeo from '@asgardeo/react';
+import { useAsgardeo } from '@asgardeo/react';
 
 const MyComponent = () => {
   const { isSignedIn, user, signIn, signOut } = useAsgardeo();
@@ -30,21 +30,23 @@ const MyComponent = () => {
 ```
 
 !!! info "Note"
-    This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
+This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
 
 ## API
 
 The hook returns all properties and methods provided by `AsgardeoContextProps`:
 
 <!-- markdownlint-disable MD056 -->
-| Property            | Type                                         | Description                                                      |
-|---------------------|----------------------------------------------|------------------------------------------------------------------|
-| `isSignedIn`        | `boolean`                                    | Whether the user is currently signed in                          |
-| `user`              | `IUser | null`                              | The authenticated user object, or `null` if not signed in        |
-| `signIn`            | `() => Promise<void>`                        | Initiates the sign-in flow                                       |
-| `signOut`           | `() => Promise<void>`                        | Initiates the sign-out flow                                      |
-| `loading`           | `boolean`                                    | Indicates if an authentication operation is in progress          |
-| `error`             | `Error | null`                              | The last error encountered during authentication, if any         |
+
+| Property     | Type                  | Description                                             |
+| ------------ | --------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| `isSignedIn` | `boolean`             | Whether the user is currently signed in                 |
+| `user`       | `IUser                | null`                                                   | The authenticated user object, or `null` if not signed in |
+| `signIn`     | `() => Promise<void>` | Initiates the sign-in flow                              |
+| `signOut`    | `() => Promise<void>` | Initiates the sign-out flow                             |
+| `loading`    | `boolean`             | Indicates if an authentication operation is in progress |
+| `error`      | `Error                | null`                                                   | The last error encountered during authentication, if any  |
+
 <!-- markdownlint-enable MD056 -->
 
 ## Error Handling

--- a/en/includes/sdks/react/hooks/use-asgardeo.md
+++ b/en/includes/sdks/react/hooks/use-asgardeo.md
@@ -30,23 +30,21 @@ const MyComponent = () => {
 ```
 
 !!! info "Note"
-This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
+    This hook must be used inside a component rendered by `AsgardeoProvider`. Otherwise, it will throw an error.
 
 ## API
 
 The hook returns all properties and methods provided by `AsgardeoContextProps`:
 
 <!-- markdownlint-disable MD056 -->
-
-| Property     | Type                  | Description                                             |
-| ------------ | --------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
-| `isSignedIn` | `boolean`             | Whether the user is currently signed in                 |
-| `user`       | `IUser                | null`                                                   | The authenticated user object, or `null` if not signed in |
-| `signIn`     | `() => Promise<void>` | Initiates the sign-in flow                              |
-| `signOut`    | `() => Promise<void>` | Initiates the sign-out flow                             |
-| `loading`    | `boolean`             | Indicates if an authentication operation is in progress |
-| `error`      | `Error                | null`                                                   | The last error encountered during authentication, if any  |
-
+| Property            | Type                                         | Description                                                      |
+|---------------------|----------------------------------------------|------------------------------------------------------------------|
+| `isSignedIn`        | `boolean`                                    | Whether the user is currently signed in                          |
+| `user`              | `IUser | null`                              | The authenticated user object, or `null` if not signed in        |
+| `signIn`            | `() => Promise<void>`                        | Initiates the sign-in flow                                       |
+| `signOut`           | `() => Promise<void>`                        | Initiates the sign-out flow                                      |
+| `loading`           | `boolean`                                    | Indicates if an authentication operation is in progress          |
+| `error`             | `Error | null`                              | The last error encountered during authentication, if any         |
 <!-- markdownlint-enable MD056 -->
 
 ## Error Handling


### PR DESCRIPTION
## Purpose
Updated the useAsgardeo import examples in the React and Next.js SDK documentation to keep them consistent with other SDK documentation examples.
## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


