### PR TITLE
Fix doubled word typos

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
@@ -75,7 +75,7 @@ Follow the instructions given below to enable SSL protocols and ciphers in `Thri
   
 ## Change the server name in HTTP response headers
 
-By default, the WSO2 Identity Server passes `WSO2 WSO2 IS server` as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 Identity Server stack will be exposed through HTTP responses. It is recommended to change this by configuring the server name in the `deployment.toml` file.
+By default, the WSO2 Identity Server passes `WSO2  IS server` as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 Identity Server stack will be exposed through HTTP responses. It is recommended to change this by configuring the server name in the `deployment.toml` file.
 
 1. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 2. Add a new server name by adding the following property under the relevant Tomcat connector configuration.


### PR DESCRIPTION
## Purpose
Fixes two doubled-word typos: "WSO2 WSO2 IS server" (including in a copy-pasteable `deployment.toml` config sample) should read "WSO2 IS server", and a duplicated "Family Name Name" label in a React tutorial code sample should read "Family Name".

## Related PRs
None

## Test environment
N/A - documentation-only change (spelling fixes)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


