### PR TITLE
docs: fix MATTR authentication provider wording

### DIFF
--- a/en/includes/tutorials/connect-with-mattr.md
+++ b/en/includes/tutorials/connect-with-mattr.md
@@ -101,7 +101,7 @@ curl -i -X POST "<MATTR_AUTH_URL>/oauth/token" \
 
 ### Step 2.3: Configure MATTR authentication provider
 
-Set up a authentication provider in MATTR VII to connect with {{ product_name }}. See the MATTR documentation on [authentication providers](https://learn.mattr.global/docs/issuance/authorization-code/authentication-provider/overview){: target="_blank"} for more details.
+Set up an authentication provider in MATTR VII to connect with {{ product_name }}. See the MATTR documentation on [authentication providers](https://learn.mattr.global/docs/issuance/authorization-code/authentication-provider/overview){: target="_blank"} for more details.
 
 ```bash
 curl -i -X POST "<MATTR_TENANT_URL>/v1/users/authentication-providers" \


### PR DESCRIPTION
Purpose

Improve the wording in the MATTR integration guide by correcting the article used before “authentication provider.”

Approach

Updated the sentence from “a authentication provider” to “an authentication provider” for grammatical correctness and improved readability.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.