### PR TITLE
Improve Node.js installation instruction in JavaScript SPA sample guide

### DIFF
--- a/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
+++ b/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
@@ -6,7 +6,7 @@ By following this guide, you will be able to deploy a Javascript single-page app
 
 - **npm with Node.js**
 
-    If you don't have them, [install npm and node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm){target="_blank"} in your local environment.
+    If you don't have them,[install npm and node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm){target="_blank"} in your local environment.
 
 - **A user account in WSO2 Identity Platform**
 

--- a/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
+++ b/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
@@ -6,7 +6,7 @@ By following this guide, you will be able to deploy a Javascript single-page app
 
 - **npm with Node.js**
 
-    If you don't have it, [install npm and node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm){target="_blank"} in your local environment.
+    If you don't have them, [install npm and node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm){target="_blank"} in your local environment.
 
 - **A user account in WSO2 Identity Platform**
 

--- a/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
+++ b/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
@@ -56,7 +56,7 @@ Follow the steps given below to register the sample Javascript SPA in WSO2 Ident
     - to redirect the user back to the application in the following scenarios.
         - if the login page times out
         - after a password reset
-        - after the self sign-up verification
+        - after self-sign-up verification
     - to re-initiate the login flow if the login flow fails.
 
 ## Download the sample

--- a/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
+++ b/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
@@ -6,7 +6,7 @@ By following this guide, you will be able to deploy a Javascript single-page app
 
 - **npm with Node.js**
 
-    If you don't have them,[install npm and node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm){target="_blank"} in your local environment.
+    If you don't have them,[install npm and Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm){target="_blank"} in your local environment.
 
 - **A user account in WSO2 Identity Platform**
 
@@ -107,7 +107,7 @@ Follow the steps given below to configure the sample app.
             <code>clientID</code>
         </td>
         <td>
-            The Client ID that you received when you registered the application in WSO2 Identity Platform.
+            The client ID that you received when you registered the application in WSO2 Identity Platform.
         </td>
       </tr>
       <tr>
@@ -151,4 +151,4 @@ Follow the steps given below to run the sample.
 4. Enter the credentials of your user account and click **Sign In**.
 
     !!! note "Extend your login session"
-        By default, the user login session is active for only `15 minutes`. You can extend the session to `14 days` by selecting the **Remember me on this computer** option provided at the login screen of your application.
+        By default, the user session is active for only `15 minutes`. You can extend the session to `14 days` by selecting the **Remember me on this computer** option provided at the login screen of your application.

--- a/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
+++ b/en/asgardeo/docs/get-started/try-samples/qsg-spa-javascript.md
@@ -107,7 +107,7 @@ Follow the steps given below to configure the sample app.
             <code>clientID</code>
         </td>
         <td>
-            The client id that you received when you registered the application in WSO2 Identity Platform.
+            The Client ID that you received when you registered the application in WSO2 Identity Platform.
         </td>
       </tr>
       <tr>

--- a/en/asgardeo/docs/guides/authentication/mfa/add-duo-login.md
+++ b/en/asgardeo/docs/guides/authentication/mfa/add-duo-login.md
@@ -66,4 +66,4 @@ Finally, you need to verify that Duo has been successfully integrated and is fun
 
 4. If your verification is successful, you will be logged into the app.
 
-You've successfully integrated Duo 2FA into your WSO2 Identity Platform application. This additional security layer helps protect your users and sensitive data from unauthorized access.
+You've successfully integrated Duo 2FA into your application. This additional security layer helps protect your users and sensitive data from unauthorized access.

--- a/en/asgardeo/docs/guides/authentication/mfa/add-duo-login.md
+++ b/en/asgardeo/docs/guides/authentication/mfa/add-duo-login.md
@@ -1,6 +1,6 @@
 # Add Duo login
 
-[Duo](https://duo.com/) is a multi-factor authentication option that offer multiple verification methods such as push notifications, SMS, phone calls, and hardware tokens.
+[Duo](https://duo.com/) is a multi-factor authentication option that offers multiple verification methods such as push notifications, SMS, phone calls, and hardware tokens.
 
 In this guide, you'll learn how to integrate Duo as a second-factor authentication provider for your WSO2 Identity Platform application.
 

--- a/en/includes/references/user-management/user-roles.md
+++ b/en/includes/references/user-management/user-roles.md
@@ -842,7 +842,7 @@ You can assign users to roles using either of the following methods:
 
 ### Try it out
 
-1. Copy the console url from **Console Settings** page.
+1. Copy the Console URL from the **Console Settings** page.
 2. Share it with the assigned users to log in to the {{ product_name }} Console.
 
 {% endif %}


### PR DESCRIPTION
This PR improves the installation instruction in the prerequisites section of the JavaScript SPA sample guide.

Changes:
- Replaced "it" with "them" to correctly refer to both npm and Node.js.
- Updated "node" to the official product name "Node.js".