### PR TITLE
docs: fix MATTR access token note grammar

### DIFF
--- a/en/includes/tutorials/connect-with-mattr.md
+++ b/en/includes/tutorials/connect-with-mattr.md
@@ -97,7 +97,7 @@ curl -i -X POST "<MATTR_AUTH_URL>/oauth/token" \
 ```
 
 !!! note
-    The sections below refers to the received access token as `<MATTR_BEARER_TOKEN>`.
+    The sections below refer to the received access token as `<MATTR_BEARER_TOKEN>`.
 
 ### Step 2.3: Configure MATTR authentication provider
 


### PR DESCRIPTION
Purpose

Correct the grammar in the MATTR integration guide by fixing a subject-verb agreement issue in the access token note.

Approach

Updated the sentence from “The sections below refers…” to “The sections below refer…” to improve readability and grammatical correctness.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.