### PR TITLE
Update broken WS-Trust connector store link

### DIFF
--- a/en/identity-server/5.11.0/docs/learn/configuring-ws-trust-security-token-service.md
+++ b/en/identity-server/5.11.0/docs/learn/configuring-ws-trust-security-token-service.md
@@ -9,7 +9,7 @@ WS-Trust authentication is no longer supported by default from IS 5.11.0 upwards
 
 To download and install the WS-Trust connector:
 
-1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector/identity-inbound-auth-sts) from the WSO2 connector store.
+1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector) from the WSO2 connector store.
 2. Copy and past the downloaded `.zip` file to the home directory of the Identity Server and extract the `.zip`.
 3. Navigate to the home of the extracted directory and execute the following commands.
     ```bash

--- a/en/identity-server/5.11.0/docs/learn/configuring-ws-trust-security-token-service.md
+++ b/en/identity-server/5.11.0/docs/learn/configuring-ws-trust-security-token-service.md
@@ -9,7 +9,7 @@ WS-Trust authentication is no longer supported by default from IS 5.11.0 upwards
 
 To download and install the WS-Trust connector:
 
-1. Download the [WS-Trust Authenticator](https://store.wso2.com/store/assets/isconnector/details/417e7ef2-76fb-424f-92b3-d5eb58e2efe6) from the WSO2 connector store.
+1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector/identity-inbound-auth-sts) from the WSO2 connector store.
 2. Copy and past the downloaded `.zip` file to the home directory of the Identity Server and extract the `.zip`.
 3. Navigate to the home of the extracted directory and execute the following commands.
     ```bash

--- a/en/identity-server/6.0.0/docs/guides/identity-federation/configure-ws-trust.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-federation/configure-ws-trust.md
@@ -9,7 +9,8 @@ WS-Trust authentication is no longer supported by default from IS 5.11.0 upwards
 
 To download and install the WS-Trust connector:
 
-1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector/identity-inbound-auth-sts) from the WSO2 connector store.
+
+1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector) from the WSO2 connector store.
 2. Copy and paste the downloaded `.zip` file to the home directory of your WSO2 Identity Server and extract the `.zip` file.
 3. Open a terminal, navigate to the home of the extracted directory and execute the following commands.
     ```bash

--- a/en/identity-server/6.0.0/docs/guides/identity-federation/configure-ws-trust.md
+++ b/en/identity-server/6.0.0/docs/guides/identity-federation/configure-ws-trust.md
@@ -9,7 +9,7 @@ WS-Trust authentication is no longer supported by default from IS 5.11.0 upwards
 
 To download and install the WS-Trust connector:
 
-1. Download the [WS-Trust Authenticator](https://store.wso2.com/store/assets/isconnector/details/417e7ef2-76fb-424f-92b3-d5eb58e2efe6) from the WSO2 connector store.
+1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector/identity-inbound-auth-sts) from the WSO2 connector store.
 2. Copy and paste the downloaded `.zip` file to the home directory of your WSO2 Identity Server and extract the `.zip` file.
 3. Open a terminal, navigate to the home of the extracted directory and execute the following commands.
     ```bash

--- a/en/identity-server/6.1.0/docs/guides/identity-federation/configure-ws-trust.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-federation/configure-ws-trust.md
@@ -9,7 +9,7 @@ WS-Trust authentication is no longer supported by default from IS 5.11.0 upwards
 
 To download and install the WS-Trust connector:
 
-1. Download the [WS-Trust Authenticator](https://store.wso2.com/store/assets/isconnector/details/417e7ef2-76fb-424f-92b3-d5eb58e2efe6) from the WSO2 connector store.
+1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector/identity-inbound-auth-sts) from the WSO2 connector store.
 2. Copy and paste the downloaded `.zip` file to the home directory of your WSO2 Identity Server and extract the `.zip` file.
 3. Open a terminal, navigate to the home of the extracted directory and execute the following commands.
     ```bash

--- a/en/identity-server/6.1.0/docs/guides/identity-federation/configure-ws-trust.md
+++ b/en/identity-server/6.1.0/docs/guides/identity-federation/configure-ws-trust.md
@@ -9,7 +9,7 @@ WS-Trust authentication is no longer supported by default from IS 5.11.0 upwards
 
 To download and install the WS-Trust connector:
 
-1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector/identity-inbound-auth-sts) from the WSO2 connector store.
+1. Download the [WS-Trust Authenticator](https://store.wso2.com/connector) from the WSO2 connector store.
 2. Copy and paste the downloaded `.zip` file to the home directory of your WSO2 Identity Server and extract the `.zip` file.
 3. Open a terminal, navigate to the home of the extracted directory and execute the following commands.
     ```bash


### PR DESCRIPTION
## Purpose

Updated the broken WSO2 Store connector links in the WS-Trust documentation for WSO2 Identity Server 5.11.0, 6.0.0, and 6.1.0.

Resolves #6259

## Related PRs

N/A

## Test environment

* Documentation-only change.
* Verified the updated connector store links in the documentation source files.
* No application code or runtime behavior was changed.

## Security checks

* [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
* [x] Ran FindSecurityBugs plugin and verified report?
* [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?



