### PR TITLE
Fix grammar in Quick Setup guide

### DIFF
--- a/en/identity-server/7.3.0/docs/get-started/quick-set-up.md
+++ b/en/identity-server/7.3.0/docs/get-started/quick-set-up.md
@@ -48,7 +48,7 @@ Note that the following log appears in the command prompt when the server starts
 ![QSG start server]({{base_path}}/assets/img/get-started/qsg-start-server.png)
 
 !!! tip "Shutting down the server"
-    To shutdown the server, press `Ctrl + C`.
+    To shut down the server, press `Ctrl + C`.
     Note that the following log appears in the command prompt on server shutdown.
 
     ![QSG stop server]({{base_path}}/assets/img/get-started/qsg-stop-server.png)


### PR DESCRIPTION
## Description

This PR fixes a grammatical issue in the WSO2 Identity Server Quick Setup documentation.

## Changes Made

- Updated "To shutdown the server" to "To shut down the server".

## Reason

"Shut down" is the correct verb phrase in this context. This change improves documentation clarity and readability without changing the meaning of the instructions.