### PR TITLE
docs: fix SAML skipURIs description grammar

### DIFF
--- a/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
+++ b/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
@@ -39,7 +39,7 @@ Follow these steps given below to register the sample Java EE web application in
           <td>Select <b>SAML</b>.</td>
       </tr>
       <tr>
-          <td>Configruation type</td>
+          <td>Configuration type</td>
           <td>Select <b>Manual</b> (Learn more about [SAML configuration types]({{base_path}}/guides/applications/register-saml-web-app/))</td>
       </tr>
     <tr>

--- a/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
+++ b/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
@@ -187,7 +187,7 @@ Follow the steps given below to configure the sample app.
         </tr>
         <tr>
           <td><code>skipURIs</code></td>
-          <td>Defines the web pages in your application that should not be secured and does not require authentication.</td>
+          <td>Defines the web pages in your application that should not be secured and do not require authentication.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Purpose

Improve the grammar in the SAML Java EE sample documentation by correcting the subject-verb agreement in the skipURIs description.

Approach

Updated the description from “does not require authentication” to “do not require authentication” to match the plural subject “web pages”.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.