### PR TITLE
Fix-typo : oracle privileges typo

### DIFF
--- a/en/identity-server/7.3.0/docs/references/tutorials/send-notification-external-schedular.md
+++ b/en/identity-server/7.3.0/docs/references/tutorials/send-notification-external-schedular.md
@@ -135,7 +135,7 @@ This tutorial illustrates how to send email notifications daily for users whose 
 
 **Step 10:** Copy and replace the files from the sample Azure Function into the directory created in the previous step.
 
-**Step 11:** You can test the Function App locally as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-storage-queue-vs-code?pivots=programming-language-python&tabs=isolated-process#run-the-function-locally){:target="_blank"} befor deploying it to Azure.
+**Step 11:** You can test the Function App locally as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-storage-queue-vs-code?pivots=programming-language-python&tabs=isolated-process#run-the-function-locally){:target="_blank"} before deploying it to Azure.
 
 ### Deploy Function App to Azure
 

--- a/en/identity-server/7.3.0/docs/references/tutorials/send-notification-external-schedular.md
+++ b/en/identity-server/7.3.0/docs/references/tutorials/send-notification-external-schedular.md
@@ -34,7 +34,7 @@ This tutorial illustrates how to send email notifications daily for users whose 
 
 **Step 6:** First [Setup the Visual Studio Code](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-vs-code?tabs=node-v3%2Cpython-v2%2Cisolated-process&pivots=programming-language-python#prerequisites){:target="_blank"} and [local environment](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-vs-code?tabs=node-v3%2Cpython-v2%2Cisolated-process&pivots=programming-language-python#prerequisites){:target="_blank"} to develop a Azure Function with Visual Studio Code.
 
-**Step 7:** Click the button below to download the sample Azure Funtion. You can also choose to view the source before doing so.
+**Step 7:** Click the button below to download the sample Azure Function. You can also choose to view the source before doing so.
 
 <div class="centered-container">
   <div class="border-text">
@@ -135,7 +135,7 @@ This tutorial illustrates how to send email notifications daily for users whose 
 
 **Step 10:** Copy and replace the files from the sample Azure Function into the directory created in the previous step.
 
-**Step 11:** You can test the Funtion App locally as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-storage-queue-vs-code?pivots=programming-language-python&tabs=isolated-process#run-the-function-locally){:target="_blank"} befor deploying it to Azure.
+**Step 11:** You can test the Function App locally as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-storage-queue-vs-code?pivots=programming-language-python&tabs=isolated-process#run-the-function-locally){:target="_blank"} befor deploying it to Azure.
 
 ### Deploy Function App to Azure
 

--- a/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle.md
+++ b/en/identity-server/next/docs/deploy/configure/databases/carbon-database/change-to-oracle.md
@@ -118,7 +118,7 @@ When the database owner is not the user used to connect to the database, specify
 	parentSchema = "<parent_schema_name>"
 	```
 
-!!! note "Database user priviledges"
+!!! note "Database user privileges"
 
     When a custom database user is created, please note that the following privildges should be granted according to the purpose of the user.
 


### PR DESCRIPTION
## Purpose
Fixes a typo in the Oracle database configuration guide where "Database user priviledges" should read "Database user privileges", for consistency with the correct spelling already used in the 7.3.0 version of this same file.

## Related PRs
None

## Test environment
N/A - documentation-only change (spelling fix)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?