### PR TITLE
Remove Beta and Preview labels from Asgardeo, IS 7.3.0, and next docs

### DIFF
--- a/en/asgardeo/docs/guides/account-configurations/account-login/configure-login-identifiers.md
+++ b/en/asgardeo/docs/guides/account-configurations/account-login/configure-login-identifiers.md
@@ -1,8 +1,5 @@
 # Configure alternative login identifiers
 
-!!! note
-    The feature is in the Beta stage. We are working on adding more capabilities for this feature.
-
 You can now configure alternative login identifiers so that the users of your WSO2 Identity Platform organization have the capability to use these identifiers to log in.
 
 !!! note

--- a/en/asgardeo/docs/guides/user-accounts/account-login/configure-login-identifiers.md
+++ b/en/asgardeo/docs/guides/user-accounts/account-login/configure-login-identifiers.md
@@ -1,8 +1,5 @@
 # Configure alternative login identifiers
 
-!!! note
-    The feature is in the Beta stage. We are working on adding more capabilities for this feature.
-
 You can now configure alternative login identifiers so that the users of your WSO2 Identity Platform organization have the capability to use these identifiers to log in.
 
 !!! note

--- a/en/asgardeo/mkdocs.yml
+++ b/en/asgardeo/mkdocs.yml
@@ -32,11 +32,6 @@ theme:
 extra:
   base_path: /asgardeo/docs
   product: asgardeo
-  nav_chip:
-    Customer Data:
-      type: Preview
-    Flow Extensions:
-      type: Beta
   content:
     sdkconfig:
       baseUrl: "https://api.asgardeo.io/t/<your-organization-name>"

--- a/en/includes/guides/account-configurations/user-onboarding/self-registration-flow.md
+++ b/en/includes/guides/account-configurations/user-onboarding/self-registration-flow.md
@@ -1,10 +1,6 @@
-<h1>Self-register Flow Builder <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div></h1>
+<h1>Self-register Flow Builder</h1>
 
 ![Self register flow banner]({{base_path}}/assets/img/guides/organization/self-registration/self-register-flow-banner.png){: width="auto" style="display: block; margin: 0;"}
-
-!!! Note
-
-    The self-registration Flow Builder is currently in **Preview**. Some features may be subject to changes in future releases.
 
 The self-registration Flow Builder provides administrators with a powerful tool to create fully customizable user registration experiences. Whether you're building a simple registration form or a complex, multi-step flow, the builder gives you complete control over the design and process.
 

--- a/en/includes/guides/authentication/login-flow-ai.md
+++ b/en/includes/guides/authentication/login-flow-ai.md
@@ -1,7 +1,9 @@
 # Login Flow AI
 
+{% if product_name == "WSO2 Identity Server" and is_version in ["7.1.0", "7.2.0"] %}
 !!! warning "Beta feature"
     The **AI Login Flow Generation** feature is currently in **Beta**. We are actively working to enhance its capabilities and improve performance.
+{% endif %}
 
 AI-powered login flow generation simplifies the setup of authentication sequences in {{product_name}} by using an AI-driven approach. This tool allows users to efficiently create tailored authentication sequences without needing in-depth knowledge of the underlying authenticators or scripting languages.
 

--- a/en/includes/guides/branding/branding-ai.md
+++ b/en/includes/guides/branding/branding-ai.md
@@ -1,7 +1,9 @@
 # Branding AI
 
+{% if product_name == "WSO2 Identity Server" and is_version in ["7.1.0", "7.2.0"] %}
 !!! warning "Beta feature"
     The **AI Branding** feature is currently in **Beta**. We are actively working to enhance its capabilities and improve performance.
+{% endif %}
 
 AI-powered branding simplifies the process of creating a cohesive branding theme by using AI to analyze your website's existing visual elements. This innovative service automates the identification and application of design elements such as colors, fonts, and button styles, ensuring brand consistency and reducing manual effort.
 

--- a/en/includes/guides/customer-data/concepts/profile-attributes.md
+++ b/en/includes/guides/customer-data/concepts/profile-attributes.md
@@ -2,10 +2,6 @@
 
 # Profile attributes
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 **Profile attributes** define the shape of data that can be stored on a profile for your organization. They control attribute names, types, mutability, and how values are resolved when two profiles are merged.
 
 Together, the set of profile attributes defined for your organization makes up the **profile attribute schema**.

--- a/en/includes/guides/customer-data/concepts/profiles.md
+++ b/en/includes/guides/customer-data/concepts/profiles.md
@@ -2,10 +2,6 @@
 
 # Profiles
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 A **profile** is the central entity in the Customer Data Service. It represents a single person's collected data, their identity attributes, behavioral traits, and per application data unified across all interactions.
 
 ![Profile List]({{base_path}}/assets/img/guides/customer-data/temporary-profiles-list.png){: width="auto" style="display: block; margin: 0;"}

--- a/en/includes/guides/customer-data/concepts/unification-rules.md
+++ b/en/includes/guides/customer-data/concepts/unification-rules.md
@@ -2,10 +2,6 @@
 
 # Unification rules
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 **Unification rules** tell the Customer Data Service when two separate profiles should be recognized as the same person and merged. Each rule specifies a profile attribute to match on, if two profiles share the same value for that attribute, they are candidates for merging.
 
 ---

--- a/en/includes/guides/customer-data/enable-customer-data-service.md
+++ b/en/includes/guides/customer-data/enable-customer-data-service.md
@@ -1,12 +1,8 @@
 {% if product == "asgardeo" %}
 
-<h1>Enable customer data service <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div></h1>
+<h1>Enable customer data service</h1>
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
-The Customer Data Service is hidden behind Feature Preview while in Preview. Once you enable it for your organization, a new **Customer Data** entry appears in the left navigation pane.
+The Customer Data Service is hidden behind Feature Preview. Once you enable it for your organization, a new **Customer Data** entry appears in the left navigation pane.
 
 ## Enable from Feature Preview
 

--- a/en/includes/guides/customer-data/guides/manage-profile-attributes.md
+++ b/en/includes/guides/customer-data/guides/manage-profile-attributes.md
@@ -2,10 +2,6 @@
 
 # Manage profile attributes
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 Profile attributes control which fields can be stored on a profile and how they behave. Manage them from **Customer Data** → **Profile Attributes** in the console.
 
 For a conceptual overview of attribute types, mutability, and merge strategies see [Profile attributes]({{base_path}}/guides/customer-data/concepts/profile-attributes).

--- a/en/includes/guides/customer-data/guides/manage-unification-rules.md
+++ b/en/includes/guides/customer-data/guides/manage-unification-rules.md
@@ -2,10 +2,6 @@
 
 # Manage unification rules
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 Unification rules tell the Customer Data Service when two profiles should be recognized as the same person and merged. Manage them from **Customer Data** → **Unification Rules** in the console.
 
 For a conceptual overview see [Unification rules]({{base_path}}/guides/customer-data/concepts/unification-rules).

--- a/en/includes/guides/customer-data/index.md
+++ b/en/includes/guides/customer-data/index.md
@@ -5,7 +5,7 @@
 The Customer Data Service (CDS) collects and unifies data about your end users across every interaction with your applications. It gives each user a single profile that represents who they are and what they have done across your applications.
 
 !!! note
-    Customer Data Service is currently in **Preview**. You need to enable it from **Feature Preview** before the **Customer Data** section appears in the console. See [Enable Customer Data Service]({{base_path}}/guides/customer-data/enable-customer-data-service).
+    You need to enable Customer Data Service from **Feature Preview** before the **Customer Data** section appears in the console. See [Enable Customer Data Service]({{base_path}}/guides/customer-data/enable-customer-data-service).
 
 ## What you can do with it
 

--- a/en/includes/guides/customer-data/use-cases/cross-device.md
+++ b/en/includes/guides/customer-data/use-cases/cross-device.md
@@ -2,10 +2,6 @@
 
 # Accumulate data across multiple devices
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 ## Overview
 
 This use case keeps a single user's activity together even when they reach your application from more than one device.

--- a/en/includes/guides/customer-data/use-cases/index.md
+++ b/en/includes/guides/customer-data/use-cases/index.md
@@ -1,12 +1,8 @@
 {% if product == "asgardeo" %}
 
-<h1>Customer data service use cases <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div></h1>
+<h1>Customer data service use cases</h1>
 
 These guides show common patterns for integrating with the Customer Data Service from your application. They capture visitor activity even before an account is created, and unify it into a single profile that follows the user across sessions, devices, and applications.
-
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
 
 ---
 

--- a/en/includes/guides/customer-data/use-cases/lead-stitching.md
+++ b/en/includes/guides/customer-data/use-cases/lead-stitching.md
@@ -2,10 +2,6 @@
 
 # Stitch user profiles across websites
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 ## Overview
 
 Lead stitching brings a person's anonymous activity together across **separate applications or domains**, before they ever create an account. It works by matching on a shared identifier such as their email address.

--- a/en/includes/guides/customer-data/use-cases/self-registration.md
+++ b/en/includes/guides/customer-data/use-cases/self-registration.md
@@ -2,10 +2,6 @@
 
 # Unify anonymous and registered profiles
 
-!!! note
-
-    The Customer Data Service is currently in **Preview**. Some features may be subject to changes in future releases.
-
 ## Overview
 
 This use case keeps a visitor's activity attached to them as they go from an anonymous visitor to a registered user.

--- a/en/includes/guides/flows/flow-ai.md
+++ b/en/includes/guides/flows/flow-ai.md
@@ -1,7 +1,9 @@
 # Flow AI
 
+{% if product_name == "WSO2 Identity Server" and is_version == "7.2.0" %}
 !!! warning "Beta feature"
     The **AI Flow Builder** feature is currently in **Beta**. We are actively working to enhance its capabilities and improve performance.
+{% endif %}
 
 AI-powered flow building simplifies the process of creating complex user journeys by using AI to translate your requirements into functional flows. This automates the setup of registration and recovery flows based on plain language descriptions, reducing manual configuration effort.
 

--- a/en/includes/guides/organization-insights.md
+++ b/en/includes/guides/organization-insights.md
@@ -1,8 +1,5 @@
 # Organization Insights
 
-!!! note
-    The feature is in the **Beta** stage. We are working on adding more capabilities for this feature.
-
 {{ product_name }} allows administrators and organization owners to view insights of the organizations they manage.
 
 To check insights of your organization:

--- a/en/includes/guides/service-extensions/understanding-service-extensions.md
+++ b/en/includes/guides/service-extensions/understanding-service-extensions.md
@@ -86,7 +86,6 @@ The following table lists the currently supported extensions and those in the ro
 <tr class="header">
 <th>Flow</th>
 <th>Trigger</th>
-<th>Availability</th>
 <th>Example use cases</th>
 </tr>
 </thead>
@@ -94,7 +93,6 @@ The following table lists the currently supported extensions and those in the ro
 <tr class="odd">
 <td>Login</td>
 <td>Authenticate</td>
-<td>Early access (beta)</td>
 <td>
 <ul>
 <li><p>Call an external service to authenticate the user.</p></li>
@@ -104,7 +102,6 @@ The following table lists the currently supported extensions and those in the ro
 <tr class="even">
 <td>Token management</td>
 <td>Pre issue access token</td>
-<td>Early access (beta)</td>
 <td>
 <ul>
 <li><p>Prevent tokens from being issued based on policy or change permissions, scopes.</p></li>
@@ -114,32 +111,17 @@ The following table lists the currently supported extensions and those in the ro
 </td>
 </tr>
 <tr class="odd">
-<td>Registration</td>
-<td>Pre registration</td>
-<td>Early May 2025</td>
-<td>
-<ul>
-<li><p>Deny registration by location.</p></li>
-<li><p>Set additional data in the user profile.</p></li>
-<li><p>Initiate an external service to trigger a verification such as an approval, biometrics, allowed lists, etc.</p></li>
-<li><p>Verify for sanctioned countries, initiate screening processes.</p></li>
-</ul>
-</td>
-</tr>
-<tr class="even">
 <td>Password update</td>
 <td>Pre password update</td>
-<td>Early access (beta)</td>
 <td>
 <ul>
 <li><p>Integrate with credential intelligence services to verify the security of password, or check against allowed lists.</p></li>
 </ul>
 </td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>Profile update</td>
 <td>Pre profile update</td>
-<td>Early access (beta)</td>
 <td>
 <ul>
 <li><p>Automated verification of user attributes.</p></li>

--- a/en/includes/guides/webhooks/understanding-webhooks.md
+++ b/en/includes/guides/webhooks/understanding-webhooks.md
@@ -11,10 +11,6 @@ Using webhooks, you can seamlessly integrate external systems with {{product_nam
 
 {% if product_name == "WSO2 Identity Platform" %}
 {{product_name}} webhooks use the [WebSubHub](https://websubhub.com/) protocol for secure and reliable event delivery.
-
-!!! Note
-      This feature is currently in **Preview**. Functionality and event payloads may change during development.  
-      Expect updates without prior notice.
 {% endif %}
 
 ## How webhooks work

--- a/en/includes/guides/webhooks/webhook-events-and-payloads.md
+++ b/en/includes/guides/webhooks/webhook-events-and-payloads.md
@@ -1,15 +1,9 @@
-# Webhook events and payloads {% if product_name == "WSO2 Identity Platform" %}<div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div>{% endif %}
+# Webhook events and payloads
 
 This guide details the webhook event types dispatched by {{product_name}}. For each event, you'll find JSON payload examples and descriptions of their properties.
 
 !!! Note
       In webhook event payloads, <code>initiatorIpAddress</code> (when present) represents the IP address of the initiator that triggered the event.
-
-{% if product_name == "WSO2 Identity Platform" %}
-!!! Note
-      This feature is currently in **Preview**. Functionality and event payloads may change during development.  
-      Expect updates without prior notice.
-{% endif %}
 
 ## Login events
 

--- a/en/includes/quick-starts/mcp-server.md
+++ b/en/includes/quick-starts/mcp-server.md
@@ -1,12 +1,8 @@
-# WSO2 Identity Platform MCP Server <div class="md-chip md-chip--preview"><span class="md-chip__label">Preview</span></div>
+# WSO2 Identity Platform MCP Server
 
 The **WSO2 Identity Platform MCP Server** helps you manage identity and access management tasks using natural language prompts. It connects your code editor or AI tool to WSO2 Identity Platform’s Management APIs, letting you automate common identity management operations—such as listing applications, updating application settings, or managing users—without going through UI interfaces or needing to write API calls.
 
 You can use the WSO2 Identity Platform MCP Server with popular editors and tools like **VS Code, Claude Desktop, Cursor, Windsurf**, and others. The MCP server acts as a bridge between your editor and WSO2 Identity Platform, handling authentication and API requests for you. This quickstart explains how to set up the server, connect it to your WSO2 Identity Platform organization, and verify your setup.
-
-!!! Note
-
-    The WSO2 Identity Platform MCP Server is currently in **Preview**. Some features may be subject to changes in future releases.
 
 ## On WSO2 Identity Platform
 


### PR DESCRIPTION
## Purpose

Several features documented for Asgardeo, IS 7.3.0, and `next` are now generally available, so their Beta and Preview labels are no longer accurate. This PR removes those labels while keeping them intact for IS 7.0.0–7.2.0, where the features remain in Beta.

## Related Issue

- N/A

## Implementation

- Removed the `nav_chip` entries for Customer Data (Preview) and Flow Extensions (Beta) from `en/asgardeo/mkdocs.yml`.
- Removed Preview chips and Preview admonition notes from all Customer Data Service pages, the MCP Server quickstart, the self-registration Flow Builder page, and the webhooks pages.
- Removed Beta admonition notes from Login Flow AI, Branding AI, Flow AI, Organization Insights, and the alternative login identifier pages.
- Removed the "Availability" column with "Early access (beta)" entries and the Registration roadmap row from the service extensions table (WSO2 Identity Platform variant only).
- Since `en/includes` is shared across all IS versions, the Beta notes for Login Flow AI, Branding AI, and Flow AI are re-added behind `is_version` conditionals so they continue to render for IS 7.1.0/7.2.0 (Flow AI: 7.2.0 only), matching the existing conditional pattern used in the includes. IS 7.0.0–7.2.0 output is unchanged.