### PR TITLE
docs: add language identifiers to discovery endpoint code blocks

### DIFF
--- a/en/includes/guides/fragments/manage-app/discover-endpoints/discover-from-discovery-endpoint.md
+++ b/en/includes/guides/fragments/manage-app/discover-endpoints/discover-from-discovery-endpoint.md
@@ -5,12 +5,12 @@ Application can dynamically discover the OpenID Connect identity provider metada
  `<issuer>/.well-known/openid-configuration`.  
 
 **Issuer of {{ product_name }}:**
-``` 
+```text
 {{ product_url_format }}/oauth2/token
 ```
 
 **Discovery endpoint of {{ product_name }}:**
-``` 
+```text
 {{ product_url_format }}/oauth2/token/.well-known/openid-configuration
 ```
 


### PR DESCRIPTION
## Purpose

Improve documentation readability and syntax highlighting by adding language identifiers to the endpoint code blocks in the discovery endpoint guide.

## Approach

- Added the `text` language identifier to the issuer endpoint code block.
- Added the `text` language identifier to the OpenID discovery endpoint code block.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only changes. No functional behavior was modified.