### PR TITLE
docs: fix API cURL code fence language

### DIFF
--- a/en/identity-server/7.3.0/docs/apis/index.md
+++ b/en/identity-server/7.3.0/docs/apis/index.md
@@ -31,7 +31,7 @@ This authentication method uses the user's credentials to invoke the APIs. If th
 
 This is a sample cURL command template for the request.
 
-``` curl
+```bash
 curl -X GET "https://localhost:9443/api/server/v1/applications?limit=30&offset=0" -H "accept: application/json" -H "Authorization: Basic <Base64(username:password)>"
 ```
 


### PR DESCRIPTION
## Purpose

Improve syntax highlighting by using the appropriate language identifier for the API cURL example.

## Approach

Updated the code fence language from `curl` to `bash` for the cURL command example without changing the command itself.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only change.