### PR TITLE
Fix: Broken WSO2 GDPR homepage link for all affected versions (product-is#28233)

### DIFF
--- a/en/identity-server/6.0.0/docs/references/concepts/compliance/gdpr.md
+++ b/en/identity-server/6.0.0/docs/references/concepts/compliance/gdpr.md
@@ -219,5 +219,5 @@ It also supports the following features.
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/)
 
     For more resources on GDPR, see the white papers, case studies, solution
-    briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/). See the original GDPR legal text
+    briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/). See the original GDPR legal text
     [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679).

--- a/en/identity-server/6.1.0/docs/references/concepts/compliance/gdpr.md
+++ b/en/identity-server/6.1.0/docs/references/concepts/compliance/gdpr.md
@@ -219,5 +219,5 @@ It also supports the following features.
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/)
 
     For more resources on GDPR, see the white papers, case studies, solution
-    briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/). See the original GDPR legal text
+    briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/). See the original GDPR legal text
     [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679).

--- a/en/identity-server/7.0.0/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/7.0.0/docs/deploy/compliance/gdpr.md
@@ -153,4 +153,4 @@ It also supports the following features.
     -   Part 4 - [GDPR Compliant Consent
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/){:target="_blank"}
 
-    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.
+    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.

--- a/en/identity-server/7.1.0/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/7.1.0/docs/deploy/compliance/gdpr.md
@@ -153,4 +153,4 @@ It also supports the following features.
     -   Part 4 - [GDPR Compliant Consent
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/){:target="_blank"}
 
-    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.
+    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.

--- a/en/identity-server/7.2.0/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/7.2.0/docs/deploy/compliance/gdpr.md
@@ -153,4 +153,4 @@ It also supports the following features.
     -   Part 4 - [GDPR Compliant Consent
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/){:target="_blank"}
 
-    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.
+    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.

--- a/en/identity-server/7.3.0/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/7.3.0/docs/deploy/compliance/gdpr.md
@@ -153,4 +153,4 @@ It also supports the following features.
     -   Part 4 - [GDPR Compliant Consent
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/){:target="_blank"}
 
-    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.
+    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.

--- a/en/identity-server/next/docs/deploy/compliance/gdpr.md
+++ b/en/identity-server/next/docs/deploy/compliance/gdpr.md
@@ -153,4 +153,4 @@ It also supports the following features.
     -   Part 4 - [GDPR Compliant Consent
         Design](https://wso2.com/library/articles/2018/03/creating-a-winning-gdpr-strategypart-4-gdpr-compliant-consent-design/){:target="_blank"}
 
-    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.
+    For more resources on GDPR, see the white papers, case studies, solution briefs, webinars, and talks published on the [WSO2 GDPR homepage](https://web.archive.org/web/20251128065028/https://wso2.com/solutions/regulatory-compliance/gdpr/){:target="_blank"}. See the original GDPR legal text [here](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32016R0679){:target="_blank"}.


### PR DESCRIPTION
- Fixes https://github.com/wso2/product-is/issues/28233
- Type: Broken Links
- Summary: The "WSO2 GDPR homepage" link (`https://wso2.com/solutions/regulatory-compliance/gdpr/`) on the GDPR compliance page returns a 404. I confirmed both that page and its `/privacy-toolkit/` subpage are dead, and found no live replacement page on wso2.com. Replaced the link with the Wayback Machine's archived snapshot from 2025-11-28 (the last time the page was live), so readers still reach the intended content.
- Affected Versions: next, 7.3.0, 7.2.0, 7.1.0, 7.0.0, 6.1.0, 6.0.0 (the issue listed next/7.3.0/7.2.0/7.1.0/7.0.0; I additionally checked 6.1.0 and 6.0.0 and found the same broken link there, so included them in this PR too)
