### PR TITLE
docs: fix grammar and placeholder issues in SAML and MCP guides

### DIFF
--- a/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
+++ b/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
@@ -39,7 +39,7 @@ Follow these steps given below to register the sample Java EE web application in
           <td>Select <b>SAML</b>.</td>
       </tr>
       <tr>
-          <td>Configruation type</td>
+          <td>Configuration type</td>
           <td>Select <b>Manual</b> (Learn more about [SAML configuration types]({{base_path}}/guides/applications/register-saml-web-app/))</td>
       </tr>
     <tr>

--- a/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
+++ b/en/includes/get-started/try-samples/qsg-saml-webapp-java-ee.md
@@ -187,7 +187,7 @@ Follow the steps given below to configure the sample app.
         </tr>
         <tr>
           <td><code>skipURIs</code></td>
-          <td>Defines the web pages in your application that should not be secured and does not require authentication.</td>
+          <td>Defines the web pages in your application that should not be secured and do not require authentication.</td>
         </tr>
       </tbody>
     </table>

--- a/en/includes/quick-starts/mcp-auth-server.md
+++ b/en/includes/quick-starts/mcp-auth-server.md
@@ -232,7 +232,7 @@ Create '.env' file and add the base URL of your {{product_name}} organization as
 {% if product_name == "WSO2 Identity Platform" %}
 
 ```env
-BASE_URL=https://api.asgardeo.io/t/<you-org-name>
+BASE_URL=https://api.asgardeo.io/t/<your-org-name>
 ```
 
 {% else %}


### PR DESCRIPTION
Purpose

Improve the clarity and consistency of the documentation by fixing several grammar issues in the SAML Java EE guides and correcting an incorrect placeholder in the MCP authentication server guide.

Approach

This PR includes the following documentation improvements:

* Corrected the “Configuration type” typo in the SAML Java EE sample.
* Fixed the grammar in the skipURIs description to use proper subject-verb agreement.
* Updated the MCP authentication server placeholder from <you-org-name> to <your-org-name> for consistency.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only changes. No functional or behavioral changes.