### PR TITLE
Add PAR request cleanup guide

### DIFF
--- a/en/asgardeo/.spelling
+++ b/en/asgardeo/.spelling
@@ -13,6 +13,7 @@ choreo-concepts
 id_token
 RequestFlow
 ResponseFlow
+Referer
 FaultFlow
 choreo-apim-mediation-fault-flow
 http

--- a/en/includes/guides/authentication/oidc/implement-login-with-par.md
+++ b/en/includes/guides/authentication/oidc/implement-login-with-par.md
@@ -89,23 +89,24 @@ client_id=DUBCMGolTZQNg6mmE9GvfQ3qfq8a
 
 {% if product_name == "WSO2 Identity Server" %}
 
-## Clean up PAR requests
+## Clean up stale PAR request records
 
-Each pushed authorization request creates a record in the `IDN_OAUTH_PAR` table. When a `request_uri` is not claimed by the `/authorize` endpoint or expires before use, the record remains in the table. Without periodic cleanup, this table can grow over time and negatively impact server performance.
+Each pushed authorization request creates a record in the `IDN_OAUTH_PAR` table. When a `request_uri` is not used or expired before use, the records remain in the table. Without periodic cleanup, this table can grow over time and negatively impact server performance.
 
-To prevent this, clean up unclaimed and expired PAR requests periodically.
+To prevent this, it is recommended to clean up unclaimed and expired PAR requests periodically.
 
 !!! tip
-    Run these scripts during a time when traffic on the server is low. You can also set `backupTables` to `TRUE` in the script to back up the records before deletion, enabling a restore if needed.
+    Run these scripts during a low traffic time window. You can also set `backupTables` to `TRUE` in the script to back up the records before deletion, enabling a restore if needed.
 
-1. Depending on your database, select the appropriate PAR request cleanup script from the links below and run it on the database.
+Depending on your database, select the appropriate PAR request cleanup script from the links below and run it on the database.
 
-    - [DB2](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/db2/par-request-cleanup/){:target="_blank"}
-    - [MSSQL](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mssql/par-request-cleanup/){:target="_blank"}
-    - [MySQL](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/par-request-cleanup/){:target="_blank"}
-    - [Oracle](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/par-request-cleanup/){:target="_blank"}
-    - [PostgreSQL 11.X](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/par-request-cleanup/){:target="_blank"}
+- [DB2](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/db2/par-request-cleanup/){:target="_blank"}
+- [MSSQL](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mssql/par-request-cleanup/){:target="_blank"}
+- [MySQL](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/par-request-cleanup/){:target="_blank"}
+- [Oracle](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/par-request-cleanup/){:target="_blank"}
+- [PostgreSQL 11.X](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/par-request-cleanup/){:target="_blank"}
 
-2. Once the cleanup is complete, you can schedule a periodic cleanup task to automate future runs.
+!!! note
+    Once the cleanup is complete, you can schedule a periodic cleanup task to automate future runs.
 
 {% endif %}

--- a/en/includes/guides/authentication/oidc/implement-login-with-par.md
+++ b/en/includes/guides/authentication/oidc/implement-login-with-par.md
@@ -86,3 +86,26 @@ client_id={CLIENT_ID}&request_uri={request_uri}
 client_id=DUBCMGolTZQNg6mmE9GvfQ3qfq8a
 &request_uri=urn:ietf:params:oauth:par:request_uri:a0cf571e-fe97-411a-8f33-3c01913c0e5f
 ```
+
+{% if product_name == "WSO2 Identity Server" %}
+
+## Clean up PAR requests
+
+Each pushed authorization request creates a record in the `IDN_OAUTH_PAR` table. When a `request_uri` is not claimed by the `/authorize` endpoint or expires before use, the record remains in the table. Without periodic cleanup, this table can grow over time and negatively impact server performance.
+
+To prevent this, clean up unclaimed and expired PAR requests periodically.
+
+!!! tip
+    Run these scripts during a time when traffic on the server is low. You can also set `backupTables` to `TRUE` in the script to back up the records before deletion, enabling a restore if needed.
+
+1. Depending on your database, select the appropriate PAR request cleanup script from the links below and run it on the database.
+
+    - [DB2](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/db2/par-request-cleanup/){:target="_blank"}
+    - [MSSQL](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mssql/par-request-cleanup/){:target="_blank"}
+    - [MySQL](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/par-request-cleanup/){:target="_blank"}
+    - [Oracle](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/par-request-cleanup/){:target="_blank"}
+    - [PostgreSQL 11.X](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/par-request-cleanup/){:target="_blank"}
+
+2. Once the cleanup is complete, you can schedule a periodic cleanup task to automate future runs.
+
+{% endif %}

--- a/en/includes/guides/authentication/oidc/private-key-jwt-client-auth.md
+++ b/en/includes/guides/authentication/oidc/private-key-jwt-client-auth.md
@@ -129,6 +129,9 @@ Listed below are the main steps for invoking the token endpoint and acquiring an
         - `client_assertion`: The authentication token (JWT assertion) must be sent as the value of this parameter.
         - `client_assertion_type`: The value of this parameter must be `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
 
+    !!! warning
+        Send the `client_assertion` (and the client secret, if you use the `client_secret_basic` or `client_secret_post` method) as form parameters in the body of the `POST` request to the token endpoint. Never send these credentials in custom HTTP headers or as URL query parameters, where they can leak through server logs, browser history, and the `Referer` header.
+
 2. The authorization server verifies the JWT using the public key.
 3. Authorization server extracts the signature using the public key and authenticates the client.
 4. The access token is granted if the client is successfully authenticated.

--- a/en/includes/references/tokens/access-tokens.md
+++ b/en/includes/references/tokens/access-tokens.md
@@ -4,6 +4,9 @@ An access token is a short-lived credential that a client presents to a resource
 
 Access tokens are sent in the HTTP `Authorization: Bearer` header when calling protected APIs. They represent delegated authorization — what the client is permitted to do — rather than who the user is.
 
+!!! warning
+    Never send access tokens as URL query parameters in GET requests. Tokens in URLs can leak through server logs, browser history, and the `Referer` header. Always send them in the `Authorization: Bearer` header.
+
 ## Token types
 
 {{product_name}} supports the following access token types.

--- a/en/includes/references/tokens/refresh-tokens.md
+++ b/en/includes/references/tokens/refresh-tokens.md
@@ -7,6 +7,8 @@ Refresh tokens are only issued when the `Refresh Token` grant type is enabled fo
 !!! warning
     A valid refresh token can get new access tokens at any time. Store refresh tokens securely — treat them with the same care as passwords or other long-lived credentials.
 
+    Never send refresh tokens as URL query parameters in GET requests. Tokens in URLs can leak through server logs, browser history, and the `Referer` header. Always send them as form parameters in the body of the `POST` request to the token endpoint.
+
 ## Refresh token rotation
 
 By default, whenever the refresh token is exchanged for a new access token, {{product_name}} issues the same refresh token back, as long as it has not expired.


### PR DESCRIPTION
## Purpose

Adds documentation for cleaning up PAR request records and clarifies how tokens
and client credentials should be transmitted.

## Changes

- Added a **Clean up PAR requests** section to the PAR guide, with links to the
  per-database cleanup scripts (DB2, MSSQL, MySQL, Oracle, PostgreSQL). Shown for
  WSO2 Identity Server only.
- Added notes on sending access tokens and refresh tokens in the request body /
  `Authorization` header rather than as URL query parameters.
- Added a note to the private key JWT guide on sending the client assertion as a
  form parameter in the token request.
- Added `Referer` to the spelling dictionary.

## Related docs

- Access tokens, refresh tokens, private key JWT client authentication, PAR guide


<img width="1099" height="684" alt="Screenshot 2026-06-17 at 18 42 21" src="https://github.com/user-attachments/assets/a3ce8b29-68db-457e-a5a3-92c4221e518f" />
<img width="892" height="407" alt="Screenshot 2026-06-17 at 18 44 34" src="https://github.com/user-attachments/assets/26dba2b9-35af-4186-93dc-7f15d391594f" />
<img width="892" height="478" alt="Screenshot 2026-06-17 at 18 45 03" src="https://github.com/user-attachments/assets/dd335469-2f93-40a4-9f5b-ac0175201f00" />
<img width="892" height="567" alt="Screenshot 2026-06-17 at 18 45 21" src="https://github.com/user-attachments/assets/ed5fdca1-71ad-4a3c-bb4d-9c0a181731a1" />


