### PR TITLE
docs: fix typo in OIDC ID token validation page

### DIFF
--- a/en/identity-server/7.3.0/docs/guides/authentication/oidc/index.md
+++ b/en/identity-server/7.3.0/docs/guides/authentication/oidc/index.md
@@ -33,7 +33,7 @@ With JWT Secured Authorization Response Mode, clients can request authorization 
 
 ## Validate ID tokens
 
-This section explains how the signature and the claims are verifieed in the ID token that is sent by WSO2 Identity Server to an application.
+This section explains how the signature and the claims are verified in the ID token that is sent by WSO2 Identity Server to an application.
 
 [Validate ID tokens]({{base_path}}/guides/authentication/oidc/validate-id-tokens/) has detailed instructions on this.
 


### PR DESCRIPTION
Purpose

Correct a typo in the OIDC ID token validation documentation to improve readability and accuracy.

Approach

Replaced the misspelled word “verifieed” with “verified” in the documentation.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.