### PR TITLE
Fix: Multiple documentation issues in install, FIPS, and conditional auth pages

### DIFF
--- a/en/identity-server/7.3.0/docs/deploy/get-started/install.md
+++ b/en/identity-server/7.3.0/docs/deploy/get-started/install.md
@@ -290,7 +290,7 @@ prompt](#java-home).
 
 The `JAVA_HOME` variable is now set and will apply to any subsequent command prompt windows you open. If you have existing command prompt windows running, you must close and reopen them for the JAVA_HOME variable to take effect, or manually set the JAVA_HOME variable in those command prompt windows as described in the next section.
 
-To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter** ) and execute the following command.
+To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and press **Enter** ) and execute the following command.
 
 ```bat
 set JAVA_HOME

--- a/en/identity-server/7.3.0/docs/deploy/get-started/install.md
+++ b/en/identity-server/7.3.0/docs/deploy/get-started/install.md
@@ -356,7 +356,7 @@ Extract the WSO2 product that you want to run as a Linux service and set the env
     ``` bash
     #!/bin/bash
      
-    case "$1″ in
+    case "$1" in
     start)
        echo "Starting Service"
     ;;

--- a/en/identity-server/7.3.0/docs/deploy/security/enable-fips-for-is.md
+++ b/en/identity-server/7.3.0/docs/deploy/security/enable-fips-for-is.md
@@ -10,7 +10,7 @@ FIPS 140-2-compliant mode is turned off by default on the Identity Server.
 To enable FIPS 140-2 compliant mode on the Identity Server:
 
 1. Shut down the Identity Server instance if it's running.
-2. Open a terminal, navigate to `<IS_HOME>/bin/` folder,  and execute the following one of the following commands:
+2. Open a terminal, navigate to `<IS_HOME>/bin/` folder,  and execute one of the following commands:
     
     === "Linux/macOS"
         ```

--- a/en/identity-server/7.3.0/docs/references/conditional-auth/api-reference.md
+++ b/en/identity-server/7.3.0/docs/references/conditional-auth/api-reference.md
@@ -1196,7 +1196,7 @@ Contains the authentication step information. It may be a null or invalid step n
   </tr>
   <tr>
     <td><code>step.authenticator</code></td>
-    <td>Give the name of the authenticator that is used for authenticating te user. You can find the authenticator names from the <a href="#authenticatorNames">connection names table</a>.</td>
+    <td>Give the name of the authenticator that is used for authenticating the user. You can find the authenticator names from the <a href="#authenticatorNames">connection names table</a>.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Purpose

This PR fixes 4 documentation issues found across the WSO2 Identity Server docs:

1. **install.md** — Fixed a mismatched quote character in the Linux service 
   startup script sample. The closing quote after `$1` was a curly/prime 
   character (U+2033) instead of a standard double quote, which would cause 
   invalid bash syntax if the script was copy-pasted as shown.
   - Before: `case "$1″ in`
   - After: `case "$1" in`

2. **install.md** — Fixed incorrect terminology in the JAVA_HOME setup 
   instructions. "Enter" is a keyboard key, so it should be "pressed", 
   not "clicked".
   - Before: "...type `CMD` and click Enter"
   - After: "...type `CMD` and press Enter"

3. **enable-fips-for-is.md** — Fixed redundant wording in the FIPS 140-2 
   setup instructions.
   - Before: "execute the following one of the following commands"
   - After: "execute one of the following commands"

4. **conditional-auth/api-reference.md** — Fixed a typo in the `step.authenticator` 
   property description in the Object Reference table.
   - Before: "...authenticating te user"
   - After: "...authenticating the user"

## Related PRs

N/A

## Test environment

N/A — documentation-only changes (no code, no build/runtime testing required).

## Security checks

N/A — documentation-only changes, no security impact.