### PR TITLE
Add magicLink and flows templates

### DIFF
--- a/en/includes/references/email-templates.md
+++ b/en/includes/references/email-templates.md
@@ -7,7 +7,6 @@
     - You can customize all available email templates to match your organization's preferences using the [Email Templates API]({{base_path}}/apis/{{ api_path }}/).
     - You can also use the Console to change some of the most frequently used email templates in {{ product_name }}. Learn how to [customize email content from the Console]({{base_path}}/guides/branding/customize-email-templates/#customize-email-content).
 
-
 ## Email templates in {{ product_name }}
 
 The following is a comprehensive list of email templates that are available in {{ product_name }}.
@@ -162,6 +161,7 @@ Some email templates in {{ product_name }} should contain URLs which users can c
     ```ts
     {{ "{{ account.recovery.endpoint-url }}"}}/confirmregistration.do?confirmation={{ "{{ confirmation-code }}"}}&userstoredomain={{ "{{ userstore-domain }}"}}&username={{ "{{ url:user-name }}" }}
     ```
+
     This URL is used in the <code>EmailConfirm</code> template.
 
 - URL to confirm a user account
@@ -169,6 +169,7 @@ Some email templates in {{ product_name }} should contain URLs which users can c
     ```ts
     {{ "{{ account.recovery.endpoint-url }}"}}/confirmregistration.do?confirmation={{ "{{ confirmation-code }}"}}&userstoredomain={{ "{{ userstore-domain }}"}}&username={{ "{{ url:user-name }}"}}&spId={{ "{{ spId }}" }}
     ```
+
     This URL is used in the <code>AccountConfirmation</code> and <code>ResendAccountConfirmation</code>.
 
 - URL to verify an updated email address.
@@ -176,6 +177,7 @@ Some email templates in {{ product_name }} should contain URLs which users can c
     ```ts
     {{ "{{ account.recovery.endpoint-url }}"}}/confirmregistration.do?confirmation={{ "{{ confirmation-code }}"}}&userstoredomain={{ "{{ userstore-domain }}"}}&amp;username={{ "{{ url:user-name }}" }}
     ```
+
     This URL is used in the <code>VerifyEmailOnUpdate</code> template.
 
 - URL to reset a password

--- a/en/includes/references/email-templates.md
+++ b/en/includes/references/email-templates.md
@@ -117,10 +117,24 @@ The following is a comprehensive list of email templates that are available in {
             <td>This email is generated when a user logs in with a magic link. The application name and the expiry time of the link can be accessed by the literals {{"{{ application-name }}"}}, and {{"{{ expiry-time }}"}} respectively.</td>
         </tr>
         <tr>
+            <td>magicLinkSignUp
+            </td>
+            <td>This email is generated when a user signs up and has to verify the account using a magic link.</td>
+        </tr>
+        <tr>
+            <td>magicLinkPasswordRecovery
+            </td>
+            <td>This email is generated when a user initiates a password recovery and has to verify the account using a magic link before resetting the password.</td>
+        </tr>
+        <tr>
             <td>AskPassword<br/><br/>
                 resendAskPassword<br/><br/>
             </td>
             <td>These emails are generated when a user is asked to create a password for the newly created account. </td>
+        </tr>
+        <tr>
+            <td>OrchestratedResendAskPassword</td>
+            <td>This email is generated when the organization administrator reinitiates the request for the user to set up their password, as part of an orchestrated flow.</td>
         </tr>
         <tr>
             <td>selfSignUpNotify<br/><br/>


### PR DESCRIPTION
## Purpose

This pull request adds documentation for several new email templates related to magic link authentication and orchestrated password setup flows. These additions help clarify when each template is used and improve the completeness of the email template reference documentation.

**Email template documentation updates:**

* Added descriptions for `magicLinkSignUp` and `magicLinkPasswordRecovery` templates, which are used for account verification and password recovery via magic links.
* Documented the `OrchestratedResendAskPassword` template, generated when an administrator reinitiates a password setup request as part of an orchestrated flow.

