### PR TITLE
Fix inconsistent maxWait value in DB2 and PostgreSQL DB pool config samples

### DIFF
--- a/en/identity-server/5.10.0/docs/setup/changing-to-ibm-db2.md
+++ b/en/identity-server/5.10.0/docs/setup/changing-to-ibm-db2.md
@@ -131,7 +131,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
@@ -145,7 +145,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"

--- a/en/identity-server/5.11.0/docs/setup/changing-to-ibm-db2.md
+++ b/en/identity-server/5.11.0/docs/setup/changing-to-ibm-db2.md
@@ -131,7 +131,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
@@ -145,7 +145,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"

--- a/en/identity-server/6.0.0/docs/deploy/change-to-ibm-db2.md
+++ b/en/identity-server/6.0.0/docs/deploy/change-to-ibm-db2.md
@@ -88,7 +88,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -102,7 +102,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/6.0.0/docs/deploy/change-to-postgresql.md
+++ b/en/identity-server/6.0.0/docs/deploy/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/6.1.0/docs/deploy/change-to-ibm-db2.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-ibm-db2.md
@@ -87,7 +87,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -101,7 +101,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/6.1.0/docs/deploy/change-to-postgresql.md
+++ b/en/identity-server/6.1.0/docs/deploy/change-to-postgresql.md
@@ -79,7 +79,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -93,7 +93,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.0.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -77,7 +77,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -91,7 +91,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.1.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.2.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -85,7 +85,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"
@@ -99,7 +99,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery = "SELECT 1 FROM sysibm.sysdummy1"

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-postgresql.md
@@ -80,7 +80,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	``` toml
 	[database.identity_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"
@@ -94,7 +94,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 	```toml
 	[database.shared_db.pool_options]
 	maxActive = "80"
-	maxWait = "360000"
+	maxWait = "60000"
 	minIdle ="5"
 	testOnBorrow = true
 	validationQuery="SELECT 1; COMMIT"


### PR DESCRIPTION
## Summary

The `maxWait` value in the sample DB pool configurations for DB2 and PostgreSQL documentation was set to `360000` ms (6 minutes), while all other database type documentation used `60000` ms (1 minute). This PR unifies the value to `60000` ms across all affected versions.

**Affected versions:** IS 5.10.0 – 7.3.0 (+ next)

**Files changed (16):**
- `change-to-ibm-db2.md` — 5.10.0, 5.11.0, 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0, 7.3.0, next
- `change-to-postgresql.md` — 6.0.0, 6.1.0, 7.0.0, 7.1.0, 7.2.0, 7.3.0, next

> Note: PostgreSQL docs for 5.10.0 and 5.11.0 already had the correct value (`60000`) and were not modified.

Fixes: https://github.com/wso2/product-is/issues/27975