### PR TITLE
Fix various documentation typos across identity-server and asgardeo docs

### DIFF
--- a/en/asgardeo/docs/references/operational-policies.md
+++ b/en/asgardeo/docs/references/operational-policies.md
@@ -249,7 +249,7 @@ Refer this guideline below for more on [subscription](https://wso2.com/asgardeo/
 
 ### 7.3 Subscription Upgrade
 
-WSO2 Identity Platform organization owners can upgrade the curent tier of their organizations using the billing portal accessible from the **WSO2 Identity Platform Console**. This [document](https://wso2.com/asgardeo/docs/guides/your-asgardeo/subscribe-to-asgardeo/subscribe-via-billing-portal/){target="_blank"} provides more insight on how to upgrade tiers. 
+WSO2 Identity Platform organization owners can upgrade the current tier of their organizations using the billing portal accessible from the **WSO2 Identity Platform Console**. This [document](https://wso2.com/asgardeo/docs/guides/your-asgardeo/subscribe-to-asgardeo/subscribe-via-billing-portal/){target="_blank"} provides more insight on how to upgrade tiers. 
 
 ### 7.4 Subscription Downgrade
 

--- a/en/asgardeo/docs/references/operational-policies.md
+++ b/en/asgardeo/docs/references/operational-policies.md
@@ -316,7 +316,7 @@ WSO2 Identity Platform, as a cloud offering, adheres to agile principles and emp
 
 ### 10.2 New Features
 
-Asgardeo thrives to introduce new features and explicitly adds ‘New’ tag to those features so that interested parties can try those new features.
+WSO2 Identity Platform thrives to introduce new features and explicitly adds ‘New’ tag to those features so that interested parties can try those new features.
 
 ### 10.3 Beta Features
 

--- a/en/asgardeo/docs/references/operational-policies.md
+++ b/en/asgardeo/docs/references/operational-policies.md
@@ -316,7 +316,7 @@ WSO2 Identity Platform, as a cloud offering, adheres to agile principles and emp
 
 ### 10.2 New Features
 
-Asgaardeo thrives to introduce new features and explicitly adds ‘New’ tag to those features so that interested parties can try those new features.
+Asgardeo thrives to introduce new features and explicitly adds ‘New’ tag to those features so that interested parties can try those new features.
 
 ### 10.3 Beta Features
 

--- a/en/identity-server/7.3.0/docs/apis/notification-sender.md
+++ b/en/identity-server/7.3.0/docs/apis/notification-sender.md
@@ -2,7 +2,7 @@
 
 The RESTful API for managing notification sender configurations in WSO2 Identity Server supports Email and SMS as the notification channels.
 
-The following section provides the instructions to contruct requests for each notification sender type.<br>
+The following section provides the instructions to construct requests for each notification sender type.<br>
 
 !!! warning "Important"
 

--- a/en/identity-server/7.3.0/docs/complete-guides/expressjs/add-login-and-logout.md
+++ b/en/identity-server/7.3.0/docs/complete-guides/expressjs/add-login-and-logout.md
@@ -10,7 +10,7 @@ read_time: 2 min
 
     In WSO2 Identity Server, the default certificate is a self signed certificate. This certificate needs to be added to the runtime path in order to avoid SSL errors.
 
-    Excute the below commands before running `npm start`
+    Execute the below commands before running `npm start`
 
     Naviate to the <IS_HOME>/repository/resources/security directory and execute the following
 

--- a/en/identity-server/7.3.0/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/7.3.0/docs/deploy/compliance/gdpr.md
@@ -19,7 +19,7 @@ Any efficient IAM solution supports anonymization to remove PII data from datase
 
 WSO2 Identity Server (WSO2 IS) is designed based on privacy best practices and is fully compliant with GDPR. GDPR compliance in IAM and API security spaces can be completely fulfilled with WSO2 IS.
 
-WSO2 IS has been designed and architectured based on well-known *Secure by Design* and *Privacy by Design* principles.  With the formalization of GDPR in 2016, the product architecture of the WSO2 Identity Server has been reviewed and fine-tuned accordingly to support privacy principles efficiently, with less overhead for product performance and user experience.
+WSO2 IS has been designed and architected based on well-known *Secure by Design* and *Privacy by Design* principles.  With the formalization of GDPR in 2016, the product architecture of the WSO2 Identity Server has been reviewed and fine-tuned accordingly to support privacy principles efficiently, with less overhead for product performance and user experience.
 
 WSO2 IS provides all privacy features enabled in the product as default options, and uses up-to-date algorithms and frameworks for all cryptographic operations such as data encryption, signing, and hashing.
 

--- a/en/identity-server/7.3.0/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/7.3.0/docs/deploy/compliance/gdpr.md
@@ -19,7 +19,7 @@ Any efficient IAM solution supports anonymization to remove PII data from datase
 
 WSO2 Identity Server (WSO2 IS) is designed based on privacy best practices and is fully compliant with GDPR. GDPR compliance in IAM and API security spaces can be completely fulfilled with WSO2 IS.
 
-WSO2 IS has been designed and architected based on well-known *Secure by Design* and *Privacy by Design* principles.  With the formalization of GDPR in 2016, the product architecture of the WSO2 Identity Server has been reviewed and fine-tuned accordingly to support privacy principles efficiently, with less overhead for product performance and user experience.
+WSO2 Identity Server has been designed and architected based on well-known *Secure by Design* and *Privacy by Design* principles.  With the formalization of GDPR in 2016, the product architecture has been reviewed and fine-tuned accordingly to support privacy principles efficiently, with less overhead for product performance and user experience.
 
 WSO2 IS provides all privacy features enabled in the product as default options, and uses up-to-date algorithms and frameworks for all cryptographic operations such as data encryption, signing, and hashing.
 

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/carbon-database/change-to-ibm-db2.md
@@ -49,7 +49,7 @@ A sample configuration is given below.
 		- `<IS_HOME>/dbscripts/consent/db2.sql`
 
 		!!! info 
-			While running the DB2 scripts via the terminal, use the following DB2 command to run the DB2 scripts with the delimeter "/" since the default delimiter script for DB2 is ";". 
+			While running the DB2 scripts via the terminal, use the following DB2 command to run the DB2 scripts with the delimiter "/" since the default delimiter script for DB2 is ";". 
 			```xml
 			db2 -td/ -f db2.sql
 			```		

--- a/en/identity-server/7.3.0/docs/deploy/configure/databases/remove-references-to-deleted-user-identities.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/databases/remove-references-to-deleted-user-identities.md
@@ -23,7 +23,7 @@ log files in WSO2 IS.
         to remove references to a user who has not been deleted from the
         system. Although it is practically possible to run the tool to
         remove references to a user who has not been deleted from the
-        system, a ttempting to do so can cause unexpected system errors.
+        system, attempting to do so can cause unexpected system errors.
     
     -   This tool is designed to replace all occurrences of a deleted user’s
         identity with either a randomly generated UUID value, or a pseudonym

--- a/en/identity-server/7.3.0/docs/deploy/security/enable-java-security-manager.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/enable-java-security-manager.md
@@ -247,7 +247,7 @@ To enable the Java Security Manager:
 		// MyFaces has a fix https://issues.apache.org/jira/browse/MYFACES-3590  
 		permission java.io.FilePermission "/META-INF", "read";
 		permission java.io.FilePermission "/META-INF/-", "read";
-		// OSGi permissions are requied to resolve bundles. Required by JSF
+		// OSGi permissions are required to resolve bundles. Required by JSF
 		permission org.osgi.framework.AdminPermission "*", "resolve,resource";
 
 		};

--- a/en/identity-server/7.3.0/docs/get-started/try-your-own-app/java-ee-saml.md
+++ b/en/identity-server/7.3.0/docs/get-started/try-your-own-app/java-ee-saml.md
@@ -173,7 +173,7 @@ Create a file named **sample-app.properties** inside the **<YOUR_APP>/src/main/r
         <code>SAML2.EnableRequestSigning</code>
       </td>
       <td>
-        If this configuration is set to <code>true</code>, {{ product_name }} validates the SAML authentication requeand logout request. You also need to [enable request signing]({{base_path}}/references/app-settings/saml-settings-for-app/) from {{ product_name }}.
+        If this configuration is set to <code>true</code>, {{ product_name }} validates the SAML authentication request and logout request. You also need to [enable request signing]({{base_path}}/references/app-settings/saml-settings-for-app/) from {{ product_name }}.
       </td>
     </tr>
     <tr>

--- a/en/identity-server/7.3.0/docs/guides/authentication/conditional-auth/acr-based-adaptive-auth.md
+++ b/en/identity-server/7.3.0/docs/guides/authentication/conditional-auth/acr-based-adaptive-auth.md
@@ -147,7 +147,7 @@ var onLoginRequest = function(context) {
 
 !!! info "Access ACR Values from the authentication script"
 
-    The authentiaction script is protocol-agnostic, i.e. it works for both OIDC and SAML SSO requests.
+    The authenticaction script is protocol-agnostic, i.e. it works for both OIDC and SAML SSO requests.
 
     - For OIDC requests the `acr_values` parameter is available as `context.requestedAcr`.
     
@@ -201,7 +201,7 @@ Follow the steps given below to try out ACR-based adaptive authentication with t
     !!! note
         Authentication Method Reference (AMR) value found in the access token provides information about the authentication methods that are used to assert the authenticity of the user.
 
-        The AMR values for the relevant request are `BasicAuthenticator` and `totp` which were the methods used for authenticaion.
+        The AMR values for the relevant request are `BasicAuthenticator` and `totp` which were the methods used for authentication.
 
 8. Logout from the application and try this flow with different ACR values.
 

--- a/en/identity-server/7.3.0/docs/guides/authentication/conditional-auth/elk-risk-based-template.md
+++ b/en/identity-server/7.3.0/docs/guides/authentication/conditional-auth/elk-risk-based-template.md
@@ -31,7 +31,7 @@ works to assess the risk of the user.
 
 ## Prerequisites
 
-- See the [general prerequisites]({{base_path}}/guides/authentication/conditional-auth/configure-conditional-auth/#prerequisites) for all adaptive authenticaiton scenarios.
+- See the [general prerequisites]({{base_path}}/guides/authentication/conditional-auth/configure-conditional-auth/#prerequisites) for all adaptive authentication scenarios.
 
 - [Configure ELK analytics for adaptive authentication]({{base_path}}/deploy/elk-analytics-for-adaptive-authentication), and run the following command to create an index named `transaction` to store transaction data.
 

--- a/en/identity-server/7.3.0/docs/guides/authentication/oidc/index.md
+++ b/en/identity-server/7.3.0/docs/guides/authentication/oidc/index.md
@@ -33,7 +33,7 @@ With JWT Secured Authorization Response Mode, clients can request authorization 
 
 ## Validate ID tokens
 
-This section explains how the signature and the claims are verifieed in the ID token that is sent by WSO2 Identity Server to an application.
+This section explains how the signature and the claims are verified in the ID token that is sent by WSO2 Identity Server to an application.
 
 [Validate ID tokens]({{base_path}}/guides/authentication/oidc/validate-id-tokens/) has detailed instructions on this.
 

--- a/en/identity-server/7.3.0/docs/guides/user-self-service/build-self-service-capabilities.md
+++ b/en/identity-server/7.3.0/docs/guides/user-self-service/build-self-service-capabilities.md
@@ -58,7 +58,7 @@ Learn more about registering OIDC applications on {{ product_name }}.
 
 - [SPA]({{base_path}}/guides/applications/register-single-page-app/)
 - [Traditional Web application]({{base_path}}/guides/applications/register-oidc-web-app/)
-- [Mobile appliction]({{base_path}}/guides/applications/register-mobile-app/)
+- [Mobile application]({{base_path}}/guides/applications/register-mobile-app/)
 
 
 ## Invoke the self-service APIs

--- a/en/identity-server/7.3.0/docs/guides/users/user-stores/primary-user-store/index.md
+++ b/en/identity-server/7.3.0/docs/guides/users/user-stores/primary-user-store/index.md
@@ -63,7 +63,7 @@ There are two steps involved in setting up the primary user store:
 
 2.  Configure user store manager properties.
 
-    In the `deployment.toml` file, you can configure the user store manager by adding the relevant properties of the seleted user store manager type.
+    In the `deployment.toml` file, you can configure the user store manager by adding the relevant properties of the selected user store manager type.
 
     Refer [properties used in user store managers]({{base_path}}/guides/users/user-stores/user-store-properties) for the complete list of user store configurations and properties.
     You can configure them as follows by adding to `<IS_HOME>/repository/conf/deployment.toml`.

--- a/en/identity-server/7.3.0/docs/references/troubleshoot/app-native-error-codes.md
+++ b/en/identity-server/7.3.0/docs/references/troubleshoot/app-native-error-codes.md
@@ -4,7 +4,7 @@ This document provides a list of error codes for the [authentication API]({{base
 
 | Error Code | HTTP status code  | Error message | Possible cause |
 |------------|-------------------|---------------|----------------|
-|401|401|Unauthorzed|Client authentication failure or client attestation failure.|
+|401|401|Unauthorized|Client authentication failure or client attestation failure.|
 |60001|400|Invalid authentication request.|Received authentication request is invalid.|
 |60002|400|Authentication failure.|Authentication flow has concluded with a failure.|
 |60003|400|Authentication failure.|Authentication failure please retry.|

--- a/en/identity-server/7.3.0/docs/references/tutorials/send-notification-external-schedular.md
+++ b/en/identity-server/7.3.0/docs/references/tutorials/send-notification-external-schedular.md
@@ -28,7 +28,7 @@ This tutorial illustrates how to send email notifications daily for users whose 
 
 **Step 4:** Sign in to [Azure portal](https://portal.azure.com/#home){:target="_blank"} with your Azure subscription.
 
-**Step 5:** Create a function app in Azure as discribed [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-function-app-portal?pivots=programming-language-python#create-a-function-app){:target="_blank"}. Select `Python` as the `Runtime stack` and `Linux` as the `Operating System`.
+**Step 5:** Create a function app in Azure as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-function-app-portal?pivots=programming-language-python#create-a-function-app){:target="_blank"}. Select `Python` as the `Runtime stack` and `Linux` as the `Operating System`.
 
 ### Develop Azure Function with Visual Studio Code
 
@@ -57,14 +57,14 @@ This tutorial illustrates how to send email notifications daily for users whose 
     </tr>
     <tr>
         <td>client_id</td>
-        <td>Client ID of the OIDC application creatde in WSO2 IS Server.</td>
+        <td>Client ID of the OIDC application created in WSO2 IS Server.</td>
     </tr>
     <tr>
         <td>client_secret</td>
-        <td>Client secret of the OIDC application creatde in WSO2 IS Server.</td>
+        <td>Client secret of the OIDC application created in WSO2 IS Server.</td>
     </tr>
     <tr>
-        <td>oragnization</td>
+        <td>organization</td>
         <td>Name of the organization.</td>
     </tr>
     <tr>
@@ -109,7 +109,7 @@ This tutorial illustrates how to send email notifications daily for users whose 
     </tr>
     <tr>
         <td>Directory location</td>
-        <td>Preferred empty file directory loaction</td>
+        <td>Preferred empty file directory location</td>
     </tr>
     <tr>
         <td>Language</td>


### PR DESCRIPTION
## Purpose
Fixes several spelling and grammar typos found across the currently deployed WSO2 Identity Server (7.3.0) and Asgardeo documentation, including a misspelling of the "Asgardeo" product name itself and an incorrect reference to "Filebeast" instead of "Filebeat".

## Related PRs
None

## Test environment
N/A - documentation-only change (spelling fixes)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
