### PR TITLE
Fix misspellings in documentation

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/application.yaml
@@ -1235,7 +1235,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/asgardeo/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -2087,7 +2087,7 @@ components:
           type: string
           description: "
             <ul>
-              <li> <b>DEFAULT</b> type indicates that the application will use the default authentication sequence specified at the organization level. When the DEFAULT type is used, the information given in the other fields of the `AuthenticationSequence` will be ignored and overriden with values defined at the organization level.</li>
+              <li> <b>DEFAULT</b> type indicates that the application will use the default authentication sequence specified at the organization level. When the DEFAULT type is used, the information given in the other fields of the `AuthenticationSequence` will be ignored and overridden with values defined at the organization level.</li>
               <li> <b>USER_DEFINED</b> type indicates that the application will use a user-defined authentication sequence.</li>
             </ul>"
           enum:

--- a/en/asgardeo/docs/apis/restapis/application-management.yaml
+++ b/en/asgardeo/docs/apis/restapis/application-management.yaml
@@ -4948,7 +4948,7 @@ components:
           type: string
           description: "
           <ul>
-            <li> <b>DEFAULT</b> type indicates that the application will use the default authentication sequence specified at the organization level. When the DEFAULT type is used, the information given in the other fields of the `AuthenticationSequence` will be ignored and overriden with values defined at the organization level.</li>
+            <li> <b>DEFAULT</b> type indicates that the application will use the default authentication sequence specified at the organization level. When the DEFAULT type is used, the information given in the other fields of the `AuthenticationSequence` will be ignored and overridden with values defined at the organization level.</li>
             <li> <b>USER_DEFINED</b> type indicates that the application will use a user-defined authentication sequence.</li>
           </ul>"
           enum:

--- a/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/7.0.0/docs/apis/organization-apis/restapis/application.yaml
@@ -1226,7 +1226,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.0.0/docs/apis/restapis/application.yaml
+++ b/en/identity-server/7.0.0/docs/apis/restapis/application.yaml
@@ -4962,7 +4962,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.0.0/docs/deploy/configure/session-persistence.md
+++ b/en/identity-server/7.0.0/docs/deploy/configure/session-persistence.md
@@ -102,7 +102,7 @@ The `[session_data.cleanup]` section is related to the cleaning up of session da
 ## Importance of correct `Deletechunksize`
 
 In the world of the World Wide Web, sessions are the simplest way to store data for individual users against a unique session ID. These can be used to persist state information between page requests. When all
-the requests ad responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
+the requests and responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
 
 After a certain period, these session data are not necessary. To stop the exponential table growth, a Session Clean Up Task in predefined time intervals is run via a script. If this storing session data is huge, the data that need to be deleted also will come in bulk.
 

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/application.yaml
@@ -1226,7 +1226,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/7.1.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -2105,7 +2105,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.1.0/docs/apis/restapis/application.yaml
+++ b/en/identity-server/7.1.0/docs/apis/restapis/application.yaml
@@ -5063,7 +5063,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.1.0/docs/deploy/configure/session-persistence.md
+++ b/en/identity-server/7.1.0/docs/deploy/configure/session-persistence.md
@@ -102,7 +102,7 @@ The `[session_data.cleanup]` section is related to the cleaning up of session da
 ## Importance of correct `Deletechunksize`
 
 In the world of the World Wide Web, sessions are the simplest way to store data for individual users against a unique session ID. These can be used to persist state information between page requests. When all
-the requests ad responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
+the requests and responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
 
 After a certain period, these session data are not necessary. To stop the exponential table growth, a Session Clean Up Task in predefined time intervals is run via a script. If this storing session data is huge, the data that need to be deleted also will come in bulk.
 

--- a/en/identity-server/7.2.0/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/7.2.0/docs/apis/organization-apis/restapis/application.yaml
@@ -1226,7 +1226,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.2.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/7.2.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -2425,7 +2425,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.2.0/docs/deploy/configure/session-persistence.md
+++ b/en/identity-server/7.2.0/docs/deploy/configure/session-persistence.md
@@ -102,7 +102,7 @@ The `[session_data.cleanup]` section is related to the cleaning up of session da
 ## Importance of correct `Deletechunksize`
 
 In the world of the World Wide Web, sessions are the simplest way to store data for individual users against a unique session ID. These can be used to persist state information between page requests. When all
-the requests ad responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
+the requests and responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
 
 After a certain period, these session data are not necessary. To stop the exponential table growth, a Session Clean Up Task in predefined time intervals is run via a script. If this storing session data is huge, the data that need to be deleted also will come in bulk.
 

--- a/en/identity-server/7.3.0/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/7.3.0/docs/apis/organization-apis/restapis/application.yaml
@@ -1230,7 +1230,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.3.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/7.3.0/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -2470,7 +2470,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/7.3.0/docs/deploy/configure/session-persistence.md
+++ b/en/identity-server/7.3.0/docs/deploy/configure/session-persistence.md
@@ -102,7 +102,7 @@ The `[session_data.cleanup]` section is related to the cleaning up of session da
 ## Importance of correct `Deletechunksize`
 
 In the world of the World Wide Web, sessions are the simplest way to store data for individual users against a unique session ID. These can be used to persist state information between page requests. When all
-the requests ad responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
+the requests and responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
 
 After a certain period, these session data are not necessary. To stop the exponential table growth, a Session Clean Up Task in predefined time intervals is run via a script. If this storing session data is huge, the data that need to be deleted also will come in bulk.
 

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/application.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/application.yaml
@@ -1230,7 +1230,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/org-application-mgt.yaml
@@ -2470,7 +2470,7 @@ components:
         type:
           type: string
           description: "
-          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overriden with values defined at the tenant level.
+          - DEFAULT type indicates that the application will use the default authentication sequence specified at the tenant level. When the DEFAULT type is used, the information given in the other fields of the AuthenticationSequence will be ignored and overridden with values defined at the tenant level.
 
            - USER_DEFINED type indicates that the application will use a user-defined authentication sequence."
           enum:

--- a/en/identity-server/next/docs/deploy/configure/session-persistence.md
+++ b/en/identity-server/next/docs/deploy/configure/session-persistence.md
@@ -102,7 +102,7 @@ The `[session_data.cleanup]` section is related to the cleaning up of session da
 ## Importance of correct `Deletechunksize`
 
 In the world of the World Wide Web, sessions are the simplest way to store data for individual users against a unique session ID. These can be used to persist state information between page requests. When all
-the requests ad responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
+the requests and responses that come to a page per day are considered, that is a large amount. Due to this reason, the session data stored in the “IDN\_AUTH\_SESSION\_STORE ” table in the WSO2CARBON\_DB of WSO2 IS is high. This table fills up quickly if your system receives too many loads of requests.
 
 After a certain period, these session data are not necessary. To stop the exponential table growth, a Session Clean Up Task in predefined time intervals is run via a script. If this storing session data is huge, the data that need to be deleted also will come in bulk.
 

--- a/en/includes/deploy/configure-console-hostname.md
+++ b/en/includes/deploy/configure-console-hostname.md
@@ -13,7 +13,7 @@ This guide outlines two strategies to achieve this in {{product_name}}:
 
 The most robust security model involves physically or logically separating the infrastructure into two planes: a **Control Plane** for administration and a **Data Plane** for runtime operations.
 
-![data-plane-control-plane-seperation]({{base_path}}/assets/img/deploy/data-plane-control-plane-seperation.png)
+![data-plane-control-plane-separation]({{base_path}}/assets/img/deploy/data-plane-control-plane-seperation.png)
 
 ### 1. Control plane (internal)
 


### PR DESCRIPTION
## Purpose
Corrects spelling errors across documentation (Asgardeo, shared includes, and Identity Server 7.0.0 onward including next):
- "requests ad responses" to "requests and responses" in the session persistence guide (next, 7.0, 7.1, 7.2, 7.3).
- "overriden" to "overridden" in the application management API descriptions (14 files).
- Image alt text "data-plane-control-plane-seperation" to "separation" in the console hostname guide.

The image filename itself was left unchanged because it is a binary asset referenced from a shared include and duplicated across version asset directories; renaming it risks broken image links.

## Related PRs
None

## Test environment
Documentation-only change.

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


