### PR TITLE
Fix formatting of administrator capabilities list

### DIFF
--- a/en/identity-server/7.3.0/docs/guides/users/index.md
+++ b/en/identity-server/7.3.0/docs/guides/users/index.md
@@ -16,7 +16,7 @@ WSO2 Identity Server supports the following types of user accounts based on thei
 
 ### Administrator
 
-An administrator can manage the organization and has access to the organization's administrative operations. Administrators can,
+An administrator can manage the organization and has access to the organization's administrative operations. Administrators can:
 
 * onboard users
 * manage users, roles and groups


### PR DESCRIPTION
- Changed "Administrators can," to "Administrators can:"
- Capitalized list items for consistency
- Added Oxford comma after "roles" for clarity
- Formatted as a proper bulleted list

## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


