### PR TITLE
Fix inconsistent maxWait value in DB2 and PostgreSQL DB pool config samples

### DIFF
--- a/en/identity-server/5.10.0/docs/setup/changing-to-ibm-db2.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-ibm-db2.md
@@ -131,7 +131,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
@@ -145,7 +145,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"

--- a/en/identity-server/5.11.0/docs/setup/changing-to-ibm-db2.md
+++ b/en/identity-server/5.11.0/docs/setup/changing-to-ibm-db2.md
@@ -131,7 +131,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
@@ -145,7 +145,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"

--- a/en/identity-server/6.0.0/docs/deploy/change-to-ibm-db2.md
+++ b/en/identity-server/6.0.0/docs/deploy/change-to-ibm-db2.md
@@ -88,7 +88,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -102,7 +102,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/6.0.0/docs/deploy/change-to-postgresql.md
+++ b/en/identity-server/6.0.0/docs/deploy/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/6.1.0/docs/deploy/change-to-ibm-db2.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-ibm-db2.md
@@ -87,7 +87,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -101,7 +101,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/6.1.0/docs/deploy/change-to-postgresql.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-postgresql.md
@@ -79,7 +79,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -93,7 +93,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -77,7 +77,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -91,7 +91,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -77,7 +77,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -91,7 +91,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -1,0 +1,141 @@
+# Change to IBM DB2
+
+By default, WSO2 Identity Server uses the embedded H2 database as the database
+for storing user management and registry data. Given below are the steps
+you need to follow in order to use DB2 for this purpose.
+    
+---
+
+## Datasource configurations
+
+{% include "../../../../includes/datasource-config.md" %}
+                       
+After setting up the DB2 database, you can point the `WSO2_IDENTITY_DB` or 
+`WSO2_SHARED_DB`, or both to the DB2 database by following the instructions given below.
+
+---
+
+## Change the default datasource
+
+### Minimum configurations for changing default datasource to DB2
+ 
+You can configure the datasource by editing the default configurations in `<IS_HOME>/repository/conf/deployment.toml`. 
+
+Following are the basic configurations and their descriptions. 
+
+{% include "../../../../includes/db-basic-config.md" %}
+
+A sample configuration is given below.
+
+1. `WSO2_IDENTITY_DB` 
+
+	1. Configure the `deployment.toml` file.
+
+		``` toml
+		[database.identity_db]
+		type = "db2"
+		hostname = "localhost"
+		name = "regdb"
+		username = "regadmin"
+		password = "regadmin"
+		port = "50000"
+		```
+	
+	1. Execute database scripts.
+	
+		Navigate to `<IS_HOME>/dbscripts`. Execute the scripts in the following files, against the database created.
+		
+		- `<IS_HOME>/dbscripts/identity/db2.sql`
+		- `<IS_HOME>/dbscripts/consent/db2.sql`
+
+		!!! info 
+			While running the DB2 scripts via the terminal, use the following DB2 command to run the DB2 scripts with the delimeter "/" since the default delimiter script for DB2 is ";". 
+			```xml
+			db2 -td/ -f db2.sql
+			```		
+		
+2. `WSO2_SHARED_DB`
+	
+	1.	Configure the `deployment.toml` file.
+
+		``` toml
+		[database.shared_db]
+		type = "db2"
+		hostname = "localhost"
+		name = "regdb"
+		username = "regadmin"
+		password = "regadmin"
+		port = "50000"
+		```
+		
+	1.	Execute database scripts.
+	
+		Execute the scripts in the `<IS_HOME>/dbscripts/db2.sql` file, against the database created.
+	
+3.	Download the [DB2 JDBC driver](https://mvnrepository.com/artifact/com.ibm.db2/jcc) and copy the JAR (jcc-x.x.x.jar) to the `<IS_HOME>/repository/components/lib` folder.
+
+---
+
+### Advanced database configurations
+
+Apart from the basic configurations specified above, WSO2 Identity Server supports some advanced database configurations as well.
+
+-	`WSO2_IDENTITY_DB` related configurations that should be added to the `deployment.toml` file.
+
+	``` toml
+	[database.identity_db.pool_options]
+	maxActive = "80"
+	maxWait = "60000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
+
+-	`WSO2_SHARED_DB` `deployment.toml` related configurations that should be added to the `deployment.toml` file.
+
+	```toml
+	[database.shared_db.pool_options]
+	maxActive = "80"
+	maxWait = "60000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
+
+{% include "../../../../includes/db-config-table.md" %}
+
+---
+
+## Configure the connection pool behavior on return 
+
+{% include "../../../../includes/connection-pool-behavior.md" %}
+
+### Configure the connection pool to commit pending transactions on connection return
+        
+{% include "../../../../includes/commit-pending.md" %}
+
+### Configure the connection pool to rollback pending transactions on connection return
+
+{% include "../../../../includes/rollback-pending.md" %}
+
+## Driver-Level Timeouts (Recommended for Production)
+
+{% include "../../../../includes/driver-level-timeouts.md" %}
+
+### Example: IBM DB2 database
+
+```toml
+[database.identity_db]
+url = "jdbc:db2://DB_HOST:50000/WSO2_IDENTITY_DB:loginTimeout=10;queryTimeout=60;"
+username = "..."
+password = "..."
+driver = "com.ibm.db2.jcc.DB2Driver"
+```
+
+Learn more in [IBM DB2 connection settings](https://www.ibm.com/docs/en/db2/11.5?topic=client-jdbc-properties){: target="_blank"}.

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -1,0 +1,136 @@
+# Change to PostgreSQL
+
+By default, WSO2 Identity Server uses the embedded H2 database as the database
+for storing user management and registry data. Given below are the steps
+you need to follow in order to use PostgreSQL for this purpose.
+
+---
+
+## Datasource configurations
+
+{% include "../../../../includes/datasource-config.md" %}
+                       
+After setting up the PostgreSQL database, you can point the `WSO2_IDENTITY_DB` or 
+`WSO2_SHARED_DB` or both to that PostgreSQL database by following the instructions given below.
+
+---
+
+## Change the default datasource
+
+### Minimum configurations for changing the default datasource to PostgreSQL
+ 
+You can configure the datasource by editing the default configurations in `<IS_HOME>/repository/conf/deployment.toml`. Following are the basic configurations and their descriptions. 
+
+{% include "../../../../includes/db-basic-config.md" %}
+ 
+A sample configuration is given below.
+
+1. `WSO2_IDENTITY_DB` 
+
+    1. Configure the `deployment.toml` file.
+
+        ``` toml
+        [database.identity_db]
+        type = "postgre"
+        hostname = "localhost"
+        name = "testdb"
+        username = "regadmin"
+        password = "regadmin"
+        port = "5432"
+        ```
+    
+    2.  Execute database scripts.
+    
+        Execute the scripts in the following files, against the database created.
+        
+        - `<IS_HOME>/dbscripts/identity/postgresql.sql`
+        - `<IS_HOME>/dbscripts/consent/postgresql.sql`
+
+        !!! info
+            For stored procedures, use the scripts in the `<IS_HOME>/dbscripts/identity/stored-procedures/postgresql/postgre-11x` folder. The supported PostgreSQL versions (15.10, 16.6, 17.4) are compatible with the 11x stored procedures.
+        
+2. `WSO2_SHARED_DB`
+    
+    1.  Configure the `deployment.toml` file.
+
+        ``` toml
+        [database.shared_db]
+        type = "postgre"
+        hostname = "localhost"
+        name = "testdb"
+        username = "regadmin"
+        password = "regadmin"
+        port = "5432"
+        ```
+        
+    2.  Execute database scripts.
+    
+        Execute the scripts in the `<IS_HOME>/dbscripts/postgresql.sql` file against the database created.
+    
+3.  Download the [PostgreSQL JDBC driver](https://mvnrepository.com/artifact/org.postgresql/postgresql) and copy the JAR (postgresql-x.x.x.jar) to the `<IS_HOME>/repository/components/lib` folder.
+
+---           
+
+### Advanced database configurations
+
+Apart from the basic configurations specified above, WSO2 Identity Server supports some advanced database configurations as well.
+
+-	`WSO2_IDENTITY_DB` related configurations that should be added to the `deployment.toml` file.
+    
+	``` toml
+	[database.identity_db.pool_options]
+	maxActive = "80"
+	maxWait = "60000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery="SELECT 1; COMMIT"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
+   
+-	`WSO2_SHARED_DB` `deployment.toml` related configurations that should be added to the `deployment.toml` file.
+	
+	```toml
+	[database.shared_db.pool_options]
+	maxActive = "80"
+	maxWait = "60000"
+	minIdle ="5"
+	testOnBorrow = true
+	validationQuery="SELECT 1; COMMIT"
+	validationInterval="30000"
+	defaultAutoCommit=false
+	commitOnReturn=true
+	```
+
+{% include "../../../../includes/db-config-table.md" %}
+
+---
+  
+## Configure the connection pool behavior on return 
+
+{% include "../../../../includes/connection-pool-behavior.md" %}
+
+### Configure the connection pool to commit pending transactions on connection return
+        
+{% include "../../../../includes/commit-pending.md" %}
+
+### Configure the connection pool to rollback pending transactions on connection return
+
+{% include "../../../../includes/rollback-pending.md" %}
+
+## Driver-Level Timeouts (Recommended for Production)
+
+{% include "../../../../includes/driver-level-timeouts.md" %}
+
+### Example: PostgreSQL database
+
+```toml
+[database.identity_db]
+url = "jdbc:postgresql://DB_HOST:5432/WSO2_IDENTITY_DB?connectTimeout=10&socketTimeout=60&tcpKeepAlive=true"
+username = "..."
+password = "..."
+driver = "org.postgresql.Driver"
+```
+
+Learn more in [PostgreSQL JDBC connection parameters](https://jdbc.postgresql.org/documentation/use/#connection-parameters){: target="_blank"}.

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"


### PR DESCRIPTION
## Summary

The `maxWait` value in the sample DB pool configurations for DB2 and PostgreSQL documentation was set to `360000` ms (6 minutes), while all other database type documentation used `60000` ms (1 minute). This PR unifies the value to `60000` ms across all affected versions.

**Affected versions:** IS 5.10.0 – 7.3.0 (+ next)

**Files changed (16):**
- `change-to-ibm-db2.md` — 5.10.0, 5.11.0, 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0, 7.3.0, next
- `change-to-postgresql.md` — 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0, 7.3.0, next

> Note: PostgreSQL docs for 5.10.0 and 5.11.0 already had the correct value (60000) and were not modified.

Fixes: https://github.com/wso2/product-is/issues/27975