### PR TITLE
docs: correct MCP auth server local org placeholder

### DIFF
--- a/en/includes/quick-starts/mcp-auth-server.md
+++ b/en/includes/quick-starts/mcp-auth-server.md
@@ -238,7 +238,7 @@ BASE_URL=https://api.asgardeo.io/t/<you-org-name>
 {% else %}
 
 ```env
-BASE_URL=https://localhost:9443/t/<you-org-name>
+BASE_URL=https://localhost:9443/t/<your-org-name>
 ```
 
 {% endif %}


### PR DESCRIPTION
Purpose

Correct the placeholder used in the local MCP authentication server example for consistency with the rest of the documentation.

Approach

Updated the placeholder from <you-org-name> to <your-org-name> in the local Identity Server example.

Related Issues

N/A

Checklist

* Tests added or updated (unit, integration, etc.)
* Samples updated (if applicable)
* Added backport/<release-branch> label if this should be backported (e.g., backport/release-v1.0)

Remarks

Documentation-only change.