### PR TITLE
docs: fix SAML sample configuration typo

### DIFF
--- a/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
+++ b/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
@@ -39,7 +39,7 @@ Follow these steps given below to register the sample Java EE web application in
           <td>Select <b>SAML</b>.</td>
       </tr>
       <tr>
-          <td>Configruation type</td>
+          <td>Configuration type</td>
           <td>Select <b>Manual</b> (Learn more about [SAML configuration types]({{base_path}}/guides/applications/register-saml-web-app/))</td>
       </tr>
     <tr>


### PR DESCRIPTION
Purpose

Correct a typo in the SAML Java EE sample configuration table to improve documentation accuracy and readability.

Approach

Updated the table entry from “Configruation type” to “Configuration type” without changing the meaning or functionality of the documentation.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.