### PR TITLE
Fix invalid HTML and grammar in checklists and references

### DIFF
--- a/en/identity-server/7.1.0/docs/deploy/deployment-checklist.md
+++ b/en/identity-server/7.1.0/docs/deploy/deployment-checklist.md
@@ -18,7 +18,9 @@
                          <li>Network-level security</li>
                     </ul>
                     <b> Related Topics </b>
+                    <ul>
                     <li><a href="{{base_path}}/deploy/security/security-guidelines/">Security Guidelines for Production Deployment</a></li>
+                    </ul>
                </td>
           </tr>
           <tr class="even">
@@ -26,7 +28,9 @@
                <td>
                     By default, WSO2 Identity Server identifies the hostname of the current machine through the Java API. However, this value sometimes yields erroneous results on some environments. Therefore, users are recommended to configure the hostname by setting the relevant parameter in the <code>&lt;IS_HOME&gt;/repository/conf/deployment.toml</code> file. <br />
                     <b> Related Topics </b>
+                    <ul>
                     <li><a href="{{base_path}}/deploy/change-the-hostname">Change the hostname</a></li>
+                    </ul>
                </td>
           </tr>
           <tr class="even">
@@ -56,7 +60,9 @@
                <td>
                     WSO2 Identity Server has additional guidelines for optimizing the performance of product-specific features. <br />
                     <b>Related Topics</b>
+                    <ul>
                     <li><a href="{{base_path}}/deploy/performance/performance-tuning-recommendations">Performance Tuning Recommendations</a> </li>
+                    </ul>
                </td>
           </tr>
           <tr class="odd">

--- a/en/identity-server/7.1.0/docs/references/grant-types.md
+++ b/en/identity-server/7.1.0/docs/references/grant-types.md
@@ -16,7 +16,7 @@
     you can turn on or turn off the process of issuing ID tokens for the grant types that have the `openid` scope. 
     By default, `IdTokenAllowed` is set to `true`, you can allow it to issue `id_tokens` for all grant types that have 
     the `openid` scope. By configuring it to false, you can stop issuing ID tokens.  
-    **Note:** You can not turn off the process of issuing ID tokens for the `authorization_code` grant type.
+    **Note:** You cannot turn off the process of issuing ID tokens for the `authorization_code` grant type.
 
     By configuring the `<IsRefreshTokenAllowed>` property to `true` or `false` along with the above configuration, 
     you can turn on or turn on the process of issuing refresh tokens. By default, `IsRefreshTokenAllowed` is set to 


### PR DESCRIPTION
## Purpose
This PR fixes formatting and grammar in the checklist and reference documentation:
1. `deployment-checklist.md`: Fixed invalid HTML where multiple `<li>` elements were placed outside of a parent `<ul>` or `<ol>` container, causing inconsistent rendering.
2. `grant-types.md`: Corrected grammar by changing "can not" (implying a choice) to "cannot" (expressing a strict inability/technical constraint).

## Related PRs
None

## Test environment
N/A (Documentation change only)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?



