### PR TITLE
docs: fix JAVA_HOME command code fence language

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/get-started/install.md
+++ b/en/identity-server/7.3.0/docs/deploy/get-started/install.md
@@ -292,7 +292,7 @@ The `JAVA_HOME` variable is now set and will apply to any subsequent command pro
 
 To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter** ) and execute the following command.
 
-```java
+```bat
 set JAVA_HOME
 ```
 


### PR DESCRIPTION
## Purpose

Improve syntax highlighting by using the appropriate language identifier for the Windows `JAVA_HOME` command example.

## Approach

Updated the code fence language from `java` to `bat` for the Windows command block without changing the commands.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only change.