### PR TITLE
Fix typo: Correct LGDP to LGPD in quick-start-guide.md

### DIFF
--- a/en/identity-server/7.3.0/docs/get-started/quick-start-guide.md
+++ b/en/identity-server/7.3.0/docs/get-started/quick-start-guide.md
@@ -38,6 +38,6 @@ Are you new to **{{ product_name }}**? Learn how you can get started.
 
 - **Secure ever-growing APIs** - {{ product_name }} plays a key role as the authorization server that supports several OAuth related standards or profiles. It supports open standards such as OAuth, OpenID Connect and SAML 2.0. It also enables high availability, failover, and performance for a smooth operation.
 
-- **To safeguard user data and give them control over it** - {{ product_name }} enables recording, reviewing, and revoking user consents by adhering to privacy by design principles and industry standards imposed by GDPR and similar privacy laws such as CCPA and LGDP.
+- **To safeguard user data and give them control over it** - {{ product_name }} enables recording, reviewing, and revoking user consents by adhering to privacy by design principles and industry standards imposed by GDPR and similar privacy laws such as CCPA and LGPD.
 
 ---


### PR DESCRIPTION
## Purpose
Fixed a typo where LGDP was incorrectly written instead of LGPD (Lei Geral de Proteção de Dados), the Brazilian data privacy law.

## Related PRs
<!-- List any other related PRs -->

## Test environment
<!-- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->

## Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


