### PR TITLE
Fixed incorrect component name in install-asgardeo-sdk guide

### DIFF
--- a/en/includes/complete-guides/react/install-asgardeo-sdk.md
+++ b/en/includes/complete-guides/react/install-asgardeo-sdk.md
@@ -52,7 +52,7 @@ createRoot(document.getElementById('root')).render(
 )
 ```
 
-As shown above, we used `<AuthProvider />` at the root level of the application to ensure that all components can interact with the authentication logic provided by {{product_name}}. It takes the configuration object with the following values for the single page application defined in the {{product_name}} console. You can copy these values from the {{product_name}}  console.
+As shown above, we used `<AsgardeoProvider />` at the root level of the application to ensure that all components can interact with the authentication logic provided by {{product_name}}. It takes the configuration object with the following values for the single page application defined in the {{product_name}} console. You can copy these values from the {{product_name}}  console.
 
 <!-- markdownlint-disable MD056 -->
 | Parameter | Type | Required | Description | Example
@@ -73,5 +73,5 @@ Here’s a brief overview of what `<AsgardeoProvider />` provides:
 
 * **Context Management:** It creates a context that holds the authentication state and methods to handle authentication actions like logging in, logging out, and checking the user's authentication status.
 * **Session Handling:** `<AsgardeoProvider />` manages user sessions, including token storage and retrieval, token refresh, and user session expiration handling.
-* **Easy Access to Authentication:** By wrapping your app with `<AuthProvider />`, any component within your app can easily access authentication details and actions using hooks like useAuthContext.
+* **Easy Access to Authentication:** By wrapping your app with `<AsgardeoProvider />`, any component within your app can easily access authentication details and actions using hooks like useAuthContext.
 * **Initialization and Configuration:** It initializes the SDK with the necessary configuration, such as client ID, server endpoints, and other authentication settings.


### PR DESCRIPTION
I have replaced the incorrect <AuthProvider /> reference with the corrrect <AsgardeoProvider/> in the prose description. The code block correctly mentions AsgardeoProvider from the new asgadeo/rect SDK. but the explanation text still referred to AuthProvider.

## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


