### PR TITLE
Document PASSWORD_CREDENTIAL authentication for notification senders

### DIFF
--- a/en/asgardeo/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
@@ -46,6 +46,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeListResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeListResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample'
         "400":
           description: Bad Request
           content:
@@ -86,7 +88,7 @@ paths:
         - Email Senders
       summary: Create an email sender
       description: |
-        This API provides the capability to create an email sender. If the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, and None authentication types are supported.<br>
+        This API provides the capability to create an email sender. If the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, Password Credential, and None authentication types are supported.<br>
         
         <b>Scope(Permission) required:</b> `internal_org_notification_senders_create`
       operationId: createEmailSender
@@ -112,6 +114,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePOSTRequestExample'
               httpNoneAuthPOSTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePOSTRequestExample'
+              httpPasswordCredentialPOSTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample'
       responses:
         "201":
           description: Successful Response
@@ -136,6 +140,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -238,6 +244,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -314,6 +322,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePUTRequestExample'
               httpNoneAuthPUTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePUTRequestExample'
+              httpPasswordCredentialPUTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample'
 
         required: true
       responses:
@@ -338,6 +348,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -1726,6 +1738,34 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample:
+      summary: "Post request for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePOSTRequestExample:
       summary: "Post request for HTTP based email providers with bearer token authentication"
       value:
@@ -1855,6 +1895,33 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample:
+      summary: "Put request for HTTP based email providers with password credential authentication"
+      value:
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePUTRequestExample:
       summary: "Put request for HTTP based email providers with bearer token authentication"
       value:
@@ -1978,6 +2045,30 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample:
+      summary: "Response for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "username"
+            value: "admin"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypeResponseExample:
       summary: "Response for HTTP based email providers with bearer token authentication"
       value:
@@ -2096,6 +2187,30 @@ components:
               value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
             - key: "clientId"
               value: "client-id-123"
+            - key: "tokenEndpoint"
+              value: "https://example.com/oauth2/token"
+            - key: "scopes"
+              value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample:
+      summary: "List response containing an HTTP-based email provider with password credential authentication"
+      value:
+        - name: "EmailPublisher"
+          provider: "HTTP"
+          providerURL: "https://api.example.com/api/v1"
+          authType: "PASSWORD_CREDENTIAL"
+          properties:
+            - key: "http.client.method"
+              value: "POST"
+            - key: contentType
+              value: "JSON"
+            - key: "http.headers"
+              value: "X-Version: 1, Custom-Header: value"
+            - key: "body"
+              value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+            - key: "clientId"
+              value: "client-id-123"
+            - key: "username"
+              value: "admin"
             - key: "tokenEndpoint"
               value: "https://example.com/oauth2/token"
             - key: "scopes"

--- a/en/asgardeo/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
+++ b/en/asgardeo/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
@@ -1587,6 +1587,18 @@ components:
               "value": "123ert45"
             }
           }``
+        - PASSWORD_CREDENTIAL: OAuth 2.0 resource owner password credentials authentication.<br>
+          ``{
+            "type": "PASSWORD_CREDENTIAL",
+            "properties": {
+              "clientId": "3e172dd2-901b-43a9-a26a-728466795f01",
+              "clientSecret": "83cdc120-ccf6-4163-a4a8-c1ba3e872daa",
+              "username": "admin",
+              "password": "admin123",
+              "tokenEndpoint": "https://custom.sms.provider/auth/token",
+              "scopes": "send_scope"
+            }
+          }``
       required:
         - type
       properties:
@@ -1597,6 +1609,7 @@ components:
             - BASIC
             - BEARER
             - API_KEY
+            - PASSWORD_CREDENTIAL
             - NONE
           example: CLIENT_CREDENTIAL
         properties:

--- a/en/asgardeo/docs/apis/restapis/notification-senders-v2.yaml
+++ b/en/asgardeo/docs/apis/restapis/notification-senders-v2.yaml
@@ -45,6 +45,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeListResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeListResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample'
         "400":
           description: Bad Request
           content:
@@ -85,7 +87,7 @@ paths:
         - Email Senders
       summary: Create an email sender
       description: |
-        This API provides the capability to create an email sender.\nIf the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, and None authentication types are supported. <br>
+        This API provides the capability to create an email sender.\nIf the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, Password Credential, and None authentication types are supported. <br>
         
         <b>Scope(Permission) required:</b> `internal_notification_senders_create`
       operationId: createEmailSender
@@ -111,6 +113,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePOSTRequestExample'
               httpNoneAuthPOSTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePOSTRequestExample'
+              httpPasswordCredentialPOSTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample'
       responses:
         "201":
           description: Successful Response
@@ -135,6 +139,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -237,6 +243,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -313,6 +321,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePUTRequestExample'
               httpNoneAuthPUTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePUTRequestExample'
+              httpPasswordCredentialPUTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample'
 
         required: true
       responses:
@@ -337,6 +347,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -1726,6 +1738,34 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample:
+      summary: "Post request for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePOSTRequestExample:
       summary: "Post request for HTTP based email providers with bearer token authentication"
       value:
@@ -1856,6 +1896,33 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample:
+      summary: "Put request for HTTP based email providers with password credential authentication"
+      value:
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePUTRequestExample:
       summary: "Put request for HTTP based email providers with bearer token authentication"
       value:
@@ -1979,6 +2046,30 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample:
+      summary: "Response for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "username"
+            value: "admin"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypeResponseExample:
       summary: "Response for HTTP based email providers with bearer token authentication"
       value:
@@ -2097,6 +2188,30 @@ components:
               value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
             - key: "clientId"
               value: "client-id-123"
+            - key: "tokenEndpoint"
+              value: "https://example.com/oauth2/token"
+            - key: "scopes"
+              value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample:
+      summary: "List response containing an HTTP-based email provider with password credential authentication"
+      value:
+        - name: "EmailPublisher"
+          provider: "HTTP"
+          providerURL: "https://api.example.com/api/v1"
+          authType: "PASSWORD_CREDENTIAL"
+          properties:
+            - key: "http.client.method"
+              value: "POST"
+            - key: contentType
+              value: "JSON"
+            - key: "http.headers"
+              value: "X-Version: 1, Custom-Header: value"
+            - key: "body"
+              value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+            - key: "clientId"
+              value: "client-id-123"
+            - key: "username"
+              value: "admin"
             - key: "tokenEndpoint"
               value: "https://example.com/oauth2/token"
             - key: "scopes"

--- a/en/asgardeo/docs/apis/restapis/notification-senders-v2.yaml
+++ b/en/asgardeo/docs/apis/restapis/notification-senders-v2.yaml
@@ -1587,6 +1587,18 @@ components:
               "value": "123ert45"
             }
           }``
+        - PASSWORD_CREDENTIAL: OAuth 2.0 resource owner password credentials authentication.<br>
+          ``{
+            "type": "PASSWORD_CREDENTIAL",
+            "properties": {
+              "clientId": "3e172dd2-901b-43a9-a26a-728466795f01",
+              "clientSecret": "83cdc120-ccf6-4163-a4a8-c1ba3e872daa",
+              "username": "admin",
+              "password": "admin123",
+              "tokenEndpoint": "https://custom.sms.provider/auth/token",
+              "scopes": "send_scope"
+            }
+          }``
       required:
         - type
       properties:
@@ -1597,6 +1609,7 @@ components:
             - BASIC
             - BEARER
             - API_KEY
+            - PASSWORD_CREDENTIAL
             - NONE
           example: CLIENT_CREDENTIAL
         properties:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
@@ -1589,6 +1589,18 @@ components:
               "value": "123ert45"
             }
           }``
+        - PASSWORD_CREDENTIAL: OAuth 2.0 resource owner password credentials authentication.<br>
+          ``{
+            "type": "PASSWORD_CREDENTIAL",
+            "properties": {
+              "clientId": "3e172dd2-901b-43a9-a26a-728466795f01",
+              "clientSecret": "83cdc120-ccf6-4163-a4a8-c1ba3e872daa",
+              "username": "admin",
+              "password": "admin123",
+              "tokenEndpoint": "https://custom.sms.provider/auth/token",
+              "scopes": "send_scope"
+            }
+          }``
         - NONE: No authentication is required.<br>
       required:
         - type
@@ -1600,6 +1612,7 @@ components:
             - BASIC
             - BEARER
             - API_KEY
+            - PASSWORD_CREDENTIAL
             - NONE
           example: CLIENT_CREDENTIAL
         properties:

--- a/en/identity-server/next/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
+++ b/en/identity-server/next/docs/apis/organization-apis/restapis/notification-senders-v2.yaml
@@ -46,6 +46,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeListResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeListResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample'
         "400":
           description: Bad Request
           content:
@@ -86,7 +88,7 @@ paths:
         - Email Senders
       summary: Create an email sender
       description: |
-        This API provides the capability to create an email sender.\n\nIf the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, and None authentication types are supported. <br>
+        This API provides the capability to create an email sender.\n\nIf the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, Password Credential, and None authentication types are supported. <br>
 
         <b>Scope(Permission) required:</b> `internal_org_notification_senders_create`
       operationId: createEmailSender
@@ -112,6 +114,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePOSTRequestExample'
               httpNoneAuthPOSTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePOSTRequestExample'
+              httpPasswordCredentialPOSTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample'
       responses:
         "201":
           description: Successful Response
@@ -136,6 +140,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -238,6 +244,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -314,6 +322,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePUTRequestExample'
               httpNoneAuthPUTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePUTRequestExample'
+              httpPasswordCredentialPUTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample'
 
         required: true
       responses:
@@ -338,6 +348,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -1729,6 +1741,34 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample:
+      summary: "Post request for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePOSTRequestExample:
       summary: "Post request for HTTP based email providers with bearer token authentication"
       value:
@@ -1859,6 +1899,33 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample:
+      summary: "Put request for HTTP based email providers with password credential authentication"
+      value:
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePUTRequestExample:
       summary: "Put request for HTTP based email providers with bearer token authentication"
       value:
@@ -1982,6 +2049,30 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample:
+      summary: "Response for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "username"
+            value: "admin"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypeResponseExample:
       summary: "Response for HTTP based email providers with bearer token authentication"
       value:
@@ -2100,6 +2191,30 @@ components:
               value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
             - key: "clientId"
               value: "client-id-123"
+            - key: "tokenEndpoint"
+              value: "https://example.com/oauth2/token"
+            - key: "scopes"
+              value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample:
+      summary: "List response containing an HTTP-based email provider with password credential authentication"
+      value:
+        - name: "EmailPublisher"
+          provider: "HTTP"
+          providerURL: "https://api.example.com/api/v1"
+          authType: "PASSWORD_CREDENTIAL"
+          properties:
+            - key: "http.client.method"
+              value: "POST"
+            - key: contentType
+              value: "JSON"
+            - key: "http.headers"
+              value: "X-Version: 1, Custom-Header: value"
+            - key: "body"
+              value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+            - key: "clientId"
+              value: "client-id-123"
+            - key: "username"
+              value: "admin"
             - key: "tokenEndpoint"
               value: "https://example.com/oauth2/token"
             - key: "scopes"

--- a/en/identity-server/next/docs/apis/restapis/notification-senders-v2.yaml
+++ b/en/identity-server/next/docs/apis/restapis/notification-senders-v2.yaml
@@ -46,6 +46,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeListResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeListResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample'
         "400":
           description: Bad Request
           content:
@@ -86,7 +88,7 @@ paths:
         - Email Senders
       summary: Create an email sender
       description: |
-        This API provides the capability to create an email sender.\nIf the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, and None authentication types are supported. <br>
+        This API provides the capability to create an email sender.\nIf the 'name' is not defined, 'EmailPublisher' is taken as the default name. For SMTP-based providers, Basic and Client Credential authentication types are supported. For HTTP-based providers, Basic, Client Credential, Bearer Token, API Key, Password Credential, and None authentication types are supported. <br>
 
         <b>Scope(Permission) required:</b> `internal_notification_senders_create`
       operationId: createEmailSender
@@ -112,6 +114,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePOSTRequestExample'
               httpNoneAuthPOSTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePOSTRequestExample'
+              httpPasswordCredentialPOSTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample'
       responses:
         "201":
           description: Successful Response
@@ -136,6 +140,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -238,6 +244,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -307,6 +315,8 @@ paths:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypePUTRequestExample'
               httpNoneAuthPUTExample:
                 $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypePUTRequestExample'
+              httpPasswordCredentialPUTExample:
+                $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample'
 
         required: true
       responses:
@@ -331,6 +341,8 @@ paths:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithAPIKeyAuthTypeResponseExample'
                 httpNoneAuthResponseExample:
                   $ref: '#/components/examples/HTTPBasedEmailSenderWithNoneAuthTypeResponseExample'
+                httpPasswordCredentialResponseExample:
+                  $ref: '#/components/examples/HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample'
         "400":
           description: Bad Request
           content:
@@ -1720,6 +1732,34 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePOSTRequestExample:
+      summary: "Post request for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePOSTRequestExample:
       summary: "Post request for HTTP based email providers with bearer token authentication"
       value:
@@ -1850,6 +1890,33 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypePUTRequestExample:
+      summary: "Put request for HTTP based email providers with password credential authentication"
+      value:
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "clientSecret"
+            value: "client-secret-abc"
+          - key: "username"
+            value: "admin"
+          - key: "password"
+            value: "admin123"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypePUTRequestExample:
       summary: "Put request for HTTP based email providers with bearer token authentication"
       value:
@@ -1973,6 +2040,30 @@ components:
             value: "https://example.com/oauth2/token"
           - key: "scopes"
             value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeResponseExample:
+      summary: "Response for HTTP based email providers with password credential authentication"
+      value:
+        name: "EmailPublisher"
+        provider: "HTTP"
+        providerURL: "https://api.example.com/api/v1"
+        authType: "PASSWORD_CREDENTIAL"
+        properties:
+          - key: "http.client.method"
+            value: "POST"
+          - key: contentType
+            value: "JSON"
+          - key: "http.headers"
+            value: "X-Version: 1, Custom-Header: value"
+          - key: "body"
+            value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+          - key: "clientId"
+            value: "client-id-123"
+          - key: "username"
+            value: "admin"
+          - key: "tokenEndpoint"
+            value: "https://example.com/oauth2/token"
+          - key: "scopes"
+            value: "send_scope"
     HTTPBasedEmailSenderWithBearerTokenAuthTypeResponseExample:
       summary: "Response for HTTP based email providers with bearer token authentication"
       value:
@@ -2091,6 +2182,30 @@ components:
               value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
             - key: "clientId"
               value: "client-id-123"
+            - key: "tokenEndpoint"
+              value: "https://example.com/oauth2/token"
+            - key: "scopes"
+              value: "send_scope"
+    HTTPBasedEmailSenderWithPasswordCredentialAuthTypeListResponseExample:
+      summary: "List response containing an HTTP-based email provider with password credential authentication"
+      value:
+        - name: "EmailPublisher"
+          provider: "HTTP"
+          providerURL: "https://api.example.com/api/v1"
+          authType: "PASSWORD_CREDENTIAL"
+          properties:
+            - key: "http.client.method"
+              value: "POST"
+            - key: contentType
+              value: "JSON"
+            - key: "http.headers"
+              value: "X-Version: 1, Custom-Header: value"
+            - key: "body"
+              value: "{\"subject\": \"{{subject}}\", \"body\": \"{{body}}\", \"footer\": \"{{footer}}\", \"to\": \"{{send-to}}\"}"
+            - key: "clientId"
+              value: "client-id-123"
+            - key: "username"
+              value: "admin"
             - key: "tokenEndpoint"
               value: "https://example.com/oauth2/token"
             - key: "scopes"

--- a/en/identity-server/next/docs/apis/restapis/notification-senders-v2.yaml
+++ b/en/identity-server/next/docs/apis/restapis/notification-senders-v2.yaml
@@ -1580,6 +1580,18 @@ components:
               "value": "123ert45"
             }
           }``
+        - PASSWORD_CREDENTIAL: OAuth 2.0 resource owner password credentials authentication.<br>
+          ``{
+            "type": "PASSWORD_CREDENTIAL",
+            "properties": {
+              "clientId": "3e172dd2-901b-43a9-a26a-728466795f01",
+              "clientSecret": "83cdc120-ccf6-4163-a4a8-c1ba3e872daa",
+              "username": "admin",
+              "password": "admin123",
+              "tokenEndpoint": "https://custom.sms.provider/auth/token",
+              "scopes": "send_scope"
+            }
+          }``
         - NONE: No authentication is required.<br>
       required:
         - type
@@ -1591,6 +1603,7 @@ components:
             - BASIC
             - BEARER
             - API_KEY
+            - PASSWORD_CREDENTIAL
             - NONE
           example: CLIENT_CREDENTIAL
         properties:


### PR DESCRIPTION
## Purpose
- Document OAuth2 resource owner password credentials (`PASSWORD_CREDENTIAL`) authentication support for SMS/Email notification senders.
- Add the full set of named request/response examples (List, GET, POST request/response, PUT request/response) for the HTTP-based Email sender's `PASSWORD_CREDENTIAL` auth type, matching the existing coverage every other auth type (Basic, Client Credential, Bearer Token, API Key, None) already has.
- Update the endpoint description to list Password Credential among the supported HTTP-based Email provider auth types.

## Related PRs
- wso2-extensions/identity-event-handler-notification#394
- wso2/identity-api-server#1157

## Related Issues
- wso2/product-is#28270