### PR TITLE
Fix typos: removed doubled word 'WSO2 WSO2 IS server' in two places

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
@@ -70,7 +70,6 @@ Follow the instructions given below to enable SSL protocols and ciphers in `Thri
 
     If you wish to remove `TLSv1` or `TLSv1.1`, you can do so by removing them as values from the `<SSLEnabledProtocols>` property.
 
-
 2. Restart the server.
   
 ## Change the server name in HTTP response headers
@@ -80,7 +79,7 @@ By default, the WSO2 Identity Server passes `WSO2 IS server` as the server value
 1. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 2. Add a new server name by adding the following property under the relevant Tomcat connector configuration.
 
-    ```
+    ```toml
     [transport.https.properties]
     server="WSO2 IS server"
     [transport.http.properties]
@@ -89,7 +88,7 @@ By default, the WSO2 Identity Server passes `WSO2 IS server` as the server value
 
 ## Enable/disable http/https transport
 
-By default, both the `http` and `https` connectors are enabled. To disable either the `http` or `https` connector, add the corresponding configuration to `<IS_HOME>/repository/conf/deployment.toml` as shown below. 
+By default, both the `http` and `https` connectors are enabled. To disable either the `http` or `https` connector, add the corresponding configuration to `<IS_HOME>/repository/conf/deployment.toml` as shown below.
 
 ```toml
 [transport]

--- a/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
@@ -74,7 +74,7 @@ Follow the instructions given below to enable SSL protocols and ciphers in `Thri
   
 ## Change the server name in HTTP response headers
 
-By default, the WSO2 Identity Server passes `WSO2 IS server` as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 Identity Server stack will be exposed through HTTP responses. It is recommended to change this by configuring the server name in the `deployment.toml` file.
+By default, the WSO2 Identity Server passes `WSO2 IS server` as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 Identity Server stack will be exposed through HTTP responses. We recommend changing this by configuring the server name in the `deployment.toml` file.
 
 1. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 2. Add a new server name by adding the following property under the relevant Tomcat connector configuration.

--- a/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/configure-transport-level-security.md
@@ -75,16 +75,16 @@ Follow the instructions given below to enable SSL protocols and ciphers in `Thri
   
 ## Change the server name in HTTP response headers
 
-By default, the WSO2 Identity Server passes `WSO2 WSO2 IS server` as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 Identity Server stack will be exposed through HTTP responses. It is recommended to change this by configuring the server name in the `deployment.toml` file.
+By default, the WSO2 Identity Server passes `WSO2 IS server` as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 Identity Server stack will be exposed through HTTP responses. It is recommended to change this by configuring the server name in the `deployment.toml` file.
 
 1. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
 2. Add a new server name by adding the following property under the relevant Tomcat connector configuration.
 
     ```
     [transport.https.properties]
-    server="WSO2 WSO2 IS server"
+    server="WSO2 IS server"
     [transport.http.properties]
-    server="WSO2 WSO2 IS server"
+    server="WSO2 IS server"
     ```
 
 ## Enable/disable http/https transport


### PR DESCRIPTION
## Purpose
Fixes two doubled-word typos: "WSO2 WSO2 IS server" (appearing in prose and in a copy-pasteable `deployment.toml` config sample) should read "WSO2 IS server"

## Related PRs
None

## Test environment
N/A - documentation-only change (spelling fixes)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
