### PR TITLE
Fix BEARER authentication example in Update Action documentation

### DIFF
--- a/en/identity-server/7.3.0/docs/apis/restapis/actions.yaml
+++ b/en/identity-server/7.3.0/docs/apis/restapis/actions.yaml
@@ -701,7 +701,7 @@ paths:
                     uri: https://myextension.com/external/token
                     authentication:
                       properties:
-                        token: 346dfbb5-6a8c-447a-9aaa-88fa2dd95962
+                        accessToken: 346dfbb5-6a8c-447a-9aaa-88fa2dd95962
                       type: BEARER
                     allowedHeaders:
                       - x-geo-location


### PR DESCRIPTION
## Purpose

This PR fixes an inconsistency in the **Update Action** API documentation for the **BEARER** authentication configuration.

The `AuthenticationType` schema documents the BEARER authentication property as `accessToken`, while the request payload example uses `token`. This inconsistency can confuse developers when constructing the request payload.

This PR updates the request payload example to use the same property name as the `AuthenticationType` schema, ensuring consistency throughout the documentation.

Resolves 
#28198
---

## Related PRs

None.

---

## Test environment

Documentation change only. No code changes or runtime testing required.

---

## Security checks

* [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
* [ ] Ran FindSecurityBugs plugin and verified report? *(Not applicable for documentation-only changes.)*
* [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?



