### PR TITLE
Fix broken card icons on app/idp settings index pages

### DIFF
--- a/en/includes/guides/authentication/user-attributes/index.md
+++ b/en/includes/guides/authentication/user-attributes/index.md
@@ -4,11 +4,11 @@
 
   <div class="cards-container">
     <a href="../../../guides/authentication/user-attributes/enable-attributes-for-oidc-app" class="card square">
-      <img src="../../../assets/img/logo/oidc-logo.svg" alt="OIDC" />
+      <img class="skip-glightbox" src="../../../assets/img/logo/oidc-logo.svg" alt="OIDC" />
       <span>OpenID Connect apps</span>
     </a>
     <a href="../../../guides/authentication/user-attributes/enable-attributes-for-saml-app" class="card square">
-      <img src="../../../assets/img/logo/saml-logo.svg" alt="SAML" />
+      <img class="skip-glightbox" src="../../../assets/img/logo/saml-logo.svg" alt="SAML" />
       <span>SAML apps</span>
     </a>
   </div>

--- a/en/includes/references/app-settings/index.md
+++ b/en/includes/references/app-settings/index.md
@@ -4,15 +4,15 @@
 
   <div class="cards-container">
     <a href="../../references/app-settings/oidc-settings-for-app" class="card square">
-      <img src="../../assets/img/logo/oidc-logo.svg" alt="OIDC" />
+      <img class="skip-glightbox" src="../../assets/img/logo/oidc-logo.svg" alt="OIDC" />
       <span>OpenID Connect</span>
     </a>
     <a href="../../references/app-settings/saml-settings-for-app" class="card square">
-      <img src="../../assets/img/logo/saml-logo.svg" alt="SAML" />
+      <img class="skip-glightbox" src="../../assets/img/logo/saml-logo.svg" alt="SAML" />
       <span>SAML</span>
     </a>
     <a href="../../references/app-settings/ws-federation-settings-for-app" class="card square">
-      <img src="../../assets/img/logo/ws-fed.svg" alt="WS-Federation" />
+      <img class="skip-glightbox" src="../../assets/img/logo/ws-fed.svg" alt="WS-Federation" /><br />
       <span>WS-Federation</span>
     </a>
   </div>

--- a/en/includes/references/idp-settings/index.md
+++ b/en/includes/references/idp-settings/index.md
@@ -4,11 +4,11 @@
 
   <div class="cards-container">
     <a href="../../references/idp-settings/oidc-settings-for-idp/" class="card square">
-      <img src="../../assets/img/logo/oidc-logo.svg" alt="OIDC" />
+      <img class="skip-glightbox" src="../../assets/img/logo/oidc-logo.svg" alt="OIDC" />
       <span>OpenID Connect</span>
     </a>
     <a href="../../references/idp-settings/saml-settings-for-idp/" class="card square">
-      <img src="../../assets/img/logo/saml-logo.svg" alt="SAML" />
+      <img class="skip-glightbox" src="../../assets/img/logo/saml-logo.svg" alt="SAML" />
       <span>SAML</span>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- Added `class="skip-glightbox"` to card icons on the app-settings and idp-settings index pages so the `glightbox` plugin stops wrapping them and breaking the card links.
- Added extra line breaks after the wide/short `ws-fed.svg` on the app-settings card to keep the WS-Federation card vertically aligned with the OIDC/SAML cards.