### PR TITLE
Fix certificate description in OIDC and SAML app settings

### DIFF
--- a/en/includes/references/app-settings/oidc-settings-for-app.md
+++ b/en/includes/references/app-settings/oidc-settings-for-app.md
@@ -267,7 +267,7 @@ The following configurations are related to the ID token.
 {% include "../../guides/fragments/manage-app/oidc-settings/refresh-token.md" %}
 
 ### Certificate
-Certificates play a critical role in validating signatures on signed requests and encrypting sensitive information in requests. To add a certificate, you can either upload one or provide a JWKS endpoint.
+Certificates play a critical role in validating signatures on signed requests from the application and encrypting sensitive information (such as ID tokens) sent to the application. To add a certificate, you can either upload one or provide a JWKS endpoint.
 
 To upload a certificate, select **Provide certificate** and upload a certificate in the `.pem` format.
 

--- a/en/includes/references/app-settings/oidc-settings-for-app.md
+++ b/en/includes/references/app-settings/oidc-settings-for-app.md
@@ -267,7 +267,7 @@ The following configurations are related to the ID token.
 {% include "../../guides/fragments/manage-app/oidc-settings/refresh-token.md" %}
 
 ### Certificate
-Certificates play a critical role in validating signatures on signed requests from the application and encrypting sensitive information (such as ID tokens) sent to the application. To add a certificate, you can either upload one or provide a JWKS endpoint.
+Certificates play a critical role in validating signatures on signed requests from the application and encrypting the ID token sent to the application when [ID token encryption](#enable-encryption) is enabled. To add a certificate, you can either upload one or provide a JWKS endpoint.
 
 To upload a certificate, select **Provide certificate** and upload a certificate in the `.pem` format.
 

--- a/en/includes/references/app-settings/saml-settings-for-app.md
+++ b/en/includes/references/app-settings/saml-settings-for-app.md
@@ -287,7 +287,7 @@ Note that, you need to encode the URLs before calling the single logout service.
 
 ### Certificate
 
-The certificate is used to validate signatures when authentication requests or logout requests from the application are signed. Note that request signature validation should be [enabled](#enable-request-signature-validation).
+The certificate is used to validate signatures when authentication requests or logout requests from the application are signed, and to encrypt the SAML assertion sent to the application. Note that request signature validation should be [enabled](#enable-request-signature-validation) for signature validation, and [assertion encryption](#enable-encryption) should be enabled for encryption.
 <br>
 You can either upload your certificate file or copy the contents. Follow the steps given below.
 

--- a/en/includes/references/app-settings/saml-settings-for-app.md
+++ b/en/includes/references/app-settings/saml-settings-for-app.md
@@ -287,7 +287,7 @@ Note that, you need to encode the URLs before calling the single logout service.
 
 ### Certificate
 
-The certificate is used to validate signatures when authentication requests or logout requests from the application are signed, and to encrypt the SAML assertion sent to the application. Note that request signature validation should be [enabled](#enable-request-signature-validation) for signature validation, and [assertion encryption](#enable-encryption) should be enabled for encryption.
+{{ product_name }} uses the certificate to validate signatures on signed authentication and logout requests from the application, and to encrypt the SAML assertion sent to the application. Make sure to [enable request signature validation](#enable-request-signature-validation) for signature validation, and [enable assertion encryption](#enable-encryption) for assertion encryption.
 <br>
 You can either upload your certificate file or copy the contents. Follow the steps given below.
 


### PR DESCRIPTION
## Summary

- Corrected the OIDC app settings certificate description, which incorrectly stated that the certificate is used to encrypt information in requests. The certificate is actually used to encrypt information sent to the application (for example, ID tokens).
- Updated the SAML app settings certificate description to also mention that the certificate is used to encrypt the SAML assertion sent to the application, in addition to validating signatures on inbound requests.