### PR TITLE
Fix WS-Trust STS client note rendered as code block

### DIFF
--- a/en/identity-server/5.11.0/docs/learn/running-an-sts-client.md
+++ b/en/identity-server/5.11.0/docs/learn/running-an-sts-client.md
@@ -27,5 +27,5 @@ To run the STS client:
 
 You can see that the SAML token issued from the STS is being printed by the client.
 
-    !!! note
-        The `connection refused` error occurs when the STS client attempts to send the received SAML token to a service that is not running in this case.
+!!! note
+    The `connection refused` error occurs when the STS client attempts to send the received SAML token to a service that is not running in this case.

--- a/en/identity-server/6.0.0/docs/includes/running-an-sts-client.md
+++ b/en/identity-server/6.0.0/docs/includes/running-an-sts-client.md
@@ -27,5 +27,5 @@ To run the STS client:
 
 You can see that the SAML token issued from the STS is being printed by the client.
 
-    !!! note
-        The `connection refused` error occurs when the STS client attempts to send the received SAML token to a service that is not running in this case.
+!!! note
+    The `connection refused` error occurs when the STS client attempts to send the received SAML token to a service that is not running in this case.

--- a/en/identity-server/6.1.0/docs/includes/running-an-sts-client.md
+++ b/en/identity-server/6.1.0/docs/includes/running-an-sts-client.md
@@ -27,5 +27,5 @@ To run the STS client:
 
 You can see that the SAML token issued from the STS is being printed by the client.
 
-    !!! note
-        The `connection refused` error occurs when the STS client attempts to send the received SAML token to a service that is not running in this case.
+!!! note
+    The `connection refused` error occurs when the STS client attempts to send the received SAML token to a service that is not running in this case.


### PR DESCRIPTION

## Purpose
Fixes a Markdown rendering bug in the "Run a sample STS Client" documentation. The !!! note admonition explaining the connection refused error was indented 4 spaces directly after a top-level paragraph. Because the preceding paragraph is not a list item, MkDocs/Python-Markdown interpreted the indented block as a code block rather than an admonition so the note rendered as a gray box showing the literal !!! note text instead of a styled "Note".

The fix reverses the indented admonition (and its body) to column 0 so it renders correctly as a note callout. Applied across  IS versions listed below.

- en/identity-server/5.11.0/docs/learn/running-an-sts-client.md
- en/identity-server/6.0.0/docs/includes/running-an-sts-client.md
- en/identity-server/6.1.0/docs/includes/running-an-sts-client.md

**Before**
<img width="811" height="154" alt="before bug" src="https://github.com/user-attachments/assets/81509b0a-8746-475a-8f4c-5dcba8aac10f" />

**After**
<img width="826" height="209" alt="bug fixed" src="https://github.com/user-attachments/assets/ba04c80f-4a33-40d6-b05b-292689add2e5" />


## Related PRs
N/A

## Test environment
Verified locally by building and serving each affected docs site with MkDocs (mkdocs serve)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


