### PR TITLE
Address post-merge review comments on token response modification docs

### DIFF
--- a/en/includes/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/sample-success-responses.md
+++ b/en/includes/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/sample-success-responses.md
@@ -189,11 +189,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+{% if product_name == "WSO2 Identity Platform" or (product_name == "WSO2 Identity Server" and is_version > "7.3.0") %}
 ## Adding a custom parameter to the token endpoint response
 
 To add a custom top-level parameter to the token endpoint response, use the <code>/response/parameters/-</code> path in the <code>event.response</code> request.
 
-String, integer, boolean, JSON objects, and arrays are allowed as parameter values. Unlike access token and refresh token claims, arrays aren't limited to string elements — they can hold any combination of these value types, including nested objects and nested arrays. The parameter name must not collide with a standard parameter name, such as <code>access_token</code>, <code>scope</code>, <code>expires_in</code>, <code>token_type</code>, <code>refresh_token</code>, <code>id_token</code>, or an already added custom parameter.
+String, integer, boolean, JSON objects, and arrays are allowed as parameter values. The parameter name must not collide with a standard parameter name, such as <code>access_token</code>, <code>scope</code>, <code>expires_in</code>, <code>token_type</code>, <code>refresh_token</code>, <code>id_token</code>, or an already added custom parameter.
 
 !!! note
     Unlike token endpoint response parameters, access token and refresh token claims only accept string, integer, boolean, and string type array values. JSON objects, and arrays containing anything other than strings, aren't allowed as claim values, so they can't be injected into the access token or the refresh token.
@@ -245,36 +246,6 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-Refer to the example response below, which demonstrates adding a custom parameter with an array value containing non-string elements, including nested JSON objects:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "actionStatus": "SUCCESS",
-  "operations": [
-    {
-      "op": "add",
-      "path": "/response/parameters/-",
-      "value": {
-        "name": "entitlements",
-        "value": [
-          {
-            "resource": "reports",
-            "level": 2
-          },
-          {
-            "resource": "billing",
-            "level": 1
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
 ## Removing an optional parameter from the token endpoint response
 
 You can suppress optional standard parameters, such as <code>refresh_token</code> or <code>id_token</code>, from the token endpoint response. To do this, use the <code>/response/parameters/</code> path followed by the name of the parameter you want to remove, in the <code>event.response</code> request. Standard parameters that are always present in the response, such as <code>access_token</code>, <code>scope</code>, <code>expires_in</code>, and <code>token_type</code>, can't be removed.
@@ -295,3 +266,4 @@ Content-Type: application/json;charset=UTF-8
   ]
 }
 ```
+{% endif %}

--- a/en/includes/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/sample-success-responses.md
+++ b/en/includes/references/service-extensions/pre-flow-extensions/pre-issue-access-token-action/sample-success-responses.md
@@ -168,6 +168,8 @@ Content-Type: application/json;charset=UTF-8
  ]
 }
 ```
+
+{% if product_name == "WSO2 Identity Platform" or (product_name == "WSO2 Identity Server" and is_version >= "7.2.0") %}
 ## Changing the refresh token validity period
 
 The duration for which the refresh token is valid can be changed in seconds.
@@ -188,6 +190,7 @@ Content-Type: application/json;charset=UTF-8
  ]
 }
 ```
+{% endif %}
 
 {% if product_name == "WSO2 Identity Platform" or (product_name == "WSO2 Identity Server" and is_version > "7.3.0") %}
 ## Adding a custom parameter to the token endpoint response


### PR DESCRIPTION
## Purpose

Follow-up to #6256, addressing review comments left by @ashanthamara after that PR was merged.

Addresses the following comments on `sample-success-responses.md`:
- Gate the "Adding a custom parameter" / "Removing an optional parameter" sections behind an `is_version > "7.3.0"` condition, since this is a common doc shared across all IS versions and the token response modification feature isn't available on older ones.
- Remove the redundant sentence about arrays holding non-string elements, since JSON objects are already mentioned as an allowed value type.
- Remove the array-of-objects example, since it's redundant with the nested JSON object example above it.

## Related Issues

- https://github.com/wso2/product-is/issues/28124

## Related PRs

- #6256

## Test environment

N/A (documentation only)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?