### PR TITLE
Fix spelling typos in change-to-oracle.md

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-oracle.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-oracle.md
@@ -108,7 +108,7 @@ Apart from the basic configurations specified above, WSO2 Identity Server suppor
 
 ### Using an alternate user to connect to database
 
-When the database owner is not the user used to connect to the database, specify the parent schema in the datasource declarion.
+When the database owner is not the user used to connect to the database, specify the parent schema in the datasource declaration.
 
 	``` toml
 	[database.identity_db.db_props]
@@ -118,9 +118,9 @@ When the database owner is not the user used to connect to the database, specify
 	parentSchema = "<parent_schema_name>"
 	```
 
-!!! note "Database user priviledges"
+!!! note "Database user privileges"
 
-    When a custom database user is created, please note that the following privildges should be granted according to the purpose of the user.
+    When a custom database user is created, please note that the following privileges should be granted according to the purpose of the user.
 
     - Execute the below permissions on the database to perform DDL operations.
         - CREATE SESSION, ALTER SESSION, UNLIMITED TABLESPACE, CREATE VIEW, CREATE SEQUENCE, CREATE TABLE, CREATE PROCEDURE, CREATE TRIGGER, CREATE PUBLIC SYNONYM
@@ -134,7 +134,7 @@ When the database owner is not the user used to connect to the database, specify
         - SELECT, INSERT, DELETE, UPDATE
             - ex: `GRANT SELECT, INSERT, DELETE, <db-user>.<table-name>;`
 
-    Please refer the offcial [oracle documentation](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/GRANT.html#GUID-20B4E2C0-A7F8-4BC8-A5E8-BE61BDC41AC3) for further details.
+    Please refer the official [oracle documentation](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/GRANT.html#GUID-20B4E2C0-A7F8-4BC8-A5E8-BE61BDC41AC3) for further details.
 
 ---
   


### PR DESCRIPTION
## Purpose
The Oracle database configuration guide had four spelling typos: "declarion" -> "declaration", "priviledges" and 
"privildges" -> "privileges" and "offcial" -> "official". This PR corrects them.

## Related PRs
N/A

## Test environment
N/A - documentation-only change

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? - N/A, documentation-only
- [ ] Ran FindSecurityBugs plugin and verified report? - N/A, documentation-only
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes


