### PR TITLE
docs: fix hostname verifier code fence language

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/enable-hostname-verification.md
+++ b/en/identity-server/7.3.0/docs/deploy/enable-hostname-verification.md
@@ -9,7 +9,7 @@ The possibility to configure hostname verification is available for the WSO2 Ide
 
 In the WSO2 Identity Server, hostname verification is enabled by default. This is done using the `httpclient.hostnameVerifier` property in the startup script ( `wso2server.sh` for Linux and `wso2server.bat` for Windows) as shown below. The product startup script is stored in the `<IS_HOME>/bin` directory. This property will be effective during server startup.
 
-``` java
+```text
 -Dhttpclient.hostnameVerifier="DefaultAndLocalhost"
 ```
 


### PR DESCRIPTION
## Purpose

Improve syntax highlighting by using the appropriate language identifier for the JVM argument example in the hostname verification guide.

## Approach

Updated the code fence language from `java` to `text` without changing the command itself.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only change.