### PR TITLE
docs: fix token log properties code fence

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/add-logs-for-tokens.md
+++ b/en/identity-server/7.3.0/docs/deploy/add-logs-for-tokens.md
@@ -2,7 +2,7 @@
 
 Entries in the `<IS_HOME>/repository/conf/security/identity_log_tokens.properties` file can determine whether tokens are added to system logs or not. By default, these are enabled in the file. The following are the entries in this file that represent different types of tokens. The tokens can be disabled from appearing in the logs by setting each token to `false`.
 
-``` c#
+```properties
 UserClaims=true
 UserIdToken=true
 XACML_Request=true


### PR DESCRIPTION
## Purpose

Improve syntax highlighting by using the appropriate language identifier for the properties configuration example.

## Approach

Updated the code fence language from `c#` to `properties` without changing the configuration content.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only change.