### PR TITLE
Fix-typo: Reponse to Response in SCIM 1.1 API docs

### DIFF
--- a/en/identity-server/7.3.0/docs/apis/scim-1.1-apis.md
+++ b/en/identity-server/7.3.0/docs/apis/scim-1.1-apis.md
@@ -275,7 +275,7 @@ exchanged and also protected with Basic Auth Authentication.
     curl -v -k --user admin:admin https://localhost:9443/wso2/scim/Groups?filter=displayNameEqengineer
     ```
 
-    ```java tab="Reponse"
+    ```java tab="Response"
     {"schemas":["urn:scim:schemas:core:1.0"],"totalResults":1,"Resources":[{"id":"b4f9bccf-4f79-4288-be21-78e0d4500714","displayName":"PRIMARY/engineer","meta":{"lastModified":"2016-01-26T18:31:57","created":"2016-01-26T18:31:57","location":"https://localhost:9443/wso2/scim/Groups/b4f9bccf-4f79-4288-be21-78e0d4500714"}}]}
     ```
 


### PR DESCRIPTION
## Purpose
Fixes a typo in the SCIM 1.1 API documentation where a code block tab was labeled `Reponse` instead of `Response`, for consistency with the other response tabs in the same file (e.g. lines 54, 106, 195 use `tab="Response"`).

## Related PRs
None

## Test environment
N/A - documentation-only change (spelling fix)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?