### PR TITLE
docs: add language to browser caching header block

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/security/prevent-browser-caching.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/prevent-browser-caching.md
@@ -2,7 +2,7 @@
 
 If there are dynamic pages in your application, which also include sensitive information, you need to prevent caching. This can be done by making sure that the applications return the following HTTP security headers in HTTP responses.
 
-```
+```http
 Expires:0
 Pragma:no-cache
 Cache-Control:no-store, no-cache, must-revalidate


### PR DESCRIPTION
## Purpose

Improve documentation readability and syntax highlighting by adding a language identifier to the HTTP header example.

## Approach

Updated the code fence to use the `http` language for the browser caching header example without changing the content.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only change.