### PR TITLE
Clarify branding inheritance behavior after customization

### DIFF
--- a/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -40,7 +40,7 @@ Application-specific branding settings apply to a single application. For a give
 - Organizations can customize their own application-specific branding settings, overriding either their organization-wide settings or the inherited settings. These overridden settings then pass down to the organization’s descendants.
 
     !!! note "Customized branding does not track later ancestor changes"
-        Once an organization customizes its application-specific branding, it stops inheriting from its ancestors for that application. Any branding changes made later at an ancestor level are **not** propagated to it; the organization keeps using its own customized settings independently. This continues until the organization reverts its branding, at which point it resumes inheriting from the nearest ancestor with custom settings.
+        Once an organization customizes its application-specific branding, it stops inheriting from its ancestors for that application. Any branding changes made later at an ancestor level are **not** propagated to it; the application keeps using its own customized settings independently. This continues until the application-specific branding is reverted, at which point it resumes using the organization’s own organization-wide branding if available, or otherwise inherits from the nearest ancestor.
 
 - Organizations can also revert application-specific branding settings. When reverted, the application uses the organization’s custom branding settings. If the organization has no custom branding, it inherits the branding from the nearest parent organization in the hierarchy that has custom settings.
 

--- a/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
+++ b/en/includes/guides/organization-management/inheritance-in-organizations/ui-branding-inheritance.md
@@ -16,6 +16,9 @@ Organization-wide branding settings apply to all applications within the organiz
 
 - Organizations can customize their own branding settings, overriding the inherited settings. These overridden settings then pass down to the organization’s descendants.
 
+    !!! note "Customized branding does not track later ancestor changes"
+        Once an organization customizes its branding, it stops inheriting from its ancestors. Any branding changes made later at an ancestor level are **not** propagated to it; the organization keeps using its own customized settings independently. This continues until the organization reverts its branding, at which point it resumes inheriting from the nearest ancestor with custom settings.
+
 - Organizations can also revert their branding settings, restoring the inherited values.
 
 ### Application-specific branding
@@ -35,6 +38,9 @@ Application-specific branding settings apply to a single application. For a give
 - If the organization has its own organization-wide branding, that applies to the application.
 
 - Organizations can customize their own application-specific branding settings, overriding either their organization-wide settings or the inherited settings. These overridden settings then pass down to the organization’s descendants.
+
+    !!! note "Customized branding does not track later ancestor changes"
+        Once an organization customizes its application-specific branding, it stops inheriting from its ancestors for that application. Any branding changes made later at an ancestor level are **not** propagated to it; the organization keeps using its own customized settings independently. This continues until the organization reverts its branding, at which point it resumes inheriting from the nearest ancestor with custom settings.
 
 - Organizations can also revert application-specific branding settings. When reverted, the application uses the organization’s custom branding settings. If the organization has no custom branding, it inherits the branding from the nearest parent organization in the hierarchy that has custom settings.
 


### PR DESCRIPTION
## Summary
- There is confusion about whether UI branding "inheritance" implies live propagation of parent branding changes, similar to OOP inheritance.
- The actual behavior: once an organization customizes its own branding (organization-wide or application-specific), it stops inheriting from ancestors — later changes made at an ancestor level are not propagated to it until it reverts to inherited values.
- This adds an explicit note under both the organization-wide and application-specific branding sections clarifying this behavior, since it was previously only implied by the "nearest ancestor with custom settings" resolution rule.