### PR TITLE
docs: fix ellipsis typo in multitenancy guide

### DIFF
--- a/en/identity-server/7.3.0/docs/guides/multitenancy/manage-tenants.md
+++ b/en/identity-server/7.3.0/docs/guides/multitenancy/manage-tenants.md
@@ -101,7 +101,7 @@ To view the details of the root organization, follow the steps given below.
     ![Root Organization Actions]({{base_path}}/assets/img/guides/multitenancy/root-organization-card-actions.png)
 
     - **Edit**: Click on the **Edit** button to navigate to the details page of the respective root organization.
-    - **More**: Click on the elipsis icon to view more actions.
+    - **More**: Click on the ellipsis icon to view more actions.
         - **Disable** / **Enable**: Depending on the current status of the root organization, you can disable or enable it.
 
 3. If you want to view details of a specific root organization, click on the **Edit** button of the respective root organization. Inside the root organization details page, you can perform the following actions:


### PR DESCRIPTION
## Purpose

Correct a typo in the multitenancy guide to improve documentation quality and readability.

## Approach

Updated the word `elipsis` to the correct spelling, `ellipsis`, in the user-facing instruction.

## Related Issues

N/A

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)

## Remarks

Documentation-only change.