### PR TITLE
Fix typo in WKA clustering description

### DIFF
--- a/en/identity-server/7.1.0/docs/deploy/deployment-guide.md
+++ b/en/identity-server/7.1.0/docs/deploy/deployment-guide.md
@@ -160,7 +160,7 @@ The following configurations need to be done in both the WSO2 Identity Server no
    `<IS_HOME>/repository/conf/deployment.toml` file.
 
     !!! info
-        The simplest is the well-known address (WKA) based clustering method. It only suites where all the nodes are deployed on machines having static IP addresses. <!--For more information, see [About Membership Schemes]({{base_path}}/deploy/clustering-overview/#about-membership-schemes).-->
+        The simplest is the well-known address (WKA) based clustering method. It only suits deployments where all the nodes are deployed on machines having static IP addresses. <!--For more information, see [About Membership Schemes]({{base_path}}/deploy/clustering-overview/#about-membership-schemes).-->
         Configurations for each membership scheme are listed below.
 
         ??? tip "Click to see the instructions for the WKA scheme"


### PR DESCRIPTION
## Purpose
This PR fixes a typo in the WKA clustering description in the deployment guide. The word "suites" (a noun meaning a set of rooms) has been corrected to the verb "suits" (meaning "is appropriate for"). The sentence structure was also slightly adjusted for better readability.

## Related PRs
None

## Test environment
N/A (Documentation change only)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


