### PR TITLE
docs: fix duplicate 'the' in product-level-security-guidelines.md file

### DIFF
--- a/en/identity-server/5.10.0/docs/administer/product-level-security-guidelines.md
+++ b/en/identity-server/5.10.0/docs/administer/product-level-security-guidelines.md
@@ -294,7 +294,7 @@ If mutual SSL authentication capabilities are not required, you can [disable it]
 ## Configuring client authentication
 
 Client authentication is used to identify the application or the client that is making the request. 
-The web applications provided out-of-the-box use a set of default credentials to authenticate with WSO2 Identity Server REST APIs that are marked as **secure** under the 'ResourceAccessControl' tag of the the`<IS_HOME>/repository/conf/identity/identity.xml` file. 
+The web applications provided out-of-the-box use a set of default credentials to authenticate with WSO2 Identity Server REST APIs that are marked as **secure** under the 'ResourceAccessControl' tag of the`<IS_HOME>/repository/conf/identity/identity.xml` file. 
 
 Follow the steps below to change the default credentials.
 


### PR DESCRIPTION
## Purpose
Fixes a duplicate word typo ("the the") found in the Identity Server 5.10.0 product-level security guidelines documentation to improve content clarity.

- Removed repeated word "the" in `en/identity-server/5.10.0/docs/administer/product-level-security-guidelines.md`.

## Related PRs
N/A

## Test environment
N/A (Documentation fix)

## Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


