### PR TITLE
fix(typos): Removed doubled word (Name)

### DIFF
--- a/en/asgardeo/docs/tutorials/react-authentication-tutorial.md
+++ b/en/asgardeo/docs/tutorials/react-authentication-tutorial.md
@@ -314,7 +314,7 @@ function MyProfile() {
             {userData && (
                 <div>
                     <p> Given Name : {userData.name.givenName}</p>
-                    <p> Family Name Name : {userData.name.familyName}</p>
+                    <p> Family Name : {userData.name.familyName}</p>
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Purpose
Fixes a duplicated word in a React tutorial code sample: the profile display label read "Family Name Name" instead of "Family Name", inconsistent with the "Given Name" label right above it in the same component.

## Related PRs
None

## Test environment
N/A - documentation-only change (spelling fix)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?