### PR TITLE
[6.0] Update compatible Java versions for deployment

### DIFF
--- a/en/identity-server/6.0.0/docs/deploy/deployment-guide.md
+++ b/en/identity-server/6.0.0/docs/deploy/deployment-guide.md
@@ -71,7 +71,8 @@ The above recommendations can change based on the expected concurrency and perfo
 </tr>
 <tr class="even">
 <th>Java</th>
-<td>Oracle JDK 1.8</td>
+<td><p>For information on tested JDKs, see <a href="{{base_path}}/deploy/environment-compatibility/#tested-operating-systems-and-jdks">Tested Operating Systems and JDKs</a>
+.</p></td>
 </tr>
 <tr class="odd">
 <th>Web browsers</th>


### PR DESCRIPTION
## Purpose
The compatible java version has been incorrectly mentioned as JDK 1.8 for 6.0.0 in deployment patterns docs. This PR updated to refer the tested JDKs for 6.0.instead, following the similar pattern for other versions.

