### PR TITLE
[Asgardeo Docs] Add behavioral change notice for redirect_uris format in DCR API response

### DIFF
--- a/en/asgardeo/docs/apis/restapis/oauth-dcr.yaml
+++ b/en/asgardeo/docs/apis/restapis/oauth-dcr.yaml
@@ -403,6 +403,9 @@ components:
           type: array
           items:
             type: string
+          description: >
+            The redirect URIs registered for the application.
+            For organizations created on or after August 1, 2026, this is returned as an array of individual URI strings when multiple redirect URIs are registered.
         grant_types:
           type: array
           example:

--- a/en/asgardeo/docs/apis/restapis/oauth-dcr.yaml
+++ b/en/asgardeo/docs/apis/restapis/oauth-dcr.yaml
@@ -405,7 +405,7 @@ components:
             type: string
           description: >
             The redirect URIs registered for the application.
-            For organizations created on or after August 1, 2026, this is returned as an array of individual URI strings when multiple redirect URIs are registered.
+            For organizations created on or after August 1, 2026, when multiple redirect URIs are registered, the response returns each URI as a separate string in an array.
         grant_types:
           type: array
           example:


### PR DESCRIPTION
## Summary

Starting August 1, 2026, the `redirect_uris` field in DCR API responses will behave differently based on when the organization was created:

- **Organizations created on or after August 1, 2026**: `redirect_uris` returned as an array of individual URI strings.
- **Organizations created before August 1, 2026**: `redirect_uris` returned as a single-element array containing a `regexp=(...)` pattern when multiple redirect URIs are registered.

This notice is added to the Asgardeo DCR API spec description to inform API consumers ahead of the change.

## Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3263
- https://github.com/wso2/carbon-identity-framework/pull/8175