### PR TITLE
[7.3.0] fix duplicated words in documentation

### DIFF
--- a/en/identity-server/7.3.0/docs/complete-guides/nextjs/register-an-application.md
+++ b/en/identity-server/7.3.0/docs/complete-guides/nextjs/register-an-application.md
@@ -29,6 +29,6 @@ Make a note of the following values from the **Protocol** and **Info** tabs of t
 
 * **`client-id`** from the **Protocol** tab.
 * **`client-secret`** from the **Protocol** tab.
-* **`issuer`** from from the **Info** tab.
+* **`issuer`** from the **Info** tab.
 
 {% include "../../../../../includes/complete-guides/nextjs/register-an-application.md" %}

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/data-dictionary/user-management-related-tables.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/data-dictionary/user-management-related-tables.md
@@ -286,7 +286,7 @@ using the respective permalinks. Following are the columns of the table.
 
 ## UM_SYSTEM_USER_ROLE
 
-Storing the system roles assigned to the the system users is done with
+Storing the system roles assigned to the system users is done with
 this table. `UM_USER_NAME` contains the username of the system user.
 `UM_ROLE_ID` contains the ID of the system role which points to the `UM_ID` column of the `UM_SYSTEM_ROLE` table. The `wso2.anonymous.role`
 system role is by default assigned to the `wso2.anonymous.user` system

--- a/en/identity-server/7.3.0/docs/get-started/try-your-own-app/java-ee-saml.md
+++ b/en/identity-server/7.3.0/docs/get-started/try-your-own-app/java-ee-saml.md
@@ -56,7 +56,7 @@ Follow the steps given below to initialize the SAML agent.
 
 ### Create the configuration file
 
-To initialize the SAML agent, you need a property file with the configurations such as the the {{ product_name }} endpoints. The {{ product_name }} SAML agent reads the configurations from this file.
+To initialize the SAML agent, you need a property file with the configurations such as the {{ product_name }} endpoints. The {{ product_name }} SAML agent reads the configurations from this file.
 
 Create a file named **sample-app.properties** inside the **<YOUR_APP>/src/main/resources** directory, using the content below.
 

--- a/en/identity-server/7.3.0/docs/guides/multitenancy/manage-tenants.md
+++ b/en/identity-server/7.3.0/docs/guides/multitenancy/manage-tenants.md
@@ -82,7 +82,7 @@ Follow the steps given below to add a new root organization from the {{ product_
     !!! note
         Keep the **Organization Name** field blank to use the **Organization Handle** (tenant domain) as the name.
 
-5. Once a new root organization is created, it will be listed in the the **Root Organization** listing page as shown below.
+5. Once a new root organization is created, it will be listed in the **Root Organization** listing page as shown below.
 
     ![Root Organization Listing]({{base_path}}/assets/img/guides/multitenancy/root-organizaiton-listing.png)
 


### PR DESCRIPTION
## Purpose
Removes accidental word repetitions in the IS 7.3.0 documentation prose. Four single word deletions, no content or meaning changed:

- `from from` to `from` - https://is.docs.wso2.com/en/latest/complete-guides/nextjs/register-an-application/
- `the the` to `the` - https://is.docs.wso2.com/en/latest/deploy/configure/databases/data-dictionary/user-management-related-tables/
- `the the` to `the` - https://is.docs.wso2.com/en/latest/get-started/try-your-own-app/java-ee-saml/
- `the the` to `the` - https://is.docs.wso2.com/en/latest/guides/multitenancy/manage-tenants/


No related product issue.

## Related PRs
N/A

## Test environment
Documentation only change (Markdown prose). No JDK/OS/DB/browser dependency.
Verified the affected lines render correctly and that markdownlint/Vale checks pass.

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
  <!-- N/A — documentation-only change, no code -->
- [x] Ran FindSecurityBugs plugin and verified report?
  <!-- N/A — documentation-only change, no code -->
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?