### PR TITLE
Add link to Asgardeo–InCountry integration guide

### DIFF
--- a/en/asgardeo/docs/references/data-residency-in-asgardeo.md
+++ b/en/asgardeo/docs/references/data-residency-in-asgardeo.md
@@ -119,7 +119,7 @@ Learn about WSO2 Identity Platform's [privacy policy](https://wso2.com/identity-
 
 ## Extended data residency with InCountry
 
-If you need identity data to remain within a specific country's borders—beyond the US and EU regional data centers described above—{{product_name}} integrates with [InCountry](https://incountry.com/){:target="_blank"}, a data residency platform. This integration lets you localize and mask identity data (such as profile fields used in registration, login, and tokens) so that it is stored and processed within your required jurisdiction.
+If you need identity data to remain within a specific country's borders beyond the US and EU regional data centers described above, {{product_name}} integrates with [InCountry](https://incountry.com/){:target="_blank"}, a data residency platform. This integration lets you localize and mask identity data (such as profile fields used in registration, login, and tokens) so that it is stored and processed within your required jurisdiction.
 
 For setup details, see the [WSO2 Asgardeo + InCountry integration guide](https://incountry.com/integrations/wso2-asgardeo/){:target="_blank"}.
 

--- a/en/asgardeo/docs/references/data-residency-in-asgardeo.md
+++ b/en/asgardeo/docs/references/data-residency-in-asgardeo.md
@@ -117,6 +117,12 @@ Therefore, note that your organization–level logs may include personal informa
 
 Learn about WSO2 Identity Platform's [privacy policy](https://wso2.com/identity-platform/privacy-policy/#:~:text=Asgardeo%20doesn%27t%20store%20any,API%20Services%20User%20Data%20Policy.) to understand how your data privacy is protected.
 
+## Extended data residency with InCountry
+
+If you need identity data to remain within a specific country's borders—beyond the US and EU regional data centers described above—{{product_name}} integrates with [InCountry](https://incountry.com/){:target="_blank"}, a data residency platform. This integration lets you localize and mask identity data (such as profile fields used in registration, login, and tokens) so that it is stored and processed within your required jurisdiction.
+
+For setup details, see the [WSO2 Asgardeo + InCountry integration guide](https://incountry.com/integrations/wso2-asgardeo/){:target="_blank"}.
+
 ## Get support
 
 If you require more details or have other data residency requirements for your organizations and businesses, contact the WSO2 Identity Platform support team.


### PR DESCRIPTION
## Purpose

Asgardeo supports integrating with [InCountry](https://incountry.com/), a data residency / data localization platform, but the docs had no link to the integration guide. This PR surfaces that link in a discoverable, topically relevant place.

## Changes

Adds an **"Extended data residency with InCountry"** section to the Asgardeo data residency reference page (`en/asgardeo/docs/references/data-residency-in-asgardeo.md`), just before the "Get support" section. It links to the partner-hosted guide: https://incountry.com/integrations/wso2-asgardeo/

InCountry lets organizations keep identity data within a specific country's borders (beyond the built-in US/EU regional data centers), so the data residency page is where readers with those requirements will look.

## Conventions followed

- Uses `{{product_name}}` templating (page is shared between Asgardeo and WSO2 Identity Server).
- Uses `{:target="_blank"}` on external links, matching the existing Moesif link on the page.
- No `mkdocs.yml` nav change needed — the page is already in the nav under **References**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)