### PR TITLE
fix(docs): correct Mixpanel link target attribute

### DIFF
--- a/en/includes/guides/analytics/web-analytics-solutions.md
+++ b/en/includes/guides/analytics/web-analytics-solutions.md
@@ -16,7 +16,7 @@ Follow the steps below to configure a web analytics solution for {{product_name}
 
     - For Mixpanel:
       
-        1. Follow the Mixpanel [documentation](https://docs.mixpanel.com/docs/what-is-mixpanel){taget="_blank"} and create an analytics project.
+        1. Follow the Mixpanel [documentation](https://docs.mixpanel.com/docs/what-is-mixpanel){target="_blank"} and create an analytics project.
       
         2. Navigate to **Settings** > **Set up Mixpanel**, and look for the token of your project in `mixpanel.init("<TOKEN>");`.
 


### PR DESCRIPTION
Purpose

Correct a typo in the Markdown attribute for the Mixpanel documentation link.

The link attribute was written as taget instead of target, which prevents the attribute from being interpreted correctly.

Approach

Updated the Markdown attribute from {:taget="_blank"} to {:target="_blank"} without changing the content or behavior of the documentation.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.